### PR TITLE
reformat markdown --- newline for each sentence

### DIFF
--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -340,7 +340,6 @@ The following list describes the components in a (customer) site domain:
 * Domain Registrar: In general the domain registrar fulfills the same functionality regarding the bootstrapping of the pledge in a (customer) site domain by facilitating the communication of the pledge with the MASA service and the domain PKI service.
   In contrast to {{RFC8995}}, the domain registrar does not interact with a pledge directly but  through the registrar-agent.
   The registrar detects if the bootstrapping is performed by the pledge directly or by the  registrar-agent.
-
 The manufacturer provided components/services (MASA and Ownership tracker) are used as defined in {{RFC8995}}.
 For issuing a voucher, the MASA may perform additional checks on voucher-request objects, to issue a voucher indicating agent-proximity instead of registrar-proximity.
 


### PR DESCRIPTION
This pull request should be content-free.
It should be just a reformat, and I'll be looking at the github markdown diff to verify.
The reason for sentence per line is to make changes easier to see.
Turn on paragraph wrap in your editor instead of doing it in the file. Emacs can do this and so can vim.
Willing to compromise with wrapped text, but new sentence on new line.

