### PR TITLE
Rewrote 5.3.1.  Discovery of Registrar by Registrar-Agent because it …

### DIFF
--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -614,7 +614,7 @@ or IPv6 address as any BRSKI connection that is supporting BRSKI so that those B
 can continue to announce unmodified "EST-TLS" in the objective-value.
 
 If the Registar-Agent enrolls pledges with other than ACP certificates, then the GRASP Objectibe
-would be "brski-registrar" and the prodedures of {{I-D.eckert-anima-grasp-dnss}} could be used.
+would be "brski-registrar" and the prodedures of {{I-D.eckert-anima-grasp-dnssd}} could be used.
 
 
 ### Discovery of Pledge by Registrar-Agent {#discovery_uc2_ppa}

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -606,7 +606,7 @@ be supported for discovery and selection.
 
 If the Registrar-Agent enrolls pledges into the ACP via BRSKI-PRM, then the GRASP Objective
 (the equivalent of the DNS-SD service name) to be used is "AN_join_registar" as defined in
-{{RFC8995}}, section 4.3. To indicate support for BRSKI-PRM, the objective-alue of the
+{{RFC8995}}, section 4.3. To indicate support for BRSKI-PRM, the objective-value of the
 objective, according to {{RFC8995}}, section 4.3 and figure 13 is "PRM-EST-TLS" for the
 connection to a registrar supporting BRSKI-PRM. To avoid backward compatiblity issues with
 AN_join_registrar announcement for BRSKI, BRSKI-PRM in this case MUST use a separate TCP port

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -551,7 +551,7 @@ DNS-SD discovery of the Registar by Registrar-Agents.
 For DNS-SD, discovery of a BRSKI-PRM Registrar uses the same service name "brski-registar" as
 defined by {{RFC8995}} and uses the DNS-SD mechanisms as defined in {{RFC6763}}, using any
 transport known to be potentially supported by the deployment domain, including mDNS (single hop),
-or unicast DNS. {{RFC8995}}, Appendix B outlines some examples. 
+or unicast DNS. {{RFC8995, Appendix B}} outlines some examples. 
 
 To allow operations of both BRSKI ({{RFC8995}}) and BRSKI-PRM on the same and/or different registrars
 using the same DNS-SD service name, DNS-SD information for Registrars that support BRSKI-PRM MUST include a TXT Key

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -562,7 +562,7 @@ indicate the value of "true". Future versions of BRSKI-PRM that are backward com
 may indicate a different value.
 
 DNS-SD information for Registrars that support BRSKI according to {{RFC8995}} and use a TXT
-RR MUST include the TXT key of "rrm" (registrar registrar mode). A registrar supporting both
+RR MUST include the TXT key of "rrm" (registrar mode). A registrar supporting both
 BRSKI and PRSKI-PRM would therefore have a TXT RR of "prm,rrm". A registrar MAY continue
 to not include a TXT RR if it only supports BRSKI and BRKSI clients (pledges or brski proxies)
 would fail in the presence of TXT RRs for the "brski-registrar" service name. Note that the

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -584,7 +584,7 @@ the Registrar-Agent MUST retry other instances.
 Registrar-Agents SHOULD allow configuration of explicit Service Instance Names as defined in
 {{RFC6763}}, Section 4.1.1 to overcome any possible issues in selecting the Registrar
 automatically as described above solely by the service name. For example when a
-Registar-Agent is configured to use a Registar by thre Service Instance Name of
+Registar-Agent is configured to use a Registar by the Service Instance Name of
 "Prime PRM Registrar", this would be expanded by the DNS-SD discovery of in the Registrar-Agent to
 "Prime PRM Registrar._brski-registar._tcp.example.com".
 


### PR DESCRIPTION
…was incorrect and incomplete:

> The discovery of the domain registrar may be done as specified in {{RFC8995}} section 4 with the
> deviation that it is done between the registrar-agent and the domain registrar.
> Alternatively, the registrar-agent may be configured with the address of the domain registrar and the certificate of the domain registrar.

Issues: we need not only discovery, but also selection. Also, this was not in section 4. Lastly, discovery of registrar does not change the need to configure/learn the certificate of the registrar in another way because discovery is not trustworthy (except over ACP, but thats just an instance of how you can pre-learn a trust anchor for the domain registrar(s)).

Fix got somewhat longer, but i tried to ensure all the interop important aspects are covered. Alas, thats a range of details.

Also fixed/added required references and IANA allocations and made the document an update to RFC8995 as indicated in the new text.

This is 50% of the github issue, the other one is 5.3.2 next.