### PR TITLE
WIP: Shepherd Review 2

### DIFF
--- a/draft-ietf-anima-brski-prm.html
+++ b/draft-ietf-anima-brski-prm.html
@@ -35,7 +35,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
     wcwidth 0.2.13
     weasyprint 60.2
 -->
-<link href="/usr/src/app/tmp/dbad6348-cc47-4d97-b1fe-c52118398dc1/brski-prm-12-mkovatsc.xml" rel="alternate" type="application/rfc+xml">
+<link href="/usr/src/app/tmp/0a0f6133-dfbd-4018-95bf-f5619587bec0/20240215.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1215,7 +1215,7 @@ li > p:last-of-type:only-child {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Fries, et al.</td>
-<td class="center">Expires 17 August 2024</td>
+<td class="center">Expires 18 August 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1228,12 +1228,12 @@ li > p:last-of-type:only-child {
 <dd class="internet-draft">draft-ietf-anima-brski-prm-12</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-02-14" class="published">14 February 2024</time>
+<time datetime="2024-02-15" class="published">15 February 2024</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-08-17">17 August 2024</time></dd>
+<dd class="expires"><time datetime="2024-08-18">18 August 2024</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1293,7 +1293,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 17 August 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 18 August 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1520,7 +1520,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 <p id="section-toc.1-1.7.2.10.1"><a href="#section-7.10" class="auto internal xref">7.10</a>. <a href="#name-enroll-status-telemetry" class="internal xref">Enroll Status Telemetry</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.10.2.1">
-                    <p id="section-toc.1-1.7.2.10.2.1.1"><a href="#section-7.10.1" class="auto internal xref">7.10.1</a>.  <a href="#name-request-artifact-vstatus-2" class="internal xref">Request Artifact: vStatus</a></p>
+                    <p id="section-toc.1-1.7.2.10.2.1.1"><a href="#section-7.10.1" class="auto internal xref">7.10.1</a>.  <a href="#name-request-artifact-estatus" class="internal xref">Request Artifact: eStatus</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.10.2.2">
                     <p id="section-toc.1-1.7.2.10.2.2.1"><a href="#section-7.10.2" class="auto internal xref">7.10.2</a>.  <a href="#name-response-3" class="internal xref">Response</a></p>
@@ -1531,99 +1531,91 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 <p id="section-toc.1-1.7.2.11.1"><a href="#section-7.11" class="auto internal xref">7.11</a>. <a href="#name-query-pledge-status" class="internal xref">Query Pledge Status</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.11.2.1">
-                    <p id="section-toc.1-1.7.2.11.2.1.1"><a href="#section-7.11.1" class="auto internal xref">7.11.1</a>.  <a href="#name-request-artifact-status-req" class="internal xref">Request Artifact: status-request</a></p>
+                    <p id="section-toc.1-1.7.2.11.2.1.1"><a href="#section-7.11.1" class="auto internal xref">7.11.1</a>.  <a href="#name-request-artifact-pstatus-re" class="internal xref">Request Artifact: pStatus-Req</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.11.2.2">
-                    <p id="section-toc.1-1.7.2.11.2.2.1"><a href="#section-7.11.2" class="auto internal xref">7.11.2</a>.  <a href="#name-response-artifact-status-re" class="internal xref">Response Artifact: status-response</a></p>
+                    <p id="section-toc.1-1.7.2.11.2.2.1"><a href="#section-7.11.2" class="auto internal xref">7.11.2</a>.  <a href="#name-response-artifact-pstatus-r" class="internal xref">Response Artifact: pStatus-Resp</a></p>
 </li>
                 </ul>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-todo-artifacts" class="internal xref">TODO Artifacts</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.1">
-                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="auto internal xref">8.1</a>.  <a href="#name-voucher-request-artifact" class="internal xref">Voucher-Request Artifact</a></p>
+                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="auto internal xref">8.1</a>.  <a href="#name-brski-well-known-registry" class="internal xref">BRSKI .well-known Registry</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.2">
+                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="auto internal xref">8.2</a>.  <a href="#name-dns-service-names" class="internal xref">DNS Service Names</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.1">
-                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="auto internal xref">9.1</a>.  <a href="#name-brski-well-known-registry" class="internal xref">BRSKI .well-known Registry</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.2">
-                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="auto internal xref">9.2</a>.  <a href="#name-dns-service-names" class="internal xref">DNS Service Names</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-privacy-considerations" class="internal xref">Privacy Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-privacy-considerations" class="internal xref">Privacy Considerations</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-11" class="auto internal xref">11</a>. <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
 <ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.1">
-                <p id="section-toc.1-1.11.2.1.1"><a href="#section-11.1" class="auto internal xref">11.1</a>.  <a href="#name-denial-of-service-dos-attac" class="internal xref">Denial of Service (DoS) Attack on Pledge</a></p>
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.1">
+                <p id="section-toc.1-1.10.2.1.1"><a href="#section-10.1" class="auto internal xref">10.1</a>.  <a href="#name-denial-of-service-dos-attac" class="internal xref">Denial of Service (DoS) Attack on Pledge</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.2">
-                <p id="section-toc.1-1.11.2.2.1"><a href="#section-11.2" class="auto internal xref">11.2</a>.  <a href="#name-misuse-of-acquired-pvr-and-" class="internal xref">Misuse of acquired PVR and PER by Registrar-Agent</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.2">
+                <p id="section-toc.1-1.10.2.2.1"><a href="#section-10.2" class="auto internal xref">10.2</a>.  <a href="#name-misuse-of-acquired-pvr-and-" class="internal xref">Misuse of acquired PVR and PER by Registrar-Agent</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.3">
-                <p id="section-toc.1-1.11.2.3.1"><a href="#section-11.3" class="auto internal xref">11.3</a>.  <a href="#name-misuse-of-registrar-agent-c" class="internal xref">Misuse of Registrar-Agent Credentials</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.3">
+                <p id="section-toc.1-1.10.2.3.1"><a href="#section-10.3" class="auto internal xref">10.3</a>.  <a href="#name-misuse-of-registrar-agent-c" class="internal xref">Misuse of Registrar-Agent Credentials</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.4">
-                <p id="section-toc.1-1.11.2.4.1"><a href="#section-11.4" class="auto internal xref">11.4</a>.  <a href="#name-misuse-of-dns-sd-with-mdns-" class="internal xref">Misuse of DNS-SD with mDNS to obtain list of pledges</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.4">
+                <p id="section-toc.1-1.10.2.4.1"><a href="#section-10.4" class="auto internal xref">10.4</a>.  <a href="#name-misuse-of-dns-sd-with-mdns-" class="internal xref">Misuse of DNS-SD with mDNS to obtain list of pledges</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.5">
-                <p id="section-toc.1-1.11.2.5.1"><a href="#section-11.5" class="auto internal xref">11.5</a>.  <a href="#name-yang-module-security-consid" class="internal xref">YANG Module Security Considerations</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.5">
+                <p id="section-toc.1-1.10.2.5.1"><a href="#section-10.5" class="auto internal xref">10.5</a>.  <a href="#name-yang-module-security-consid" class="internal xref">YANG Module Security Considerations</a></p>
 </li>
             </ul>
 </li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="auto internal xref">11</a>. <a href="#name-acknowledgments" class="internal xref">Acknowledgments</a></p>
+</li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-12" class="auto internal xref">12</a>. <a href="#name-acknowledgments" class="internal xref">Acknowledgments</a></p>
+            <p id="section-toc.1-1.12.1"><a href="#section-12" class="auto internal xref">12</a>. <a href="#name-references" class="internal xref">References</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.1">
+                <p id="section-toc.1-1.12.2.1.1"><a href="#section-12.1" class="auto internal xref">12.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.2">
+                <p id="section-toc.1-1.12.2.2.1"><a href="#section-12.2" class="auto internal xref">12.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-13" class="auto internal xref">13</a>. <a href="#name-references" class="internal xref">References</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-examples" class="internal xref">Examples</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.1">
-                <p id="section-toc.1-1.13.2.1.1"><a href="#section-13.1" class="auto internal xref">13.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+                <p id="section-toc.1-1.13.2.1.1"><a href="#appendix-A.1" class="auto internal xref">A.1</a>.  <a href="#name-example-pledge-voucher-requ" class="internal xref">Example Pledge Voucher-Request (PVR) - from Pledge to Registrar-Agent</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.2">
-                <p id="section-toc.1-1.13.2.2.1"><a href="#section-13.2" class="auto internal xref">13.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+                <p id="section-toc.1-1.13.2.2.1"><a href="#appendix-A.2" class="auto internal xref">A.2</a>.  <a href="#name-example-parboiled-registrar" class="internal xref">Example Parboiled Registrar Voucher-Request (RVR) - from Registrar to MASA</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.3">
+                <p id="section-toc.1-1.13.2.3.1"><a href="#appendix-A.3" class="auto internal xref">A.3</a>.  <a href="#name-example-voucher-from-masa-t" class="internal xref">Example Voucher - from MASA to Pledge, via Registrar and Registrar-Agent</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.4">
+                <p id="section-toc.1-1.13.2.4.1"><a href="#appendix-A.4" class="auto internal xref">A.4</a>.  <a href="#name-example-voucher-masa-issued" class="internal xref">Example Voucher, MASA issued Voucher with additional Registrar signature (from MASA to Pledge, via Registrar and Registrar-Agent)</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-examples" class="internal xref">Examples</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.1">
-                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-A.1" class="auto internal xref">A.1</a>.  <a href="#name-example-pledge-voucher-requ" class="internal xref">Example Pledge Voucher-Request (PVR) - from Pledge to Registrar-Agent</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.2">
-                <p id="section-toc.1-1.14.2.2.1"><a href="#appendix-A.2" class="auto internal xref">A.2</a>.  <a href="#name-example-parboiled-registrar" class="internal xref">Example Parboiled Registrar Voucher-Request (RVR) - from Registrar to MASA</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.3">
-                <p id="section-toc.1-1.14.2.3.1"><a href="#appendix-A.3" class="auto internal xref">A.3</a>.  <a href="#name-example-voucher-from-masa-t" class="internal xref">Example Voucher - from MASA to Pledge, via Registrar and Registrar-Agent</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.4">
-                <p id="section-toc.1-1.14.2.4.1"><a href="#appendix-A.4" class="auto internal xref">A.4</a>.  <a href="#name-example-voucher-masa-issued" class="internal xref">Example Voucher, MASA issued Voucher with additional Registrar signature (from MASA to Pledge, via Registrar and Registrar-Agent)</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-B" class="auto internal xref">Appendix B</a>.  <a href="#name-http-over-tls-operations-be" class="internal xref">HTTP-over-TLS operations between Registrar-Agent and Pledge</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15">
-            <p id="section-toc.1-1.15.1"><a href="#appendix-B" class="auto internal xref">Appendix B</a>.  <a href="#name-http-over-tls-operations-be" class="internal xref">HTTP-over-TLS operations between Registrar-Agent and Pledge</a></p>
+            <p id="section-toc.1-1.15.1"><a href="#appendix-C" class="auto internal xref">Appendix C</a>.  <a href="#name-history-of-changes-rfc-edit" class="internal xref">History of Changes [RFC Editor: please delete]</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16">
-            <p id="section-toc.1-1.16.1"><a href="#appendix-C" class="auto internal xref">Appendix C</a>.  <a href="#name-history-of-changes-rfc-edit" class="internal xref">History of Changes [RFC Editor: please delete]</a></p>
+            <p id="section-toc.1-1.16.1"><a href="#appendix-D" class="auto internal xref"></a><a href="#name-contributors" class="internal xref">Contributors</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.17">
-            <p id="section-toc.1-1.17.1"><a href="#appendix-D" class="auto internal xref"></a><a href="#name-contributors" class="internal xref">Contributors</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.18">
-            <p id="section-toc.1-1.18.1"><a href="#appendix-E" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.17.1"><a href="#appendix-E" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1710,7 +1702,8 @@ The binding is assumed to be provided through a digital signature of the actual 
         <dd class="break"></dd>
 <dt id="section-2-3.9">EE:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.10">
-          <p id="section-2-3.10.1">End entity.<a href="#section-2-3.10.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.10.1">End entity, as defined in <span>[<a href="#RFC9483" class="cite xref">RFC9483</a>]</span>.
+Typically a device or service that owns a public-private key pair for which it manages a public key certificate.<a href="#section-2-3.10.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 <dt id="section-2-3.11">EE certificate:</dt>
@@ -1893,10 +1886,10 @@ Certificate updates may utilize the certificate that is to be updated.<a href="#
 <p id="section-4-5">Solution examples based on existing technology are provided with the focus on existing IETF RFCs:<a href="#section-4-5" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-4-6.1">
-          <p id="section-4-6.1.1">Voucher-requests and -responses as used in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> already provide both, POP and POI, through a digital signature to protect the integrity of the voucher, while the corresponding signing certificate contains the identity of the signer.<a href="#section-4-6.1.1" class="pilcrow">¶</a></p>
+          <p id="section-4-6.1.1">Voucher-Requests and Vouchers as used in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> already provide both, POP and POI, through a digital signature to protect the integrity of the voucher, while the corresponding signing certificate contains the identity of the signer.<a href="#section-4-6.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-6.2">
-          <p id="section-4-6.2.1">Certification requests are data structures containing the information from a requester for a CA to create a certificate.
+          <p id="section-4-6.2.1">Enroll-Requests are data structures containing the information from a requester for a CA to create a certificate.
 The certification request format in BRSKI is PKCS#10 <span>[<a href="#RFC2986" class="cite xref">RFC2986</a>]</span>.
 In PKCS#10, the structure is signed to ensure integrity protection and POP of the private key of the requester that corresponds to the contained public key.
 In the application examples, this POP alone is not sufficient.
@@ -2406,12 +2399,10 @@ In BRSKI, the TLS connection is considered provisional until the pledge receives
 In a similar fashion, the pledge <span class="bcp14">MUST</span> accept the Registrar-Agent EE certificate provisionally.
 See also <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5" class="relref">Section 5</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> on "provisional state".<a href="#section-5.4-3" class="pilcrow">¶</a></p>
 <p id="section-5.4-4">For agent-proximity, the EE certificate of the Registrar-Agent <span class="bcp14">MUST</span> be an LDevID certificate signed by the domain owner.
-TODO[always in agent-signed-data] Further, the Registrar-Agent <span class="bcp14">MUST</span> include its LDevID certificate in the PVR trigger message and, in turn, the pledge <span class="bcp14">MUST</span> include it in the Pledge Voucher Request (PVR).
-TODO[no other field, right?] The corresponding fields are defined in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.<a href="#section-5.4-4" class="pilcrow">¶</a></p>
-<p id="section-5.4-5">Akin to the proximity assertion in the BRSKI case, the agent-proximity provides pledge proximity evidence to the MASA.
-But additionally, agent-proximity allows the domain registrar to be sure that the PVR collected by the Registrar-Agent was in fact collected by the Registrar-Agent, to which the registrar is connected to.<a href="#section-5.4-5" class="pilcrow">¶</a></p>
-<p id="section-5.4-6">The provisioning of the Registrar-Agent LDevID certificate is out of scope for this document, but may be done in advance using a separate BRSKI run or by other means like configuration.
-It is recommended to use short lived Registrar-Agent LDevIDs in the range of days or weeks as outlined in <a href="#sec_cons_reg-agt" class="auto internal xref">Section 11.3</a>.<a href="#section-5.4-6" class="pilcrow">¶</a></p>
+Akin to the proximity assertion in the BRSKI case, the agent-proximity provides pledge proximity evidence to the MASA.
+But additionally, agent-proximity allows the domain registrar to be sure that the PVR collected by the Registrar-Agent was in fact collected by the Registrar-Agent, to which the registrar is connected to.<a href="#section-5.4-4" class="pilcrow">¶</a></p>
+<p id="section-5.4-5">The provisioning of the Registrar-Agent LDevID certificate is out of scope for this document, but may be done in advance using a separate BRSKI run or by other means like configuration.
+It is recommended to use short lived Registrar-Agent LDevIDs in the range of days or weeks as outlined in <a href="#sec_cons_reg-agt" class="auto internal xref">Section 10.3</a>.<a href="#section-5.4-5" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -2546,7 +2537,7 @@ The product-serial-number composition is manufacturer dependent and may contain 
               <p id="section-6.2.2-5.2.1">"_brski-pledge._tcp.local" to get a list of pledges to be bootstrapped.<a href="#section-6.2.2-5.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.2.2-6">A manufacturer may allow the pledge to react on DNS-SD with mDNS discovery without his product-serial-number contained. This allows a commissioning tool to discover pledges to be bootstrapped in the domain. The manufacturer support this functionality as outlined in <a href="#sec_cons_mDNS" class="auto internal xref">Section 11.4</a>.<a href="#section-6.2.2-6" class="pilcrow">¶</a></p>
+<p id="section-6.2.2-6">A manufacturer may allow the pledge to react on DNS-SD with mDNS discovery without his product-serial-number contained. This allows a commissioning tool to discover pledges to be bootstrapped in the domain. The manufacturer support this functionality as outlined in <a href="#sec_cons_mDNS" class="auto internal xref">Section 10.4</a>.<a href="#section-6.2.2-6" class="pilcrow">¶</a></p>
 <p id="section-6.2.2-7">Establishing network connectivity of the pledge is out of scope of this document but necessary to apply DNS-SD with mDNS.
 For Ethernet it is provided by simply connecting the network cable.
 For WiFi networks, connectivity can be provided by using a pre-agreed SSID for bootstrapping, e.g., as proposed in <span>[<a href="#I-D.richardson-emu-eap-onboarding" class="cite xref">I-D.richardson-emu-eap-onboarding</a>]</span>.
@@ -2663,22 +2654,12 @@ This enables the registrar to verify that it is the desired registrar for handli
 The registrar EE certificate may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar.<a href="#section-7-2" class="pilcrow">¶</a></p>
 <p id="section-7-3">In addition, the Registrar-Agent provides "agent-signed-data" containing the pledge product serial number signed with the private key corresponding to the EE certificate of the Registrar-Agent, as described in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.
 This enables the registrar to verify and log, which Registrar-Agent was in contact with the pledge, when verifying the PVR.<a href="#section-7-3" class="pilcrow">¶</a></p>
-<p id="section-7-4">The registrar provides the EE certificate of the Registrar-Agent identified by the SubjectKeyIdentifier (SKID) in the header of the "agent-signed-data" from the PVR in its RVR (see also <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a>).<a href="#section-7-4" class="pilcrow">¶</a></p>
-<p id="section-7-5">The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-certificate" leaf and may assert the PVR as "verified" or "logged".<a href="#section-7-5" class="pilcrow">¶</a></p>
-<p id="section-7-6">TODO[LDevID as EE cert for agent-proximity]
-In addition, the MASA may issue the assertion "agent-proximity" as follows:
-The MASA verifies the signature of the "agent-signed-data" contained in the "prior-signed-voucher-request", based on the provided EE certificate of the Registrar-Agent in the "agent-sign-cert" leaf of the RVR.
-If both can be verified successfully, the MASA can assert "agent-proximity" in the voucher.
-The assertion of "agent-proximity" is similar to the proximity assertion by the MASA when using BRSKI.
-Note that the different assertions do not provide a metric of strength as the security properties are not comparable.<a href="#section-7-6" class="pilcrow">¶</a></p>
-<p id="section-7-7">Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx response status codes as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-When successful, the Voucher will then be supplied via the registrar to the Registrar-Agent.<a href="#section-7-7" class="pilcrow">¶</a></p>
-<p id="section-7-8"><a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> provides an overview of the exchanges detailed in the following subsections.<a href="#section-7-8" class="pilcrow">¶</a></p>
+<p id="section-7-4"><a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> provides an overview of the exchanges detailed in the following subsections.<a href="#section-7-4" class="pilcrow">¶</a></p>
 <span id="name-overview-pledge-responder-m"></span><div id="exchangesfig_uc2_all">
 <figure id="figure-4">
-        <div id="section-7-9.1">
-          <div class="alignLeft art-svg artwork" id="section-7-9.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="1776" width="560" viewBox="0 0 560 1776" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+        <div id="section-7-5.1">
+          <div class="alignLeft art-svg artwork" id="section-7-5.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="1792" width="560" viewBox="0 0 560 1792" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
               <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
               <path d="M 32,88 L 32,192" fill="none" stroke="black"></path>
               <path d="M 32,256 L 32,320" fill="none" stroke="black"></path>
@@ -2691,6 +2672,7 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
               <path d="M 32,1344 L 32,1392" fill="none" stroke="black"></path>
               <path d="M 32,1456 L 32,1552" fill="none" stroke="black"></path>
               <path d="M 32,1616 L 32,1648" fill="none" stroke="black"></path>
+              <path d="M 32,1712 L 32,1760" fill="none" stroke="black"></path>
               <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
               <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
               <path d="M 168,88 L 168,192" fill="none" stroke="black"></path>
@@ -2704,6 +2686,7 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
               <path d="M 168,1344 L 168,1392" fill="none" stroke="black"></path>
               <path d="M 168,1456 L 168,1552" fill="none" stroke="black"></path>
               <path d="M 168,1616 L 168,1648" fill="none" stroke="black"></path>
+              <path d="M 168,1712 L 168,1760" fill="none" stroke="black"></path>
               <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
               <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
               <path d="M 312,88 L 312,192" fill="none" stroke="black"></path>
@@ -2718,6 +2701,7 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
               <path d="M 312,1344 L 312,1392" fill="none" stroke="black"></path>
               <path d="M 312,1456 L 312,1520" fill="none" stroke="black"></path>
               <path d="M 312,1616 L 312,1648" fill="none" stroke="black"></path>
+              <path d="M 312,1712 L 312,1760" fill="none" stroke="black"></path>
               <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
               <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
               <path d="M 432,88 L 432,192" fill="none" stroke="black"></path>
@@ -2732,6 +2716,7 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
               <path d="M 432,1344 L 432,1392" fill="none" stroke="black"></path>
               <path d="M 432,1456 L 432,1488" fill="none" stroke="black"></path>
               <path d="M 432,1616 L 432,1648" fill="none" stroke="black"></path>
+              <path d="M 432,1712 L 432,1760" fill="none" stroke="black"></path>
               <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
               <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
               <path d="M 536,88 L 536,192" fill="none" stroke="black"></path>
@@ -2746,6 +2731,7 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
               <path d="M 536,1344 L 536,1392" fill="none" stroke="black"></path>
               <path d="M 536,1456 L 536,1520" fill="none" stroke="black"></path>
               <path d="M 536,1616 L 536,1648" fill="none" stroke="black"></path>
+              <path d="M 536,1712 L 536,1760" fill="none" stroke="black"></path>
               <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
               <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
               <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
@@ -2820,6 +2806,7 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
               <path d="M 504,1520 L 528,1520" fill="none" stroke="black"></path>
               <path d="M 176,1632 L 200,1632" fill="none" stroke="black"></path>
               <path d="M 280,1632 L 304,1632" fill="none" stroke="black"></path>
+              <path d="M 40,1728 L 56,1728" fill="none" stroke="black"></path>
               <polygon class="arrowhead" points="536,1504 524,1498.4 524,1509.6" fill="black" transform="rotate(0,528,1504)"></polygon>
               <polygon class="arrowhead" points="536,656 524,650.4 524,661.6" fill="black" transform="rotate(0,528,656)"></polygon>
               <polygon class="arrowhead" points="536,640 524,634.4 524,645.6" fill="black" transform="rotate(0,528,640)"></polygon>
@@ -2853,6 +2840,7 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
               <polygon class="arrowhead" points="168,304 156,298.4 156,309.6" fill="black" transform="rotate(0,160,304)"></polygon>
               <polygon class="arrowhead" points="168,272 156,266.4 156,277.6" fill="black" transform="rotate(0,160,272)"></polygon>
               <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
+              <polygon class="arrowhead" points="48,1728 36,1722.4 36,1733.6" fill="black" transform="rotate(180,40,1728)"></polygon>
               <polygon class="arrowhead" points="48,1360 36,1354.4 36,1365.6" fill="black" transform="rotate(180,40,1360)"></polygon>
               <polygon class="arrowhead" points="48,1248 36,1242.4 36,1253.6" fill="black" transform="rotate(180,40,1248)"></polygon>
               <polygon class="arrowhead" points="48,1232 36,1226.4 36,1237.6" fill="black" transform="rotate(180,40,1232)"></polygon>
@@ -2920,10 +2908,12 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
                 <text x="536" y="468">~</text>
                 <text x="40" y="484">(3)</text>
                 <text x="88" y="484">Request</text>
-                <text x="152" y="484">Voucher</text>
-                <text x="204" y="484">from</text>
-                <text x="240" y="484">the</text>
-                <text x="296" y="484">Registrar</text>
+                <text x="136" y="484">PVR</text>
+                <text x="164" y="484">to</text>
+                <text x="216" y="484">Registrar</text>
+                <text x="280" y="484">incl.</text>
+                <text x="336" y="484">backend</text>
+                <text x="416" y="484">interaction</text>
                 <text x="32" y="500">~</text>
                 <text x="168" y="500">~</text>
                 <text x="312" y="500">~</text>
@@ -2957,6 +2947,9 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
                 <text x="128" y="772">PER</text>
                 <text x="156" y="772">to</text>
                 <text x="208" y="772">Registrar</text>
+                <text x="272" y="772">incl.</text>
+                <text x="328" y="772">backend</text>
+                <text x="408" y="772">interaction</text>
                 <text x="32" y="788">~</text>
                 <text x="168" y="788">~</text>
                 <text x="312" y="788">~</text>
@@ -3102,50 +3095,55 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
                 <text x="312" y="1700">~</text>
                 <text x="432" y="1700">~</text>
                 <text x="536" y="1700">~</text>
-                <text x="32" y="1716">|</text>
-                <text x="168" y="1716">|</text>
-                <text x="312" y="1716">|</text>
-                <text x="432" y="1716">|</text>
-                <text x="536" y="1716">|</text>
-                <text x="44" y="1732">TODO</text>
-                <text x="32" y="1748">|</text>
-                <text x="168" y="1748">|</text>
-                <text x="312" y="1748">|</text>
-                <text x="432" y="1748">|</text>
-                <text x="536" y="1748">|</text>
-                <text x="32" y="1764">~</text>
-                <text x="168" y="1764">~</text>
-                <text x="312" y="1764">~</text>
-                <text x="432" y="1764">~</text>
-                <text x="536" y="1764">~</text>
+                <text x="112" y="1732">pStatus-Req--</text>
+                <text x="100" y="1748">--pStatus-Resp-&gt;</text>
+                <text x="32" y="1780">~</text>
+                <text x="168" y="1780">~</text>
+                <text x="312" y="1780">~</text>
+                <text x="432" y="1780">~</text>
+                <text x="536" y="1780">~</text>
               </g>
-            </svg><a href="#section-7-9.1.1" class="pilcrow">¶</a>
+            </svg><a href="#section-7-5.1.1" class="pilcrow">¶</a>
 </div>
 </div>
 <figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
 <a href="#name-overview-pledge-responder-m" class="selfRef">Overview pledge-responder-mode exchanges</a>
         </figcaption></figure>
 </div>
-<p id="section-7-10">TODO[where general status req/res]<a href="#section-7-10" class="pilcrow">¶</a></p>
-<p id="section-7-11">The following sub sections split the interactions shown in <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> between the different components into:<a href="#section-7-11" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-7-12">
-<li id="section-7-12.1">
-          <p id="section-7-12.1.1"><a href="#tpvr" class="auto internal xref">Section 7.1</a> describes the request object acquisition by the Registrar-Agent from pledge.<a href="#section-7-12.1.1" class="pilcrow">¶</a></p>
+<p id="section-7-6">The following sub sections split the interactions shown in <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> between the different components into:<a href="#section-7-6" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-7-7">
+<li id="section-7-7.1">
+          <p id="section-7-7.1.1"><a href="#tpvr" class="auto internal xref">Section 7.1</a> describes the request object acquisition for the Pledge Voucher-Request by the Registrar-Agent.<a href="#section-7-7.1.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-12.2">
-          <p id="section-7-12.2.1"><a href="#tper" class="auto internal xref">Section 7.2</a> TODO<a href="#section-7-12.2.1" class="pilcrow">¶</a></p>
+        <li id="section-7-7.2">
+          <p id="section-7-7.2.1"><a href="#tper" class="auto internal xref">Section 7.2</a> describes the request object acquisition for the Pledge Enroll-Request by the Registrar-Agent.<a href="#section-7-7.2.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-12.3">
-          <p id="section-7-12.3.1"><a href="#pvr" class="auto internal xref">Section 7.3</a> describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA and the domain CA including the response object processing by these entities.<a href="#section-7-12.3.1" class="pilcrow">¶</a></p>
+        <li id="section-7-7.3">
+          <p id="section-7-7.3.1"><a href="#pvr" class="auto internal xref">Section 7.3</a> describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA using the RVR <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a> including the response object processing by these entities.<a href="#section-7-7.3.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-12.4">
-          <p id="section-7-12.4.1"><a href="#voucher" class="auto internal xref">Section 7.6</a> describes the supply of the Voucher from the Registrar-Agent to the pledge including the returned status information.<a href="#section-7-12.4.1" class="pilcrow">¶</a></p>
+        <li id="section-7-7.4">
+          <p id="section-7-7.4.1"><a href="#per" class="auto internal xref">Section 7.4</a> describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the CA using the PER including the response object processing by these entities.<a href="#section-7-7.4.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-12.5">
-          <p id="section-7-12.5.1"><a href="#enroll_response" class="auto internal xref">Section 7.8</a> describes the supply of the Enroll Reponse from the Registrar-Agent to the pledge including the returned status information.<a href="#section-7-12.5.1" class="pilcrow">¶</a></p>
+        <li id="section-7-7.5">
+          <p id="section-7-7.5.1"><a href="#req_cacerts" class="auto internal xref">Section 7.5</a> describes the object acquisition for the optional CA certificate provisioning to the Pledge initiated by the Registrar-Agent to the CA.<a href="#section-7-7.5.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-12.6">
-          <p id="section-7-12.6.1"><a href="#vstatus" class="auto internal xref">Section 7.9</a> and <a href="#estatus" class="auto internal xref">Section 7.10</a> describe the general status handling and addresses corresponding exchanges between the Registrar-Agent and the registrar.<a href="#section-7-12.6.1" class="pilcrow">¶</a></p>
+        <li id="section-7-7.6">
+          <p id="section-7-7.6.1"><a href="#voucher" class="auto internal xref">Section 7.6</a> describes the supply of the Voucher from the Registrar-Agent to the pledge including the returned status information.<a href="#section-7-7.6.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-7-7.7">
+          <p id="section-7-7.7.1"><a href="#cacerts" class="auto internal xref">Section 7.7</a> describes the supply of CA certificates to the Pledge by the Registrar-Agent.<a href="#section-7-7.7.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-7-7.8">
+          <p id="section-7-7.8.1"><a href="#enroll_response" class="auto internal xref">Section 7.8</a> describes the supply of the Enroll Reponse (containing the LDevID (Pledge) certificate) from the Registrar-Agent to the pledge including the returned status information.<a href="#section-7-7.8.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-7-7.9">
+          <p id="section-7-7.9.1"><a href="#vstatus" class="auto internal xref">Section 7.9</a> describes the status handling for the pledge processing of the voucher and addresses corresponding exchanges between the Registrar-Agent and the registrar as well as between the registrar and the MASA.<a href="#section-7-7.9.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-7-7.10">
+          <p id="section-7-7.10.1"><a href="#estatus" class="auto internal xref">Section 7.10</a> describes the status handling for the pledge processing of the enrollment response  and addresses the corresponding exchange between the Registrar-Agent and the registrar.<a href="#section-7-7.10.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-7-7.11">
+          <p id="section-7-7.11.1"><a href="#query" class="auto internal xref">Section 7.11</a> describes the general status handling to query information about the bootstrapping state from the pledge initiated by the Registrar-Agent.<a href="#section-7-7.11.1" class="pilcrow">¶</a></p>
 </li>
       </ol>
 <div id="tpvr">
@@ -3646,6 +3644,15 @@ As the "agent-sign-cert" field is defined as array (x5c), it can handle multiple
           </ul>
 <p id="section-7.3.2-19">If validation fails, the MASA <span class="bcp14">SHOULD</span> respond with an HTTP 4xx client error status code to the registrar.
 The HTTP error status codes are kept the same as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> and comprise the codes: 403, 404, 406, and 415.<a href="#section-7.3.2-19" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-20">The registrar provides the EE certificate of the Registrar-Agent identified by the SubjectKeyIdentifier (SKID) in the header of the "agent-signed-data" from the PVR in its RVR (see also <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a>).<a href="#section-7.3.2-20" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-21">The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-certificate" leaf and may assert the PVR as "verified" or "logged".<a href="#section-7.3.2-21" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-22">In addition, the MASA may issue the assertion "agent-proximity" as follows:
+The MASA verifies the signature of the "agent-signed-data" contained in the "prior-signed-voucher-request", based on the provided EE certificate of the Registrar-Agent in the "agent-sign-cert" leaf of the RVR.
+If both can be verified successfully, the MASA can assert "agent-proximity" in the voucher.
+The assertion of "agent-proximity" is similar to the proximity assertion by the MASA when using BRSKI.
+Note that the different assertions do not provide a metric of strength as the security properties are not comparable.<a href="#section-7.3.2-22" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-23">Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx response status codes as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+When successful, the Voucher will then be supplied via the registrar to the Registrar-Agent.<a href="#section-7.3.2-23" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="exchanges_uc2_2_vc">
@@ -3718,7 +3725,7 @@ While the pledge could not, at the time, validate the certificate truly belonged
 <p id="section-7.3.4-5">In the BRSKI-PRM mode, with the Registrar-Agent mediating all communication, the Pledge has not as yet been able to witness that the intended Registrar really does possess the relevant private key.
 This second signature provides for the same level of assurance to the pledge, and that it matches the public key that the pledge received in the trigger for the PVR (see <a href="#pavrt" class="auto internal xref">Figure 5</a>).<a href="#section-7.3.4-5" class="pilcrow">¶</a></p>
 <p id="section-7.3.4-6">The registrar <span class="bcp14">MUST</span> use the same registrar EE credentials used for authentication in the TLS handshake to authenticate towards the Registrar-Agent.
-This has some operational implications when the registrar may be part of a scalable framework as described in <span>[<a href="#I-D.richardson-anima-registrar-considerations" class="cite xref">I-D.richardson-anima-registrar-considerations</a>], <a href="https://datatracker.ietf.org/doc/html/draft-richardson-anima-registrar-considerations-07#section-1.3.1" class="relref">Section 1.3.1</a></span>.<a href="#section-7.3.4-6" class="pilcrow">¶</a></p>
+This has some operational implications when the registrar may be part of a scalable framework as described in <span>[<a href="#I-D.richardson-anima-registrar-considerations" class="cite xref">I-D.richardson-anima-registrar-considerations</a>], <a href="https://datatracker.ietf.org/doc/html/draft-richardson-anima-registrar-considerations-08#section-1.3.1" class="relref">Section 1.3.1</a></span>.<a href="#section-7.3.4-6" class="pilcrow">¶</a></p>
 <p id="section-7.3.4-7">The second signature <span class="bcp14">MUST</span> either be done with the private key associated with the registrar EE certificate provided to the Registrar-Agent, or the use of a certificate chain is necessary.
 This ensures that the same registrar EE certificate can be used to verify the signature as transmitted in the voucher-request as also transferred in the PVR in the "agent-provided-proximity-registrar-cert".<a href="#section-7.3.4-7" class="pilcrow">¶</a></p>
 <p id="section-7.3.4-8"><a href="#MASA-REG-vr" class="auto internal xref">Figure 12</a> below provides an example of the voucher with two signatures.<a href="#section-7.3.4-8" class="pilcrow">¶</a></p>
@@ -3797,7 +3804,7 @@ In addition, the registrar <span class="bcp14">SHALL</span> verify the following
               <p id="section-7.3.5-2.2.1">agent-signed-data: The registrar <span class="bcp14">MUST</span> verify that the Registrar-Agent provided data has been signed with the private key corresponding to the EE (RegAgt) certificate indicated in the "kid" JOSE header parameter.
 The registrar <span class="bcp14">MUST</span> verify that the LDevID(ReAgt) certificate, corresponding to the signature, is still valid.
 If the certificate is already expired, the registrar <span class="bcp14">SHALL</span> reject the request.
-Validity of used signing certificates at the time of signing the agent-signed-data is necessary to avoid that a rogue Registrar-Agent generates agent-signed-data objects to onboard arbitrary pledges at a later point in time, see also <a href="#sec_cons_reg-agt" class="auto internal xref">Section 11.3</a>.
+Validity of used signing certificates at the time of signing the agent-signed-data is necessary to avoid that a rogue Registrar-Agent generates agent-signed-data objects to onboard arbitrary pledges at a later point in time, see also <a href="#sec_cons_reg-agt" class="auto internal xref">Section 10.3</a>.
 The registrar <span class="bcp14">MUST</span> fetch the EE (RegAgt) certificate, based on the provided SubjectKeyIdentifier (SKID) contained in the "kid" header parameter of the agent-signed-data, and perform this verification.
 This requires, that the registrar has access to the EE (RegAgt) certificate data (including intermediate CA certificates if existent) based on the SKID.
 Note, the registrar may have stored the EE (RegAgt) certificate if used during TLS establishment between Registrar-Agent and registrar or it may be provided via a repository.<a href="#section-7.3.5-2.2.1" class="pilcrow">¶</a></p>
@@ -4087,24 +4094,6 @@ As the reason field is optional (see <span>[<a href="#RFC8995" class="cite xref"
 <p id="section-7.7.1-3">The CA certificates message has the Content-Type <code>application/jose+json</code> and is signed using the credential of the registrar as shown in <a href="#PCAC" class="auto internal xref">Figure 13</a>.<a href="#section-7.7.1-3" class="pilcrow">¶</a></p>
 <p id="section-7.7.1-4">The CA certificates are provided as base64-encoded "x5bag".
 The pledge <span class="bcp14">SHALL</span> install the received CA certificates as trust anchor after successful verification of the registrar's signature.<a href="#section-7.7.1-4" class="pilcrow">¶</a></p>
-<p id="section-7.7.1-5">The verification comprises the following steps the pledge <span class="bcp14">MUST</span> perform. Maintaining the order of versification steps as indicated allows to determine, which verification has already been passed:<a href="#section-7.7.1-5" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-7.7.1-6">
-<li id="section-7.7.1-6.1">
-              <p id="section-7.7.1-6.1.1">Check content-type of the CA certificates message. If no Content-Type is contained in the HTTP header, the default Content-Type utilized in this document (JSON-in-JWS) is used. If the Content-Type of the response is in an unknown or unsupported format, the pledge <span class="bcp14">SHOULD</span> reply with a 415 Unsupported media type error code.<a href="#section-7.7.1-6.1.1" class="pilcrow">¶</a></p>
-</li>
-            <li id="section-7.7.1-6.2">
-              <p id="section-7.7.1-6.2.1">Check the encoding of the payload. If the pledge detects errors in the encoding of the payload, it <span class="bcp14">SHOULD</span> reply with 400 Bad Request error code.<a href="#section-7.7.1-6.2.1" class="pilcrow">¶</a></p>
-</li>
-            <li id="section-7.7.1-6.3">
-              <p id="section-7.7.1-6.3.1">Verify that the wrapped CA certificate object is signed using the registrar certificate against the pinned-domain certificate. This <span class="bcp14">MAY</span> be done by comparing the hash that is indicating the certificate used to sign the message is that of the pinned-domain certificate. If the validation against the pinned domain-certificate fails, the client <span class="bcp14">SHOULD</span> reply with a 401 Unauthorized error code. It signals that the authentication has failed and therefore the object was not accepted.<a href="#section-7.7.1-6.3.1" class="pilcrow">¶</a></p>
-</li>
-            <li id="section-7.7.1-6.4">
-              <p id="section-7.7.1-6.4.1">Verify signature of the the received wrapped CA certificate object. If the validation of the signature fails, the pledge <span class="bcp14">SHOULD</span> reply with a 406 Not Acceptable. It signals that the object has not been accepted.<a href="#section-7.7.1-6.4.1" class="pilcrow">¶</a></p>
-</li>
-            <li id="section-7.7.1-6.5">
-              <p id="section-7.7.1-6.5.1">If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span>.<a href="#section-7.7.1-6.5.1" class="pilcrow">¶</a></p>
-</li>
-          </ol>
 </section>
 </div>
 <div id="response">
@@ -4112,7 +4101,24 @@ The pledge <span class="bcp14">SHALL</span> install the received CA certificates
           <h4 id="name-response">
 <a href="#section-7.7.2" class="section-number selfRef">7.7.2. </a><a href="#name-response" class="section-name selfRef">Response</a>
           </h4>
-<p id="section-7.7.2-1">TODO[empty?]<a href="#section-7.7.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.7.2-1">The verification comprises the following steps the pledge <span class="bcp14">MUST</span> perform. Maintaining the order of versification steps as indicated allows to determine, which verification has already been passed:<a href="#section-7.7.2-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-7.7.2-2">
+<li id="section-7.7.2-2.1">
+              <p id="section-7.7.2-2.1.1">Check content-type of the CA certificates message. If no Content-Type is contained in the HTTP header, the default Content-Type utilized in this document (JSON-in-JWS) is used. If the Content-Type of the response is in an unknown or unsupported format, the pledge <span class="bcp14">SHOULD</span> reply with a 415 Unsupported media type error code.<a href="#section-7.7.2-2.1.1" class="pilcrow">¶</a></p>
+</li>
+            <li id="section-7.7.2-2.2">
+              <p id="section-7.7.2-2.2.1">Check the encoding of the payload. If the pledge detects errors in the encoding of the payload, it <span class="bcp14">SHOULD</span> reply with 400 Bad Request error code.<a href="#section-7.7.2-2.2.1" class="pilcrow">¶</a></p>
+</li>
+            <li id="section-7.7.2-2.3">
+              <p id="section-7.7.2-2.3.1">Verify that the wrapped CA certificate object is signed using the registrar certificate against the pinned-domain certificate. This <span class="bcp14">MAY</span> be done by comparing the hash that is indicating the certificate used to sign the message is that of the pinned-domain certificate. If the validation against the pinned domain-certificate fails, the client <span class="bcp14">SHOULD</span> reply with a 401 Unauthorized error code. It signals that the authentication has failed and therefore the object was not accepted.<a href="#section-7.7.2-2.3.1" class="pilcrow">¶</a></p>
+</li>
+            <li id="section-7.7.2-2.4">
+              <p id="section-7.7.2-2.4.1">Verify signature of the the received wrapped CA certificate object. If the validation of the signature fails, the pledge <span class="bcp14">SHOULD</span> reply with a 406 Not Acceptable. It signals that the object has not been accepted.<a href="#section-7.7.2-2.4.1" class="pilcrow">¶</a></p>
+</li>
+            <li id="section-7.7.2-2.5">
+              <p id="section-7.7.2-2.5.1">If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span>.<a href="#section-7.7.2-2.5.1" class="pilcrow">¶</a></p>
+</li>
+          </ol>
 </section>
 </div>
 </section>
@@ -4235,7 +4241,7 @@ It <span class="bcp14">SHALL</span> provide the status information to the regist
 <p id="section-7.9-2">Preconditions in addition to <a href="#pvr" class="auto internal xref">Section 7.3</a>:<a href="#section-7.9-2" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.9-3.1">
-            <p id="section-7.9-3.1.1">Registrar-Agent: obtained voucher status and enroll status from pledge.<a href="#section-7.9-3.1.1" class="pilcrow">¶</a></p>
+            <p id="section-7.9-3.1.1">Registrar-Agent: obtained voucher status (vStatus) and enroll status (eStatus) from pledge.<a href="#section-7.9-3.1.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 <span id="name-bootstrapping-status-handli"></span><div id="exchangesfig_uc2_4">
@@ -4268,14 +4274,14 @@ It <span class="bcp14">SHALL</span> provide the status information to the regist
                 <path d="M 408,80 L 488,80" fill="none" stroke="black"></path>
                 <path d="M 48,160 L 104,160" fill="none" stroke="black"></path>
                 <path d="M 160,160 L 216,160" fill="none" stroke="black"></path>
-                <path d="M 48,192 L 64,192" fill="none" stroke="black"></path>
-                <path d="M 200,192 L 216,192" fill="none" stroke="black"></path>
+                <path d="M 48,192 L 88,192" fill="none" stroke="black"></path>
+                <path d="M 168,192 L 216,192" fill="none" stroke="black"></path>
                 <path d="M 232,208 L 248,208" fill="none" stroke="black"></path>
                 <path d="M 424,208 L 440,208" fill="none" stroke="black"></path>
                 <path d="M 232,224 L 264,224" fill="none" stroke="black"></path>
                 <path d="M 416,224 L 440,224" fill="none" stroke="black"></path>
-                <path d="M 48,272 L 64,272" fill="none" stroke="black"></path>
-                <path d="M 192,272 L 216,272" fill="none" stroke="black"></path>
+                <path d="M 48,272 L 88,272" fill="none" stroke="black"></path>
+                <path d="M 168,272 L 216,272" fill="none" stroke="black"></path>
                 <polygon class="arrowhead" points="448,208 436,202.4 436,213.6" fill="black" transform="rotate(0,440,208)"></polygon>
                 <polygon class="arrowhead" points="240,224 228,218.4 228,229.6" fill="black" transform="rotate(180,232,224)"></polygon>
                 <polygon class="arrowhead" points="224,272 212,266.4 212,277.6" fill="black" transform="rotate(0,216,272)"></polygon>
@@ -4300,8 +4306,7 @@ It <span class="bcp14">SHALL</span> provide the status information to the regist
                   <text x="84" y="132">info</text>
                   <text x="148" y="132">available]</text>
                   <text x="132" y="164">mTLS</text>
-                  <text x="104" y="196">Voucher</text>
-                  <text x="164" y="196">Status</text>
+                  <text x="128" y="196">vStatus</text>
                   <text x="300" y="212">req-device</text>
                   <text x="368" y="212">audit</text>
                   <text x="408" y="212">log</text>
@@ -4312,8 +4317,7 @@ It <span class="bcp14">SHALL</span> provide the status information to the regist
                   <text x="240" y="244">audit</text>
                   <text x="280" y="244">log</text>
                   <text x="304" y="244">]</text>
-                  <text x="100" y="276">Enroll</text>
-                  <text x="156" y="276">Status</text>
+                  <text x="128" y="276">eStatus</text>
                 </g>
               </svg><a href="#section-7.9-4.1.1" class="pilcrow">¶</a>
 </div>
@@ -4366,10 +4370,10 @@ Within the server logs the server <span class="bcp14">SHOULD</span> capture this
         </h3>
 <p id="section-7.10-1">The Registrar-Agent <span class="bcp14">MUST</span> provide the pledge's enroll status to the registrar.
 The status indicates the pledge could process the Enroll-Response (certificate) and holds the corresponding private key.<a href="#section-7.10-1" class="pilcrow">¶</a></p>
-<div id="request-artifact-vstatus-1">
+<div id="request-artifact-estatus">
 <section id="section-7.10.1">
-          <h4 id="name-request-artifact-vstatus-2">
-<a href="#section-7.10.1" class="section-number selfRef">7.10.1. </a><a href="#name-request-artifact-vstatus-2" class="section-name selfRef">Request Artifact: vStatus</a>
+          <h4 id="name-request-artifact-estatus">
+<a href="#section-7.10.1" class="section-number selfRef">7.10.1. </a><a href="#name-request-artifact-estatus" class="section-name selfRef">Request Artifact: eStatus</a>
           </h4>
 <p id="section-7.10.1-1">The Registrar-Agent sends the pledge enroll status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/enrollstatus".
 The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#estat" class="auto internal xref">Figure 16</a>.<a href="#section-7.10.1-1" class="pilcrow">¶</a></p>
@@ -4403,19 +4407,10 @@ Within the server log the registrar <span class="bcp14">SHOULD</span> capture th
 <p id="section-7.11-1">The following assumes that a Registrar-Agent may need to query the status of a pledge.
 This information may be useful to solve errors, when the pledge was not able to connect to the target domain during the bootstrapping.
 The pledge <span class="bcp14">MAY</span> provide a dedicated endpoint to accept status-requests.<a href="#section-7.11-1" class="pilcrow">¶</a></p>
-<p id="section-7.11-2">Preconditions:<a href="#section-7.11-2" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-7.11-3.1">
-            <p id="section-7.11-3.1.1">Registrar-Agent: possesses LDevID (RegAgt), may have a list of product-serial-number(s) of pledges to be queried and a list of corresponding manufacturer trust anchors to be able to verify signatures performed with the IDevID credential.<a href="#section-7.11-3.1.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="normal" id="section-7.11-3.2">
-            <p id="section-7.11-3.2.1">Pledge: may already possess domain credentials and LDevID(Pledge), or may not possess one or both of these.<a href="#section-7.11-3.2.1" class="pilcrow">¶</a></p>
-</li>
-        </ul>
 <span id="name-pledge-status-handling-betw"></span><div id="exchangesfig_uc2_5">
 <figure id="figure-18">
-          <div id="section-7.11-4.1">
-            <div class="alignLeft art-svg artwork" id="section-7.11-4.1.1">
+          <div id="section-7.11-2.1">
+            <div class="alignLeft art-svg artwork" id="section-7.11-2.1.1">
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="176" width="360" viewBox="0 0 360 176" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
                 <path d="M 40,88 L 40,160" fill="none" stroke="black"></path>
@@ -4427,32 +4422,30 @@ The pledge <span class="bcp14">MAY</span> provide a dedicated endpoint to accept
                 <path d="M 256,32 L 352,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
                 <path d="M 256,80 L 352,80" fill="none" stroke="black"></path>
-                <path d="M 48,112 L 72,112" fill="none" stroke="black"></path>
-                <path d="M 264,112 L 296,112" fill="none" stroke="black"></path>
-                <path d="M 48,144 L 72,144" fill="none" stroke="black"></path>
-                <path d="M 272,144 L 296,144" fill="none" stroke="black"></path>
+                <path d="M 48,112 L 112,112" fill="none" stroke="black"></path>
+                <path d="M 224,112 L 296,112" fill="none" stroke="black"></path>
+                <path d="M 56,144 L 112,144" fill="none" stroke="black"></path>
+                <path d="M 232,144 L 296,144" fill="none" stroke="black"></path>
                 <polygon class="arrowhead" points="304,144 292,138.4 292,149.6" fill="black" transform="rotate(0,296,144)"></polygon>
                 <polygon class="arrowhead" points="56,112 44,106.4 44,117.6" fill="black" transform="rotate(180,48,112)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
                   <text x="308" y="52">Registrar-</text>
                   <text x="288" y="68">Agent</text>
-                  <text x="136" y="116">pledge-status</text>
-                  <text x="224" y="116">request</text>
-                  <text x="136" y="148">pledge-status</text>
-                  <text x="228" y="148">response</text>
+                  <text x="168" y="116">pStatus-Req</text>
+                  <text x="172" y="148">pStatus-Resp</text>
                 </g>
-              </svg><a href="#section-7.11-4.1.1" class="pilcrow">¶</a>
+              </svg><a href="#section-7.11-2.1.1" class="pilcrow">¶</a>
 </div>
 </div>
 <figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
 <a href="#name-pledge-status-handling-betw" class="selfRef">Pledge-status handling between Registrar-Agent and pledge</a>
           </figcaption></figure>
 </div>
-<div id="request-artifact-status-request">
+<div id="request-artifact-pstatus-req">
 <section id="section-7.11.1">
-          <h4 id="name-request-artifact-status-req">
-<a href="#section-7.11.1" class="section-number selfRef">7.11.1. </a><a href="#name-request-artifact-status-req" class="section-name selfRef">Request Artifact: status-request</a>
+          <h4 id="name-request-artifact-pstatus-re">
+<a href="#section-7.11.1" class="section-number selfRef">7.11.1. </a><a href="#name-request-artifact-pstatus-re" class="section-name selfRef">Request Artifact: pStatus-Req</a>
           </h4>
 <p id="section-7.11.1-1">The Registrar-Agent requests the pledge-status via HTTP POST on the defined pledge endpoint: "/.well-known/brski/qps"<a href="#section-7.11.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.11.1-2">The Registrar-Agent Content-Type header for the pledge-status request is: <code>application/jose+json</code>.
@@ -4526,12 +4519,12 @@ This is out of scope for this specification.<a href="#section-7.11.1-5" class="p
 </div>
 </section>
 </div>
-<div id="response-artifact-status-response">
+<div id="response-artifact-pstatus-resp">
 <section id="section-7.11.2">
-          <h4 id="name-response-artifact-status-re">
-<a href="#section-7.11.2" class="section-number selfRef">7.11.2. </a><a href="#name-response-artifact-status-re" class="section-name selfRef">Response Artifact: status-response</a>
+          <h4 id="name-response-artifact-pstatus-r">
+<a href="#section-7.11.2" class="section-number selfRef">7.11.2. </a><a href="#name-response-artifact-pstatus-r" class="section-name selfRef">Response Artifact: pStatus-Resp</a>
           </h4>
-<p id="section-7.11.2-1">If the pledge receives the pledge-status request with status-type "bootstrap" it <span class="bcp14">SHALL</span> react with a status response message based on the telemetry information described in TODO.<a href="#section-7.11.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-1">If the pledge receives the pledge-status request with status-type "bootstrap" it <span class="bcp14">SHALL</span> react with a status response message based on previously collected telemetry information (see <a href="#vstatus" class="auto internal xref">Section 7.9</a> and <a href="#estatus" class="auto internal xref">Section 7.10</a>) in a single status-response artifact.<a href="#section-7.11.2-1" class="pilcrow">¶</a></p>
 <p id="section-7.11.2-2">The pledge-status response Content-Type header is <code>application/jose+json</code>.<a href="#section-7.11.2-2" class="pilcrow">¶</a></p>
 <p id="section-7.11.2-3">The following CDDL explains the structure of the format for the status response, which is:<a href="#section-7.11.2-3" class="pilcrow">¶</a></p>
 <span id="name-cddl-for-pledge-status-resp"></span><div id="stat_res_def">
@@ -4589,25 +4582,24 @@ Additional information may be provided in the reason or reason-context.
 The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-7.5.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.11.2-8">The reason and the reason-context <span class="bcp14">SHOULD</span> contain the telemetry information as described in TODO[exchanges_uc2_3].<a href="#section-7.11.2-8" class="pilcrow">¶</a></p>
-<p id="section-7.11.2-9">As the pledge is assumed to utilize its bootstrapped credentials (LDevID) in communication with other peers, additional status information is provided for the connectivity to other peers, which may be helpful in analyzing potential error cases.<a href="#section-7.11.2-9" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-8">As the pledge is assumed to utilize its bootstrapped credentials (LDevID) in communication with other peers, additional status information is provided for the connectivity to other peers, which may be helpful in analyzing potential error cases.<a href="#section-7.11.2-8" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-7.11.2-10.1">
-              <p id="section-7.11.2-10.1.1">"connect-success": Pledge could successfully establish a connection to another peer.
+<li class="normal" id="section-7.11.2-9.1">
+              <p id="section-7.11.2-9.1.1">"connect-success": Pledge could successfully establish a connection to another peer.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-10.1.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-9.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-10.2">
-              <p id="section-7.11.2-10.2.1">"connect-error": Pledge connection establishment terminated with error.
+            <li class="normal" id="section-7.11.2-9.2">
+              <p id="section-7.11.2-9.2.1">"connect-error": Pledge connection establishment terminated with error.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-10.2.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-9.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.11.2-11">The pledge-status responses are cumulative in the sense that connect-success implies enroll-success, which in turn implies voucher-success.<a href="#section-7.11.2-11" class="pilcrow">¶</a></p>
-<p id="section-7.11.2-12"><a href="#stat_res" class="auto internal xref">Figure 22</a> provides an example for the bootstrapping-status information.<a href="#section-7.11.2-12" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-10">The pledge-status responses are cumulative in the sense that connect-success implies enroll-success, which in turn implies voucher-success.<a href="#section-7.11.2-10" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-11"><a href="#stat_res" class="auto internal xref">Figure 22</a> provides an example for the bootstrapping-status information.<a href="#section-7.11.2-11" class="pilcrow">¶</a></p>
 <span id="name-example-of-pledge-status-re"></span><div id="stat_res">
 <figure id="figure-22">
-            <div class="alignLeft art-text artwork" id="section-7.11.2-13.1">
+            <div class="alignLeft art-text artwork" id="section-7.11.2-12.1">
 <pre>
 # The pledge "status-response" in General JWS Serialization syntax
 {
@@ -4647,72 +4639,44 @@ The pledge signs the response message using its LDevID(Pledge).<a href="#section
             </figcaption></figure>
 </div>
 <ul class="normal">
-<li class="normal" id="section-7.11.2-14.1">
-              <p id="section-7.11.2-14.1.1">In case "factory-default" the pledge does not possess the domain certificate resp. the domain trust-anchor.
-It will not be able to verify the signature of the Registrar-Agent in the bootstrapping-status request.<a href="#section-7.11.2-14.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.11.2-13.1">
+              <p id="section-7.11.2-13.1.1">In case "factory-default" the pledge does not possess the domain certificate resp. the domain trust-anchor.
+It will not be able to verify the signature of the Registrar-Agent in the bootstrapping-status request.<a href="#section-7.11.2-13.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-14.2">
-              <p id="section-7.11.2-14.2.1">In cases "vouchered" and "enrolled" the pledge already possesses the domain certificate (has domain trust-anchor) and can therefore validate the signature of the Registrar-Agent.
-If validation of the JWS signature fails, the pledge <span class="bcp14">SHOULD</span> respond with the HTTP 403 Forbidden status code.<a href="#section-7.11.2-14.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-13.2">
+              <p id="section-7.11.2-13.2.1">In cases "vouchered" and "enrolled" the pledge already possesses the domain certificate (has domain trust-anchor) and can therefore validate the signature of the Registrar-Agent.
+If validation of the JWS signature fails, the pledge <span class="bcp14">SHOULD</span> respond with the HTTP 403 Forbidden status code.<a href="#section-7.11.2-13.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-14.3">
-              <p id="section-7.11.2-14.3.1">The HTTP 406 Not Acceptable status code <span class="bcp14">SHOULD</span> be used, if the Accept header in the request indicates an unknown or unsupported format.<a href="#section-7.11.2-14.3.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-13.3">
+              <p id="section-7.11.2-13.3.1">The HTTP 406 Not Acceptable status code <span class="bcp14">SHOULD</span> be used, if the Accept header in the request indicates an unknown or unsupported format.<a href="#section-7.11.2-13.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-14.4">
-              <p id="section-7.11.2-14.4.1">The HTTP 415 Unsupported Media Type status code <span class="bcp14">SHOULD</span> be used, if the Content-Type of the request is an unknown or unsupported format.<a href="#section-7.11.2-14.4.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-13.4">
+              <p id="section-7.11.2-13.4.1">The HTTP 415 Unsupported Media Type status code <span class="bcp14">SHOULD</span> be used, if the Content-Type of the request is an unknown or unsupported format.<a href="#section-7.11.2-13.4.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-14.5">
-              <p id="section-7.11.2-14.5.1">The HTTP 400 Bad Request status code <span class="bcp14">SHOULD</span> be used, if the Accept/Content-Type headers are correct but nevertheless the status-request cannot be correctly parsed.<a href="#section-7.11.2-14.5.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-13.5">
+              <p id="section-7.11.2-13.5.1">The HTTP 400 Bad Request status code <span class="bcp14">SHOULD</span> be used, if the Accept/Content-Type headers are correct but nevertheless the status-request cannot be correctly parsed.<a href="#section-7.11.2-13.5.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.11.2-15">The pledge <span class="bcp14">SHOULD</span> by default only respond to requests from nodes it can authenticate (such as registrar
-agent), once the pledge is enrolled with CA certificates and a matching domain certificate.<a href="#section-7.11.2-15" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-14">The pledge <span class="bcp14">SHOULD</span> by default only respond to requests from nodes it can authenticate (such as registrar
+agent), once the pledge is enrolled with CA certificates and a matching domain certificate.<a href="#section-7.11.2-14" class="pilcrow">¶</a></p>
 </section>
 </div>
-</section>
-</div>
-</section>
-</div>
-<div id="todo-artifacts">
-<section id="section-8">
-      <h2 id="name-todo-artifacts">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-todo-artifacts" class="section-name selfRef">TODO Artifacts</a>
-      </h2>
-<div id="voucher-request-prm-yang">
-<section id="section-8.1">
-        <h3 id="name-voucher-request-artifact">
-<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-voucher-request-artifact" class="section-name selfRef">Voucher-Request Artifact</a>
-        </h3>
-<p id="section-8.1-1"><span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> extends the voucher-request as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> to include additional fields necessary for handling bootstrapping in the pledge-responder-mode.
-These additional fields are defined in <a href="#tpvr" class="auto internal xref">Section 7.1</a> as:<a href="#section-8.1-1" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-8.1-2.1">
-            <p id="section-8.1-2.1.1">agent-signed-data to provide a JSON encoded artifact from the involved Registrar-Agent, which allows the registrar to verify the Registrar-Agent's involvement<a href="#section-8.1-2.1.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="normal" id="section-8.1-2.2">
-            <p id="section-8.1-2.2.1">agent-provided-proximity-registrar-cert to provide the registrar certificate visible to the Registrar-Agent, comparable to the registrar-proximity-certificate used in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span><a href="#section-8.1-2.2.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="normal" id="section-8.1-2.3">
-            <p id="section-8.1-2.3.1">TODO[where used? LDevID?] agent-signing certificate to optionally provide the Registrar-Agent signing certificate.<a href="#section-8.1-2.3.1" class="pilcrow">¶</a></p>
-</li>
-        </ul>
-<p id="section-8.1-3">Examples for the application of these fields in the context of a PVR are provided in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-8.1-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="iana-con">
-<section id="section-9">
+<section id="section-8">
       <h2 id="name-iana-considerations">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
-<p id="section-9-1">This document requires the following IANA actions.<a href="#section-9-1" class="pilcrow">¶</a></p>
+<p id="section-8-1">This document requires the following IANA actions.<a href="#section-8-1" class="pilcrow">¶</a></p>
 <div id="brski-well-known-registry">
-<section id="section-9.1">
+<section id="section-8.1">
         <h3 id="name-brski-well-known-registry">
-<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-brski-well-known-registry" class="section-name selfRef">BRSKI .well-known Registry</a>
+<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-brski-well-known-registry" class="section-name selfRef">BRSKI .well-known Registry</a>
         </h3>
-<p id="section-9.1-1">IANA is requested to enhance the Registry entitled: "BRSKI Well-Known URIs" with the following endpoints:<a href="#section-9.1-1" class="pilcrow">¶</a></p>
+<p id="section-8.1-1">IANA is requested to enhance the Registry entitled: "BRSKI Well-Known URIs" with the following endpoints:<a href="#section-8.1-1" class="pilcrow">¶</a></p>
 <span id="name-brski-well-known-uris-addit"></span><div id="iana_table">
 <table class="center" id="table-3">
           <caption>
@@ -4773,168 +4737,168 @@ These additional fields are defined in <a href="#tpvr" class="auto internal xref
 </section>
 </div>
 <div id="dns-service-names">
-<section id="section-9.2">
+<section id="section-8.2">
         <h3 id="name-dns-service-names">
-<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-dns-service-names" class="section-name selfRef">DNS Service Names</a>
+<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-dns-service-names" class="section-name selfRef">DNS Service Names</a>
         </h3>
-<p id="section-9.2-1">IANA has registered the following service names:<a href="#section-9.2-1" class="pilcrow">¶</a></p>
-<p id="section-9.2-2"><strong>Service Name:</strong> brski-pledge<br>
+<p id="section-8.2-1">IANA has registered the following service names:<a href="#section-8.2-1" class="pilcrow">¶</a></p>
+<p id="section-8.2-2"><strong>Service Name:</strong> brski-pledge<br>
           <strong>Transport Protocol(s):</strong> tcp<br>
           <strong>Assignee:</strong> IESG <a href="mailto:iesg@ietf.org">iesg@ietf.org</a><br>
           <strong>Contact:</strong> IESG <a href="mailto:iesg@ietf.org">iesg@ietf.org</a><br>
           <strong>Description:</strong> The Bootstrapping Remote Secure Key Infrastructure Pledge<br>
-          <strong>Reference:</strong> [THISRFC]<a href="#section-9.2-2" class="pilcrow">¶</a></p>
+          <strong>Reference:</strong> [THISRFC]<a href="#section-8.2-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="privacy-considerations">
-<section id="section-10">
+<section id="section-9">
       <h2 id="name-privacy-considerations">
-<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-privacy-considerations" class="section-name selfRef">Privacy Considerations</a>
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-privacy-considerations" class="section-name selfRef">Privacy Considerations</a>
       </h2>
-<p id="section-10-1">In general, the privacy considerations of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> apply for BRSKI-PRM also.
-Further privacy aspects need to be considered for:<a href="#section-10-1" class="pilcrow">¶</a></p>
+<p id="section-9-1">In general, the privacy considerations of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> apply for BRSKI-PRM also.
+Further privacy aspects need to be considered for:<a href="#section-9-1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-10-2.1">
-          <p id="section-10-2.1.1">the introduction of the additional component Registrar-Agent<a href="#section-10-2.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-9-2.1">
+          <p id="section-9-2.1.1">the introduction of the additional component Registrar-Agent<a href="#section-9-2.1.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="normal" id="section-10-2.2">
-          <p id="section-10-2.2.1">potentially no transport layer security between Registrar-Agent and pledge<a href="#section-10-2.2.1" class="pilcrow">¶</a></p>
+        <li class="normal" id="section-9-2.2">
+          <p id="section-9-2.2.1">potentially no transport layer security between Registrar-Agent and pledge<a href="#section-9-2.2.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
-<p id="section-10-3"><a href="#tpvr" class="auto internal xref">Section 7.1</a> describes to optional apply TLS to protect the communication between the Registrar-Agent and the pledge.
-The following is therefore applicable to the communication without the TLS protection.<a href="#section-10-3" class="pilcrow">¶</a></p>
-<p id="section-10-4">The credential used by the Registrar-Agent to sign the data for the pledge <span class="bcp14">SHOULD NOT</span> contain any personal information.
+<p id="section-9-3"><a href="#tpvr" class="auto internal xref">Section 7.1</a> describes to optional apply TLS to protect the communication between the Registrar-Agent and the pledge.
+The following is therefore applicable to the communication without the TLS protection.<a href="#section-9-3" class="pilcrow">¶</a></p>
+<p id="section-9-4">The credential used by the Registrar-Agent to sign the data for the pledge <span class="bcp14">SHOULD NOT</span> contain any personal information.
 Therefore, it is recommended to use an LDevID certificate associated with the commissioning device instead of an LDevID certificate associated with the service technician operating the device.
-This avoids revealing potentially included personal information to Registrar and MASA.<a href="#section-10-4" class="pilcrow">¶</a></p>
-<p id="section-10-5">The communication between the pledge and the Registrar-Agent is performed over plain HTTP.
+This avoids revealing potentially included personal information to Registrar and MASA.<a href="#section-9-4" class="pilcrow">¶</a></p>
+<p id="section-9-5">The communication between the pledge and the Registrar-Agent is performed over plain HTTP.
 Therefore, it is subject to disclosure by a Dolev-Yao attacker (an "oppressive observer")<span>[<a href="#onpath" class="cite xref">onpath</a>]</span>.
-Depending on the requests and responses, the following information is disclosed.<a href="#section-10-5" class="pilcrow">¶</a></p>
+Depending on the requests and responses, the following information is disclosed.<a href="#section-9-5" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-10-6.1">
-          <p id="section-10-6.1.1">the Pledge product-serial-number is contained in the trigger message for the PVR and in all responses from the pledge.
+<li class="normal" id="section-9-6.1">
+          <p id="section-9-6.1.1">the Pledge product-serial-number is contained in the trigger message for the PVR and in all responses from the pledge.
 This information reveals the identity of the devices being bootstrapped and allows deduction of which products an operator is using in their environment.
 As the communication between the pledge and the Registrar-Agent may be realized over wireless link, this information could easily be eavesdropped, if the wireless network is unencrypted.
-Even if the wireless network is encrypted, if it uses a network-wide key, then layer-2 attacks (ARP/ND spoofing) could insert an on-path observer into the path.<a href="#section-10-6.1.1" class="pilcrow">¶</a></p>
+Even if the wireless network is encrypted, if it uses a network-wide key, then layer-2 attacks (ARP/ND spoofing) could insert an on-path observer into the path.<a href="#section-9-6.1.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="normal" id="section-10-6.2">
-          <p id="section-10-6.2.1">the Timestamp data could reveal the activation time of the device.<a href="#section-10-6.2.1" class="pilcrow">¶</a></p>
+        <li class="normal" id="section-9-6.2">
+          <p id="section-9-6.2.1">the Timestamp data could reveal the activation time of the device.<a href="#section-9-6.2.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="normal" id="section-10-6.3">
-          <p id="section-10-6.3.1">the Status data of the device could reveal information about the current state of the device in the domain network.<a href="#section-10-6.3.1" class="pilcrow">¶</a></p>
+        <li class="normal" id="section-9-6.3">
+          <p id="section-9-6.3.1">the Status data of the device could reveal information about the current state of the device in the domain network.<a href="#section-9-6.3.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 </section>
 </div>
 <div id="sec_cons">
-<section id="section-11">
+<section id="section-10">
       <h2 id="name-security-considerations">
-<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
-<p id="section-11-1">In general, the security considerations of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> apply for BRSKI-PRM also.
-Further security aspects are considered here related to:<a href="#section-11-1" class="pilcrow">¶</a></p>
+<p id="section-10-1">In general, the security considerations of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> apply for BRSKI-PRM also.
+Further security aspects are considered here related to:<a href="#section-10-1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-11-2.1">
-          <p id="section-11-2.1.1">the introduction of the additional component Registrar-Agent<a href="#section-11-2.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-10-2.1">
+          <p id="section-10-2.1.1">the introduction of the additional component Registrar-Agent<a href="#section-10-2.1.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="normal" id="section-11-2.2">
-          <p id="section-11-2.2.1">the reversal of the pledge communication direction (push mode, compared to BRSKI)<a href="#section-11-2.2.1" class="pilcrow">¶</a></p>
+        <li class="normal" id="section-10-2.2">
+          <p id="section-10-2.2.1">the reversal of the pledge communication direction (push mode, compared to BRSKI)<a href="#section-10-2.2.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="normal" id="section-11-2.3">
-          <p id="section-11-2.3.1">no transport layer security between Registrar-Agent and pledge<a href="#section-11-2.3.1" class="pilcrow">¶</a></p>
+        <li class="normal" id="section-10-2.3">
+          <p id="section-10-2.3.1">no transport layer security between Registrar-Agent and pledge<a href="#section-10-2.3.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <div id="sec_cons-dos">
-<section id="section-11.1">
+<section id="section-10.1">
         <h3 id="name-denial-of-service-dos-attac">
-<a href="#section-11.1" class="section-number selfRef">11.1. </a><a href="#name-denial-of-service-dos-attac" class="section-name selfRef">Denial of Service (DoS) Attack on Pledge</a>
+<a href="#section-10.1" class="section-number selfRef">10.1. </a><a href="#name-denial-of-service-dos-attac" class="section-name selfRef">Denial of Service (DoS) Attack on Pledge</a>
         </h3>
-<p id="section-11.1-1">Disrupting the pledge behavior by a DoS attack may prevent the bootstrapping of the pledge to a new domain.
-Because in BRSKI-PRM, the pledge responds to requests from real or illicit Registrar-Agents, pledges are more subject to DoS attacks from Registrar-Agents in BRSKI-PRM than they are from illicit registrars in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, where pledges do initiate the connections.<a href="#section-11.1-1" class="pilcrow">¶</a></p>
-<p id="section-11.1-2">A DoS attack with a faked Registrar-Agent may block the bootstrapping of the pledge due changing state on the pledge (the pledge may produce a voucher-request, and refuse to produce another one).
+<p id="section-10.1-1">Disrupting the pledge behavior by a DoS attack may prevent the bootstrapping of the pledge to a new domain.
+Because in BRSKI-PRM, the pledge responds to requests from real or illicit Registrar-Agents, pledges are more subject to DoS attacks from Registrar-Agents in BRSKI-PRM than they are from illicit registrars in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, where pledges do initiate the connections.<a href="#section-10.1-1" class="pilcrow">¶</a></p>
+<p id="section-10.1-2">A DoS attack with a faked Registrar-Agent may block the bootstrapping of the pledge due changing state on the pledge (the pledge may produce a voucher-request, and refuse to produce another one).
 One mitigation may be that the pledge does not limited the number of voucher-requests it creates until at least one has finished.
-An alternative may be that the onboarding state may expire after a certain time, if no further interaction has happened.<a href="#section-11.1-2" class="pilcrow">¶</a></p>
-<p id="section-11.1-3">In addition, the pledge may assume that repeated triggering for PVR are the result of a communication error with the Registrar-Agent.
+An alternative may be that the onboarding state may expire after a certain time, if no further interaction has happened.<a href="#section-10.1-2" class="pilcrow">¶</a></p>
+<p id="section-10.1-3">In addition, the pledge may assume that repeated triggering for PVR are the result of a communication error with the Registrar-Agent.
 In that case the pledge <span class="bcp14">MAY</span> simply resent the PVR previously sent.
-Note that in case of resending, a contained nonce and also the contained agent-signed-data in the PVR would consequently be reused.<a href="#section-11.1-3" class="pilcrow">¶</a></p>
+Note that in case of resending, a contained nonce and also the contained agent-signed-data in the PVR would consequently be reused.<a href="#section-10.1-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="misuse-of-acquired-pvr-and-per-by-registrar-agent">
-<section id="section-11.2">
+<section id="section-10.2">
         <h3 id="name-misuse-of-acquired-pvr-and-">
-<a href="#section-11.2" class="section-number selfRef">11.2. </a><a href="#name-misuse-of-acquired-pvr-and-" class="section-name selfRef">Misuse of acquired PVR and PER by Registrar-Agent</a>
+<a href="#section-10.2" class="section-number selfRef">10.2. </a><a href="#name-misuse-of-acquired-pvr-and-" class="section-name selfRef">Misuse of acquired PVR and PER by Registrar-Agent</a>
         </h3>
-<p id="section-11.2-1">A Registrar-Agent that uses previously requested PVR and PER for domain-A, may attempt to onboard the device into domain-B.  This can be detected by the domain registrar while PVR processing.
+<p id="section-10.2-1">A Registrar-Agent that uses previously requested PVR and PER for domain-A, may attempt to onboard the device into domain-B.  This can be detected by the domain registrar while PVR processing.
 The domain registrar needs to verify that the "proximity-registrar-cert" field in the PVR matches its own registrar LDevID certificate.
 In addition, the domain registrar needs to verify the association of the pledge to its domain based on the product-serial-number contained in the PVR and in the IDevID certificate of the pledge. (This is just part of the supply chain integration).
-Moreover, the domain registrar verifies if the Registrar-Agent is authorized to interact with the pledge for voucher-requests and enroll-requests, based on the EE (RegAgt) certificate data contained in the PVR.<a href="#section-11.2-1" class="pilcrow">¶</a></p>
-<p id="section-11.2-2">Misbinding of a pledge by a faked domain registrar is countered as described in BRSKI security considerations <span><a href="https://rfc-editor.org/rfc/rfc8995#section-11.4" class="relref">Section 11.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-11.2-2" class="pilcrow">¶</a></p>
+Moreover, the domain registrar verifies if the Registrar-Agent is authorized to interact with the pledge for voucher-requests and enroll-requests, based on the EE (RegAgt) certificate data contained in the PVR.<a href="#section-10.2-1" class="pilcrow">¶</a></p>
+<p id="section-10.2-2">Misbinding of a pledge by a faked domain registrar is countered as described in BRSKI security considerations <span><a href="https://rfc-editor.org/rfc/rfc8995#section-11.4" class="relref">Section 11.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-10.2-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="sec_cons_reg-agt">
-<section id="section-11.3">
+<section id="section-10.3">
         <h3 id="name-misuse-of-registrar-agent-c">
-<a href="#section-11.3" class="section-number selfRef">11.3. </a><a href="#name-misuse-of-registrar-agent-c" class="section-name selfRef">Misuse of Registrar-Agent Credentials</a>
+<a href="#section-10.3" class="section-number selfRef">10.3. </a><a href="#name-misuse-of-registrar-agent-c" class="section-name selfRef">Misuse of Registrar-Agent Credentials</a>
         </h3>
-<p id="section-11.3-1">Concerns of misusage of a Registrar-Agent with a valid EE (RegAgt) certificate may be addressed by utilizing short-lived certificates (e.g., valid for a day) to authenticate the Registrar-Agent against the domain registrar.
+<p id="section-10.3-1">Concerns of misusage of a Registrar-Agent with a valid EE (RegAgt) certificate may be addressed by utilizing short-lived certificates (e.g., valid for a day) to authenticate the Registrar-Agent against the domain registrar.
 The EE (RegAgt) certificate may have been acquired by a prior BRSKI run for the Registrar-Agent, if an IDevID is available on Registrar-Agent.
-Alternatively, the EE (RegAgt) certificate may be acquired by a service technician from the domain PKI system in an authenticated way.<a href="#section-11.3-1" class="pilcrow">¶</a></p>
-<p id="section-11.3-2">In addition it is required that the EE (RegAgt) certificate is valid for the complete bootstrapping phase.
+Alternatively, the EE (RegAgt) certificate may be acquired by a service technician from the domain PKI system in an authenticated way.<a href="#section-10.3-1" class="pilcrow">¶</a></p>
+<p id="section-10.3-2">In addition it is required that the EE (RegAgt) certificate is valid for the complete bootstrapping phase.
 This avoids that a Registrar-Agent could be misused to create arbitrary "agent-signed-data" objects to perform an authorized bootstrapping of a rogue pledge at a later point in time.
 In this misuse "agent-signed-data" could be dated after the validity time of the EE (RegAgt) certificate, due to missing trusted timestamp in the Registrar-Agents signature.
 To address this, the registrar <span class="bcp14">SHOULD</span> verify the certificate used to create the signature on "agent-signed-data".
-Furthermore the registrar also verifies the EE (RegAgt) certificate used in the TLS handshake with the Registrar-Agent. If both certificates are verified successfully, the Registrar-Agent's signature can be considered as valid.<a href="#section-11.3-2" class="pilcrow">¶</a></p>
+Furthermore the registrar also verifies the EE (RegAgt) certificate used in the TLS handshake with the Registrar-Agent. If both certificates are verified successfully, the Registrar-Agent's signature can be considered as valid.<a href="#section-10.3-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="sec_cons_mDNS">
-<section id="section-11.4">
+<section id="section-10.4">
         <h3 id="name-misuse-of-dns-sd-with-mdns-">
-<a href="#section-11.4" class="section-number selfRef">11.4. </a><a href="#name-misuse-of-dns-sd-with-mdns-" class="section-name selfRef">Misuse of DNS-SD with mDNS to obtain list of pledges</a>
+<a href="#section-10.4" class="section-number selfRef">10.4. </a><a href="#name-misuse-of-dns-sd-with-mdns-" class="section-name selfRef">Misuse of DNS-SD with mDNS to obtain list of pledges</a>
         </h3>
-<p id="section-11.4-1">To discover a specific pledge a Registrar-Agent may request the service name in combination with the product-serial-number of a specific pledge.
-The pledge reacts on this if its product-serial-number is part of the request message.<a href="#section-11.4-1" class="pilcrow">¶</a></p>
-<p id="section-11.4-2">If the Registrar-Agent performs DNS-based Service Discovery without a specific product-serial-number, all  pledges in the domain react if the functionality is supported.
+<p id="section-10.4-1">To discover a specific pledge a Registrar-Agent may request the service name in combination with the product-serial-number of a specific pledge.
+The pledge reacts on this if its product-serial-number is part of the request message.<a href="#section-10.4-1" class="pilcrow">¶</a></p>
+<p id="section-10.4-2">If the Registrar-Agent performs DNS-based Service Discovery without a specific product-serial-number, all  pledges in the domain react if the functionality is supported.
 This functionality enumerates and reveals the information of devices available in the domain.
 The information about this is provided here as a feature to support the commissioning of devices.
-A manufacturer may decide to support this feature only for devices not possessing a LDevID or to not support this feature at all, to avoid an enumeration in an operative domain.<a href="#section-11.4-2" class="pilcrow">¶</a></p>
+A manufacturer may decide to support this feature only for devices not possessing a LDevID or to not support this feature at all, to avoid an enumeration in an operative domain.<a href="#section-10.4-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="yang-module-security-considerations">
-<section id="section-11.5">
+<section id="section-10.5">
         <h3 id="name-yang-module-security-consid">
-<a href="#section-11.5" class="section-number selfRef">11.5. </a><a href="#name-yang-module-security-consid" class="section-name selfRef">YANG Module Security Considerations</a>
+<a href="#section-10.5" class="section-number selfRef">10.5. </a><a href="#name-yang-module-security-consid" class="section-name selfRef">YANG Module Security Considerations</a>
         </h3>
-<p id="section-11.5-1">The enhanced voucher-request described in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> is based on <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, but uses a different encoding based on <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
-The security considerations as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-11.7" class="relref">Section 11.7</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> (Security Considerations) apply.<a href="#section-11.5-1" class="pilcrow">¶</a></p>
-<p id="section-11.5-2">The YANG module specified in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> defines the schema for data that is subsequently encapsulated by a JOSE signed-data Content-type as described in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
-As such, all of the YANG-modeled data is protected against modification.<a href="#section-11.5-2" class="pilcrow">¶</a></p>
-<p id="section-11.5-3">The use of YANG to define data structures via the <span>[<a href="#RFC8971" class="cite xref">RFC8971</a>]</span> "structure" statement, is relatively
+<p id="section-10.5-1">The enhanced voucher-request described in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> is based on <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, but uses a different encoding based on <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
+The security considerations as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-11.7" class="relref">Section 11.7</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> (Security Considerations) apply.<a href="#section-10.5-1" class="pilcrow">¶</a></p>
+<p id="section-10.5-2">The YANG module specified in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> defines the schema for data that is subsequently encapsulated by a JOSE signed-data Content-type as described in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
+As such, all of the YANG-modeled data is protected against modification.<a href="#section-10.5-2" class="pilcrow">¶</a></p>
+<p id="section-10.5-3">The use of YANG to define data structures via the <span>[<a href="#RFC8971" class="cite xref">RFC8971</a>]</span> "structure" statement, is relatively
 new and distinct from the traditional use of YANG to define an API accessed by network management protocols such as NETCONF <span>[<a href="#RFC6241" class="cite xref">RFC6241</a>]</span> and RESTCONF <span>[<a href="#RFC8040" class="cite xref">RFC8040</a>]</span>.
-For this reason, these guidelines do not follow the template described by <span><a href="https://rfc-editor.org/rfc/rfc8407#section-3.7" class="relref">Section 3.7</a> of [<a href="#RFC8407" class="cite xref">RFC8407</a>]</span> (Security Considerations).<a href="#section-11.5-3" class="pilcrow">¶</a></p>
+For this reason, these guidelines do not follow the template described by <span><a href="https://rfc-editor.org/rfc/rfc8407#section-3.7" class="relref">Section 3.7</a> of [<a href="#RFC8407" class="cite xref">RFC8407</a>]</span> (Security Considerations).<a href="#section-10.5-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="acknowledgments">
-<section id="section-12">
+<section id="section-11">
       <h2 id="name-acknowledgments">
-<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
       </h2>
-<p id="section-12-1">We would like to thank the various reviewers, in particular Brian E. Carpenter, Charlie Kaufman (Early SECDIR review), Martin Björklund (Early YANGDOCTORS review), Marco Tiloca (Early IOTDIR review), Oskar Camenzind, Hendrik Brockhaus, and Ingo Wenda for their input and discussion on use cases and call flows.
+<p id="section-11-1">We would like to thank the various reviewers, in particular Brian E. Carpenter, Charlie Kaufman (Early SECDIR review), Martin Björklund (Early YANGDOCTORS review), Marco Tiloca (Early IOTDIR review), Oskar Camenzind, Hendrik Brockhaus, and Ingo Wenda for their input and discussion on use cases and call flows.
 Further review input was provided by Jesser Bouzid, Dominik Tacke, and Christian Spindler.
 Special thanks to Esko Dijk for the in deep review and the improving proposals.
-Support in PoC implementations and comments resulting from the implementation was provided by Hong Rui Li and He Peng Jia.<a href="#section-12-1" class="pilcrow">¶</a></p>
+Support in PoC implementations and comments resulting from the implementation was provided by Hong Rui Li and He Peng Jia.<a href="#section-11-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<section id="section-13">
+<section id="section-12">
       <h2 id="name-references">
-<a href="#section-13" class="section-number selfRef">13. </a><a href="#name-references" class="section-name selfRef">References</a>
+<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-references" class="section-name selfRef">References</a>
       </h2>
 <div id="sec-normative-references">
-<section id="section-13.1">
+<section id="section-12.1">
         <h3 id="name-normative-references">
-<a href="#section-13.1" class="section-number selfRef">13.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+<a href="#section-12.1" class="section-number selfRef">12.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
         </h3>
 <dl class="references">
 <dt id="I-D.ietf-anima-jws-voucher">[I-D.ietf-anima-jws-voucher]</dt>
@@ -5001,9 +4965,9 @@ Support in PoC implementations and comments resulting from the implementation wa
 </section>
 </div>
 <div id="sec-informative-references">
-<section id="section-13.2">
+<section id="section-12.2">
         <h3 id="name-informative-references">
-<a href="#section-13.2" class="section-number selfRef">13.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+<a href="#section-12.2" class="section-number selfRef">12.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
         </h3>
 <dl class="references">
 <dt id="androidnsd">[androidnsd]</dt>
@@ -5032,7 +4996,7 @@ Support in PoC implementations and comments resulting from the implementation wa
 <dd class="break"></dd>
 <dt id="I-D.richardson-anima-registrar-considerations">[I-D.richardson-anima-registrar-considerations]</dt>
         <dd>
-<span class="refAuthor">Richardson, M.</span> and <span class="refAuthor">W. Pan</span>, <span class="refTitle">"Operational Considerations for BRSKI Registrar"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-richardson-anima-registrar-considerations-07</span>, <time datetime="2023-05-11" class="refDate">11 May 2023</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-richardson-anima-registrar-considerations-07">https://datatracker.ietf.org/doc/html/draft-richardson-anima-registrar-considerations-07</a>&gt;</span>. </dd>
+<span class="refAuthor">Richardson, M.</span> and <span class="refAuthor">W. Pan</span>, <span class="refTitle">"Operational Considerations for BRSKI Registrar"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-richardson-anima-registrar-considerations-08</span>, <time datetime="2024-02-14" class="refDate">14 February 2024</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-richardson-anima-registrar-considerations-08">https://datatracker.ietf.org/doc/html/draft-richardson-anima-registrar-considerations-08</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="I-D.richardson-emu-eap-onboarding">[I-D.richardson-emu-eap-onboarding]</dt>
         <dd>
@@ -5093,6 +5057,10 @@ Support in PoC implementations and comments resulting from the implementation wa
 <dt id="RFC9238">[RFC9238]</dt>
         <dd>
 <span class="refAuthor">Richardson, M.</span>, <span class="refAuthor">Latour, J.</span>, and <span class="refAuthor">H. Habibi Gharakheili</span>, <span class="refTitle">"Loading Manufacturer Usage Description (MUD) URLs from QR Codes"</span>, <span class="seriesInfo">RFC 9238</span>, <span class="seriesInfo">DOI 10.17487/RFC9238</span>, <time datetime="2022-05" class="refDate">May 2022</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc9238">https://www.rfc-editor.org/rfc/rfc9238</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9483">[RFC9483]</dt>
+        <dd>
+<span class="refAuthor">Brockhaus, H.</span>, <span class="refAuthor">von Oheimb, D.</span>, and <span class="refAuthor">S. Fries</span>, <span class="refTitle">"Lightweight Certificate Management Protocol (CMP) Profile"</span>, <span class="seriesInfo">RFC 9483</span>, <span class="seriesInfo">DOI 10.17487/RFC9483</span>, <time datetime="2023-11" class="refDate">November 2023</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc9483">https://www.rfc-editor.org/rfc/rfc9483</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC9525">[RFC9525]</dt>
       <dd>
@@ -5621,7 +5589,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-5.3.1">issue #128: included notation of nomadic operation of the Registrar-Agent in <a href="#architecture" class="auto internal xref">Section 5</a>, including proposed text from PR #131<a href="#appendix-C-5.3.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-5.4">
-          <p id="appendix-C-5.4.1">issue #130, introduced DNS service discovery name for brski_pledge to enable discovery by the Registrar-Agent in <a href="#iana-con" class="auto internal xref">Section 9</a><a href="#appendix-C-5.4.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-5.4.1">issue #130, introduced DNS service discovery name for brski_pledge to enable discovery by the Registrar-Agent in <a href="#iana-con" class="auto internal xref">Section 8</a><a href="#appendix-C-5.4.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-5.5">
           <p id="appendix-C-5.5.1">removed unused reference RFC 5280<a href="#appendix-C-5.5.1" class="pilcrow">¶</a></p>
@@ -5657,7 +5625,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-7.4.1">issue #106, included additional text to elaborate more the registrar status handling in <a href="#vstatus" class="auto internal xref">Section 7.9</a> and <a href="#estatus" class="auto internal xref">Section 7.10</a><a href="#appendix-C-7.4.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.5">
-          <p id="appendix-C-7.5.1">issue #116, enhanced DoS description in <a href="#sec_cons-dos" class="auto internal xref">Section 11.1</a><a href="#appendix-C-7.5.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.5.1">issue #116, enhanced DoS description in <a href="#sec_cons-dos" class="auto internal xref">Section 10.1</a><a href="#appendix-C-7.5.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.6">
           <p id="appendix-C-7.6.1">issue #120, included statement regarding pledge host header processing in <a href="#pledge_ep" class="auto internal xref">Section 6.3</a><a href="#appendix-C-7.6.1" class="pilcrow">¶</a></p>
@@ -5744,7 +5712,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-9.18.1">issue #105: included negative example in <a href="#estat" class="auto internal xref">Figure 16</a><a href="#appendix-C-9.18.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.19">
-          <p id="appendix-C-9.19.1">issue #107: included example for certificate revocation in exchanges_uc2_4 TODO[N/A]<a href="#appendix-C-9.19.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.19.1">issue #107: included example for certificate revocation in <a href="#estatus" class="auto internal xref">Section 7.10</a><a href="#appendix-C-9.19.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.20">
           <p id="appendix-C-9.20.1">issue #108: renamed heading to Pledge-Status Request of <a href="#query" class="auto internal xref">Section 7.11</a><a href="#appendix-C-9.20.1" class="pilcrow">¶</a></p>
@@ -6025,8 +5993,7 @@ the description and references to UC1.<a href="#appendix-C-27.1.1" class="pilcro
 </li>
         <li class="normal" id="appendix-C-27.2">
           <p id="appendix-C-27.2.1">Addressed feedback for voucher-request enhancements from YANG doctor
-early review in <a href="#voucher-request-prm-yang" class="auto internal xref">Section 8.1</a> as well as in the
-security considerations (formerly named ietf-async-voucher-request).<a href="#appendix-C-27.2.1" class="pilcrow">¶</a></p>
+early review, meanwhile moved to <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> as well as in the security considerations (formerly named ietf-async-voucher-request).<a href="#appendix-C-27.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-27.3">
           <p id="appendix-C-27.3.1">Renamed ietf-async-voucher-request to IETF-voucher-request-prm to

--- a/draft-ietf-anima-brski-prm.html
+++ b/draft-ietf-anima-brski-prm.html
@@ -35,7 +35,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
     wcwidth 0.2.13
     weasyprint 61.0
 -->
-<link href="/usr/src/app/tmp/a20127f7-d256-46a5-807a-2baa813f45e9/20240229.xml" rel="alternate" type="application/rfc+xml">
+<link href="/usr/src/app/tmp/c1f2ff52-492b-44d0-927b-6409e843d1a7/brski-prm-12-mkovatsc-2.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1215,11 +1215,11 @@ li > p:last-of-type:only-child {
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">BRSKI-PRM</td>
-<td class="right">February 2024</td>
+<td class="right">March 2024</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Fries, et al.</td>
-<td class="center">Expires 1 September 2024</td>
+<td class="center">Expires 4 September 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1232,12 +1232,12 @@ li > p:last-of-type:only-child {
 <dd class="internet-draft">draft-ietf-anima-brski-prm-12</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-02-29" class="published">29 February 2024</time>
+<time datetime="2024-03-03" class="published">3 March 2024</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-09-01">1 September 2024</time></dd>
+<dd class="expires"><time datetime="2024-09-04">4 September 2024</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1297,7 +1297,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 1 September 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 4 September 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1432,19 +1432,19 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3">
-                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="auto internal xref">7.3</a>.  <a href="#name-supply-voucher-request-to-r" class="internal xref">Supply Voucher Request to Registrar (including backend interaction)</a></p>
+                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="auto internal xref">7.3</a>.  <a href="#name-supply-pvr-to-registrar-inc" class="internal xref">Supply PVR to Registrar (including backend interaction)</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.1">
-                    <p id="section-toc.1-1.7.2.3.2.1.1"><a href="#section-7.3.1" class="auto internal xref">7.3.1</a>.  <a href="#name-request-artifact-pvr" class="internal xref">Request Artifact: PVR</a></p>
+                    <p id="section-toc.1-1.7.2.3.2.1.1"><a href="#section-7.3.1" class="auto internal xref">7.3.1</a>.  <a href="#name-request-artifact-pledge-vouc" class="internal xref">Request Artifact: Pledge Voucher-Request (PVR)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.2">
-                    <p id="section-toc.1-1.7.2.3.2.2.1"><a href="#section-7.3.2" class="auto internal xref">7.3.2</a>.  <a href="#name-registrar-voucher-request-r" class="internal xref">Registrar Voucher-Request (RVR) Processing (Registrar to MASA)</a></p>
+                    <p id="section-toc.1-1.7.2.3.2.2.1"><a href="#section-7.3.2" class="auto internal xref">7.3.2</a>.  <a href="#name-supply-rvr-to-masa-backend-" class="internal xref">Supply RVR to MASA (backend interaction)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.3">
-                    <p id="section-toc.1-1.7.2.3.2.3.1"><a href="#section-7.3.3" class="auto internal xref">7.3.3</a>.  <a href="#name-voucher-issuance-by-masa" class="internal xref">Voucher Issuance by MASA</a></p>
+                    <p id="section-toc.1-1.7.2.3.2.3.1"><a href="#section-7.3.3" class="auto internal xref">7.3.3</a>.  <a href="#name-issue-voucher-by-masa-backe" class="internal xref">Issue Voucher by MASA (backend interaction)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.4">
-                    <p id="section-toc.1-1.7.2.3.2.4.1"><a href="#section-7.3.4" class="auto internal xref">7.3.4</a>.  <a href="#name-masa-issued-voucher-process" class="internal xref">MASA issued Voucher Processing by Registrar</a></p>
+                    <p id="section-toc.1-1.7.2.3.2.4.1"><a href="#section-7.3.4" class="auto internal xref">7.3.4</a>.  <a href="#name-supply-voucher-to-registrar" class="internal xref">Supply Voucher to Registrar (backend interaction)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.5">
                     <p id="section-toc.1-1.7.2.3.2.5.1"><a href="#section-7.3.5" class="auto internal xref">7.3.5</a>.  <a href="#name-response-artifact-voucher" class="internal xref">Response Artifact: Voucher</a></p>
@@ -1458,10 +1458,10 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                     <p id="section-toc.1-1.7.2.4.2.1.1"><a href="#section-7.4.1" class="auto internal xref">7.4.1</a>.  <a href="#name-request-artifact-pledge-enro" class="internal xref">Request Artifact: Pledge Enroll-Request (PER)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.4.2.2">
-                    <p id="section-toc.1-1.7.2.4.2.2.1"><a href="#section-7.4.2" class="auto internal xref">7.4.2</a>.  <a href="#name-enrollment-by-domain-ca" class="internal xref">Enrollment by Domain CA</a></p>
+                    <p id="section-toc.1-1.7.2.4.2.2.1"><a href="#section-7.4.2" class="auto internal xref">7.4.2</a>.  <a href="#name-enroll-pledge-by-domain-ca-" class="internal xref">Enroll Pledge by Domain CA (backend interaction)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.4.2.3">
-                    <p id="section-toc.1-1.7.2.4.2.3.1"><a href="#section-7.4.3" class="auto internal xref">7.4.3</a>.  <a href="#name-response-artifact-enroll-re" class="internal xref">Response Artifact: Enroll-Response</a></p>
+                    <p id="section-toc.1-1.7.2.4.2.3.1"><a href="#section-7.4.3" class="auto internal xref">7.4.3</a>.  <a href="#name-response-artifact-enroll-re" class="internal xref">Response Artifact: Enroll-Response (Enroll-Resp)</a></p>
 </li>
                 </ul>
 </li>
@@ -1469,10 +1469,10 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 <p id="section-toc.1-1.7.2.5.1"><a href="#section-7.5" class="auto internal xref">7.5</a>.  <a href="#name-request-ca-certificates" class="internal xref">Request CA Certificates</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.5.2.1">
-                    <p id="section-toc.1-1.7.2.5.2.1.1"><a href="#section-7.5.1" class="auto internal xref">7.5.1</a>.  <a href="#name-request-artifact-cacert-req" class="internal xref">Request Artifact: cACert-Req</a></p>
+                    <p id="section-toc.1-1.7.2.5.2.1.1"><a href="#section-7.5.1" class="auto internal xref">7.5.1</a>.  <a href="#name-request-artifact-cacert-req" class="internal xref">Request Artifact: cACert-Request (cACert-Req)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.5.2.2">
-                    <p id="section-toc.1-1.7.2.5.2.2.1"><a href="#section-7.5.2" class="auto internal xref">7.5.2</a>.  <a href="#name-response-artifact-cacert-re" class="internal xref">Response Artifact: cACert-Resp</a></p>
+                    <p id="section-toc.1-1.7.2.5.2.2.1"><a href="#section-7.5.2" class="auto internal xref">7.5.2</a>.  <a href="#name-response-artifact-cacert-re" class="internal xref">Response Artifact: cACert-Response (cACert-Resp)</a></p>
 </li>
                 </ul>
 </li>
@@ -1488,13 +1488,13 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.7">
-                <p id="section-toc.1-1.7.2.7.1"><a href="#section-7.7" class="auto internal xref">7.7</a>.  <a href="#name-supply-ca-certificates-to-p" class="internal xref">Supply CA certificates to Pledge</a></p>
+                <p id="section-toc.1-1.7.2.7.1"><a href="#section-7.7" class="auto internal xref">7.7</a>.  <a href="#name-supply-ca-certificates-to-p" class="internal xref">Supply CA Certificates to Pledge</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.7.2.1">
                     <p id="section-toc.1-1.7.2.7.2.1.1"><a href="#section-7.7.1" class="auto internal xref">7.7.1</a>.  <a href="#name-request-artifact" class="internal xref">Request Artifact:</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.7.2.2">
-                    <p id="section-toc.1-1.7.2.7.2.2.1"><a href="#section-7.7.2" class="auto internal xref">7.7.2</a>.  <a href="#name-response" class="internal xref">Response</a></p>
+                    <p id="section-toc.1-1.7.2.7.2.2.1"><a href="#section-7.7.2" class="auto internal xref">7.7.2</a>.  <a href="#name-response-no-artifact" class="internal xref">Response (no artifact)</a></p>
 </li>
                 </ul>
 </li>
@@ -1502,7 +1502,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 <p id="section-toc.1-1.7.2.8.1"><a href="#section-7.8" class="auto internal xref">7.8</a>.  <a href="#name-supply-enroll-response-to-p" class="internal xref">Supply Enroll-Response to Pledge</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.8.2.1">
-                    <p id="section-toc.1-1.7.2.8.2.1.1"><a href="#section-7.8.1" class="auto internal xref">7.8.1</a>.  <a href="#name-request-artifact-enroll-res" class="internal xref">Request Artifact: Enroll-Response</a></p>
+                    <p id="section-toc.1-1.7.2.8.2.1.1"><a href="#section-7.8.1" class="auto internal xref">7.8.1</a>.  <a href="#name-request-artifact-enroll-res" class="internal xref">Request Artifact: Enroll-Response (Enroll-Resp)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.8.2.2">
                     <p id="section-toc.1-1.7.2.8.2.2.1"><a href="#section-7.8.2" class="auto internal xref">7.8.2</a>.  <a href="#name-response-artifact-enroll-st" class="internal xref">Response Artifact: Enroll Status (eStatus)</a></p>
@@ -1510,13 +1510,13 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.9">
-                <p id="section-toc.1-1.7.2.9.1"><a href="#section-7.9" class="auto internal xref">7.9</a>.  <a href="#name-voucher-status-telemetry" class="internal xref">Voucher Status Telemetry</a></p>
+                <p id="section-toc.1-1.7.2.9.1"><a href="#section-7.9" class="auto internal xref">7.9</a>.  <a href="#name-voucher-status-telemetry-in" class="internal xref">Voucher Status Telemetry (including backend interaction)</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.9.2.1">
                     <p id="section-toc.1-1.7.2.9.2.1.1"><a href="#section-7.9.1" class="auto internal xref">7.9.1</a>.  <a href="#name-request-artifact-voucher-st" class="internal xref">Request Artifact: Voucher Status (vStatus)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.9.2.2">
-                    <p id="section-toc.1-1.7.2.9.2.2.1"><a href="#section-7.9.2" class="auto internal xref">7.9.2</a>.  <a href="#name-response-2" class="internal xref">Response</a></p>
+                    <p id="section-toc.1-1.7.2.9.2.2.1"><a href="#section-7.9.2" class="auto internal xref">7.9.2</a>.  <a href="#name-response-no-artifact-2" class="internal xref">Response (no artifact)</a></p>
 </li>
                 </ul>
 </li>
@@ -1527,7 +1527,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                     <p id="section-toc.1-1.7.2.10.2.1.1"><a href="#section-7.10.1" class="auto internal xref">7.10.1</a>.  <a href="#name-request-artifact-enroll-sta" class="internal xref">Request Artifact: Enroll Status (eStatus)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.10.2.2">
-                    <p id="section-toc.1-1.7.2.10.2.2.1"><a href="#section-7.10.2" class="auto internal xref">7.10.2</a>.  <a href="#name-response-3" class="internal xref">Response</a></p>
+                    <p id="section-toc.1-1.7.2.10.2.2.1"><a href="#section-7.10.2" class="auto internal xref">7.10.2</a>.  <a href="#name-response-no-artifact-3" class="internal xref">Response (no artifact)</a></p>
 </li>
                 </ul>
 </li>
@@ -1535,10 +1535,10 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 <p id="section-toc.1-1.7.2.11.1"><a href="#section-7.11" class="auto internal xref">7.11</a>. <a href="#name-query-pledge-status" class="internal xref">Query Pledge Status</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.11.2.1">
-                    <p id="section-toc.1-1.7.2.11.2.1.1"><a href="#section-7.11.1" class="auto internal xref">7.11.1</a>.  <a href="#name-request-artifact-pledge-sta" class="internal xref">Request Artifact: Pledge Status Request (pStatus-Req)</a></p>
+                    <p id="section-toc.1-1.7.2.11.2.1.1"><a href="#section-7.11.1" class="auto internal xref">7.11.1</a>.  <a href="#name-request-artifact-status-que" class="internal xref">Request Artifact: Status Query (qStatus)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.11.2.2">
-                    <p id="section-toc.1-1.7.2.11.2.2.1"><a href="#section-7.11.2" class="auto internal xref">7.11.2</a>.  <a href="#name-response-artifact-pledge-st" class="internal xref">Response Artifact: Pledge Status Response (pStatus-Resp)</a></p>
+                    <p id="section-toc.1-1.7.2.11.2.2.1"><a href="#section-7.11.2" class="auto internal xref">7.11.2</a>.  <a href="#name-response-artifact-pledge-st" class="internal xref">Response Artifact: Pledge Status (pStatus)</a></p>
 </li>
                 </ul>
 </li>
@@ -1765,7 +1765,7 @@ It may contain the PVR received from the pledge.<a href="#section-2-3.30.1" clas
 </dd>
       <dd class="break"></dd>
 </dl>
-<p id="section-2-4">This document uses the following encoding notations in the given JWS Voucher <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span> examples:<a href="#section-2-4" class="pilcrow">¶</a></p>
+<p id="section-2-4">This document uses the following encoding notations in the given JWS-signed artifact examples:<a href="#section-2-4" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlParallel" id="section-2-5">
         <dt id="section-2-5.1">BASE64URL(OCTETS):</dt>
         <dd style="margin-left: 1.5em" id="section-2-5.2">
@@ -1942,7 +1942,7 @@ To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:<a
 <span id="name-brski-prm-architecture-over"></span><div id="uc2figure">
 <figure id="figure-1">
           <div id="section-5.1-9.1">
-            <div class="alignLeft art-svg artwork" id="section-5.1-9.1.1">
+            <div class="alignCenter art-svg artwork" id="section-5.1-9.1.1">
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="464" width="456" viewBox="0 0 456 464" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,240 L 8,384" fill="none" stroke="black"></path>
                 <path d="M 80,240 L 80,384" fill="none" stroke="black"></path>
@@ -2140,7 +2140,7 @@ This is often the case in the aforementioned building automation use case (<a hr
 <span id="name-registrar-agent-nomadic-con"></span><div id="uc3figure">
 <figure id="figure-2">
           <div id="section-5.2-2.1">
-            <div class="alignLeft art-svg artwork" id="section-5.2-2.1.1">
+            <div class="alignCenter art-svg artwork" id="section-5.2-2.1.1">
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="496" width="456" viewBox="0 0 456 496" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 24,128 L 24,176" fill="none" stroke="black"></path>
                 <path d="M 96,128 L 96,176" fill="none" stroke="black"></path>
@@ -2297,7 +2297,7 @@ In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, pledges inst
 <span id="name-registrar-agent-integrated-"></span><div id="uc4figure">
 <figure id="figure-3">
           <div id="section-5.3-2.1">
-            <div class="alignLeft art-svg artwork" id="section-5.3-2.1.1">
+            <div class="alignCenter art-svg artwork" id="section-5.3-2.1.1">
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="352" width="472" viewBox="0 0 472 352" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,160 L 8,208" fill="none" stroke="black"></path>
                 <path d="M 80,160 L 80,208" fill="none" stroke="black"></path>
@@ -2440,14 +2440,14 @@ These endpoints accommodate for the signature-wrapped objects used by BRSKI-PRM 
           <tbody>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">requestenroll</td>
-              <td class="text-left" rowspan="1" colspan="1">Supply PER to registrar</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply PER to Registrar</td>
               <td class="text-left" rowspan="1" colspan="1">
                 <a href="#per" class="auto internal xref">Section 7.4</a>
 </td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">wrappedcacerts</td>
-              <td class="text-left" rowspan="1" colspan="1">Request CA certificates</td>
+              <td class="text-left" rowspan="1" colspan="1">Request CA Certificates</td>
               <td class="text-left" rowspan="1" colspan="1">
                 <a href="#req_cacerts" class="auto internal xref">Section 7.5</a>
 </td>
@@ -2590,21 +2590,21 @@ The endpoints are defined with short names to also accommodate for resource-cons
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">svr</td>
-              <td class="text-left" rowspan="1" colspan="1">Supply Voucher to pledge</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply Voucher to Pledge</td>
               <td class="text-left" rowspan="1" colspan="1">
                 <a href="#voucher" class="auto internal xref">Section 7.6</a>
 </td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">scac</td>
-              <td class="text-left" rowspan="1" colspan="1">Supply CA certificates to pledge</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply CA Certificates to Pledge</td>
               <td class="text-left" rowspan="1" colspan="1">
                 <a href="#cacerts" class="auto internal xref">Section 7.7</a>
 </td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">ser</td>
-              <td class="text-left" rowspan="1" colspan="1">Supply Enroll-Response to pledge</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply Enroll-Response to Pledge</td>
               <td class="text-left" rowspan="1" colspan="1">
                 <a href="#enroll_response" class="auto internal xref">Section 7.8</a>
 </td>
@@ -2650,504 +2650,534 @@ If it still acts as server, the defined BRSKI-PRM endpoints to trigger a Pledge 
 <p id="section-7-1">The interaction of the pledge with the Registrar-Agent may be accomplished using different transports (i.e., protocols and/or network technologies).
 This specification utilizes HTTP as default transport.
 Other specifications may define alternative transports such as CoAP, Bluetooth Low Energy (BLE), or Near Field Communication (NFC).
-These transports may differ from and are independent of the ones used between the Registrar-Agent and the registrar.
-Transport independence is realized through data objects that are not bound to specific transport security and stay the same along the communication path from the pledge via the Registrar-Agent to the registrar.
-Therefore, authenticated self-contained objects (e.g., signature-wrapped JWS objects) are applied for data exchanges between the pledge and the registrar.<a href="#section-7-1" class="pilcrow">¶</a></p>
-<p id="section-7-2">The Registrar-Agent provides the domain registrar EE certificate to the pledge to be included in the PVR leaf "agent-provided-proximity-registrar-certificate".
-This enables the registrar to verify that it is the desired registrar for handling the request.
-The registrar EE certificate may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar.<a href="#section-7-2" class="pilcrow">¶</a></p>
-<p id="section-7-3">In addition, the Registrar-Agent provides "agent-signed-data" containing the pledge product serial number signed with the private key corresponding to the EE certificate of the Registrar-Agent, as described in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.
-This enables the registrar to verify and log, which Registrar-Agent was in contact with the pledge, when verifying the PVR.<a href="#section-7-3" class="pilcrow">¶</a></p>
-<p id="section-7-4"><a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> provides an overview of the exchanges detailed in the following subsections.<a href="#section-7-4" class="pilcrow">¶</a></p>
+These transports may differ from and are independent of the ones used between the Registrar-Agent and the registrar.<a href="#section-7-1" class="pilcrow">¶</a></p>
+<p id="section-7-2">Transport independence is realized through data objects that are not bound to specific transport security and stay the same along the communication path from the pledge via the Registrar-Agent to the registrar.
+Therefore, authenticated self-contained artifacts (e.g., JWS-signed JSON structures or COSE-signed CBOR structures) are used for the data exchanges between the pledge and the registrar via the Registrar-Agent.<a href="#section-7-2" class="pilcrow">¶</a></p>
+<p id="section-7-3"><a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> provides an overview of the exchanges detailed in the following subsections.<a href="#section-7-3" class="pilcrow">¶</a></p>
 <span id="name-overview-pledge-responder-m"></span><div id="exchangesfig_uc2_all">
 <figure id="figure-4">
-        <div id="section-7-5.1">
-          <div class="alignLeft art-svg artwork" id="section-7-5.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="1792" width="560" viewBox="0 0 560 1792" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+        <div id="section-7-4.1">
+          <div class="alignCenter art-svg artwork" id="section-7-4.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="1872" width="576" viewBox="0 0 576 1872" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
               <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-              <path d="M 32,88 L 32,192" fill="none" stroke="black"></path>
-              <path d="M 32,256 L 32,320" fill="none" stroke="black"></path>
-              <path d="M 32,384 L 32,448" fill="none" stroke="black"></path>
-              <path d="M 32,512 L 32,736" fill="none" stroke="black"></path>
-              <path d="M 32,800 L 32,912" fill="none" stroke="black"></path>
-              <path d="M 32,976 L 32,1024" fill="none" stroke="black"></path>
-              <path d="M 32,1088 L 32,1152" fill="none" stroke="black"></path>
-              <path d="M 32,1216 L 32,1280" fill="none" stroke="black"></path>
-              <path d="M 32,1344 L 32,1392" fill="none" stroke="black"></path>
-              <path d="M 32,1456 L 32,1552" fill="none" stroke="black"></path>
-              <path d="M 32,1616 L 32,1648" fill="none" stroke="black"></path>
-              <path d="M 32,1712 L 32,1760" fill="none" stroke="black"></path>
+              <path d="M 16,88 L 16,192" fill="none" stroke="black"></path>
+              <path d="M 16,256 L 16,320" fill="none" stroke="black"></path>
+              <path d="M 16,384 L 16,448" fill="none" stroke="black"></path>
+              <path d="M 16,512 L 16,736" fill="none" stroke="black"></path>
+              <path d="M 16,800 L 16,912" fill="none" stroke="black"></path>
+              <path d="M 16,976 L 16,1040" fill="none" stroke="black"></path>
+              <path d="M 16,1104 L 16,1168" fill="none" stroke="black"></path>
+              <path d="M 16,1232 L 16,1296" fill="none" stroke="black"></path>
+              <path d="M 16,1360 L 16,1424" fill="none" stroke="black"></path>
+              <path d="M 16,1488 L 16,1600" fill="none" stroke="black"></path>
+              <path d="M 16,1664 L 16,1712" fill="none" stroke="black"></path>
+              <path d="M 16,1776 L 16,1840" fill="none" stroke="black"></path>
               <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-              <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+              <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
               <path d="M 168,88 L 168,192" fill="none" stroke="black"></path>
               <path d="M 168,256 L 168,320" fill="none" stroke="black"></path>
               <path d="M 168,384 L 168,448" fill="none" stroke="black"></path>
               <path d="M 168,512 L 168,736" fill="none" stroke="black"></path>
               <path d="M 168,800 L 168,912" fill="none" stroke="black"></path>
-              <path d="M 168,976 L 168,1024" fill="none" stroke="black"></path>
-              <path d="M 168,1088 L 168,1152" fill="none" stroke="black"></path>
-              <path d="M 168,1216 L 168,1280" fill="none" stroke="black"></path>
-              <path d="M 168,1344 L 168,1392" fill="none" stroke="black"></path>
-              <path d="M 168,1456 L 168,1552" fill="none" stroke="black"></path>
-              <path d="M 168,1616 L 168,1648" fill="none" stroke="black"></path>
-              <path d="M 168,1712 L 168,1760" fill="none" stroke="black"></path>
-              <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-              <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+              <path d="M 168,976 L 168,1040" fill="none" stroke="black"></path>
+              <path d="M 168,1104 L 168,1168" fill="none" stroke="black"></path>
+              <path d="M 168,1232 L 168,1296" fill="none" stroke="black"></path>
+              <path d="M 168,1360 L 168,1424" fill="none" stroke="black"></path>
+              <path d="M 168,1488 L 168,1600" fill="none" stroke="black"></path>
+              <path d="M 168,1664 L 168,1712" fill="none" stroke="black"></path>
+              <path d="M 168,1776 L 168,1840" fill="none" stroke="black"></path>
+              <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+              <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
               <path d="M 312,88 L 312,192" fill="none" stroke="black"></path>
               <path d="M 312,256 L 312,320" fill="none" stroke="black"></path>
               <path d="M 312,384 L 312,448" fill="none" stroke="black"></path>
               <path d="M 312,512 L 312,528" fill="none" stroke="black"></path>
               <path d="M 312,624 L 312,736" fill="none" stroke="black"></path>
               <path d="M 312,800 L 312,912" fill="none" stroke="black"></path>
-              <path d="M 312,976 L 312,1024" fill="none" stroke="black"></path>
-              <path d="M 312,1088 L 312,1152" fill="none" stroke="black"></path>
-              <path d="M 312,1216 L 312,1280" fill="none" stroke="black"></path>
-              <path d="M 312,1344 L 312,1392" fill="none" stroke="black"></path>
-              <path d="M 312,1456 L 312,1520" fill="none" stroke="black"></path>
-              <path d="M 312,1616 L 312,1648" fill="none" stroke="black"></path>
-              <path d="M 312,1712 L 312,1760" fill="none" stroke="black"></path>
-              <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-              <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-              <path d="M 432,88 L 432,192" fill="none" stroke="black"></path>
-              <path d="M 432,256 L 432,320" fill="none" stroke="black"></path>
-              <path d="M 432,384 L 432,448" fill="none" stroke="black"></path>
-              <path d="M 432,512 L 432,624" fill="none" stroke="black"></path>
-              <path d="M 432,720 L 432,736" fill="none" stroke="black"></path>
-              <path d="M 432,800 L 432,912" fill="none" stroke="black"></path>
-              <path d="M 432,976 L 432,1024" fill="none" stroke="black"></path>
-              <path d="M 432,1088 L 432,1152" fill="none" stroke="black"></path>
-              <path d="M 432,1216 L 432,1280" fill="none" stroke="black"></path>
-              <path d="M 432,1344 L 432,1392" fill="none" stroke="black"></path>
-              <path d="M 432,1456 L 432,1488" fill="none" stroke="black"></path>
-              <path d="M 432,1616 L 432,1648" fill="none" stroke="black"></path>
-              <path d="M 432,1712 L 432,1760" fill="none" stroke="black"></path>
-              <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+              <path d="M 312,976 L 312,1040" fill="none" stroke="black"></path>
+              <path d="M 312,1104 L 312,1168" fill="none" stroke="black"></path>
+              <path d="M 312,1232 L 312,1296" fill="none" stroke="black"></path>
+              <path d="M 312,1360 L 312,1424" fill="none" stroke="black"></path>
+              <path d="M 312,1488 L 312,1568" fill="none" stroke="black"></path>
+              <path d="M 312,1664 L 312,1712" fill="none" stroke="black"></path>
+              <path d="M 312,1776 L 312,1840" fill="none" stroke="black"></path>
+              <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+              <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+              <path d="M 456,88 L 456,192" fill="none" stroke="black"></path>
+              <path d="M 456,256 L 456,320" fill="none" stroke="black"></path>
+              <path d="M 456,384 L 456,448" fill="none" stroke="black"></path>
+              <path d="M 456,512 L 456,632" fill="none" stroke="black"></path>
+              <path d="M 456,720 L 456,736" fill="none" stroke="black"></path>
+              <path d="M 456,800 L 456,912" fill="none" stroke="black"></path>
+              <path d="M 456,976 L 456,1040" fill="none" stroke="black"></path>
+              <path d="M 456,1104 L 456,1168" fill="none" stroke="black"></path>
+              <path d="M 456,1232 L 456,1296" fill="none" stroke="black"></path>
+              <path d="M 456,1360 L 456,1424" fill="none" stroke="black"></path>
+              <path d="M 456,1488 L 456,1528" fill="none" stroke="black"></path>
+              <path d="M 456,1584 L 456,1600" fill="none" stroke="black"></path>
+              <path d="M 456,1664 L 456,1712" fill="none" stroke="black"></path>
+              <path d="M 456,1776 L 456,1840" fill="none" stroke="black"></path>
               <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-              <path d="M 536,88 L 536,192" fill="none" stroke="black"></path>
-              <path d="M 536,256 L 536,320" fill="none" stroke="black"></path>
-              <path d="M 536,384 L 536,448" fill="none" stroke="black"></path>
-              <path d="M 536,512 L 536,656" fill="none" stroke="black"></path>
-              <path d="M 536,704 L 536,736" fill="none" stroke="black"></path>
-              <path d="M 536,800 L 536,912" fill="none" stroke="black"></path>
-              <path d="M 536,976 L 536,1024" fill="none" stroke="black"></path>
-              <path d="M 536,1088 L 536,1152" fill="none" stroke="black"></path>
-              <path d="M 536,1216 L 536,1280" fill="none" stroke="black"></path>
-              <path d="M 536,1344 L 536,1392" fill="none" stroke="black"></path>
-              <path d="M 536,1456 L 536,1520" fill="none" stroke="black"></path>
-              <path d="M 536,1616 L 536,1648" fill="none" stroke="black"></path>
-              <path d="M 536,1712 L 536,1760" fill="none" stroke="black"></path>
-              <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+              <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+              <path d="M 560,88 L 560,192" fill="none" stroke="black"></path>
+              <path d="M 560,256 L 560,320" fill="none" stroke="black"></path>
+              <path d="M 560,384 L 560,448" fill="none" stroke="black"></path>
+              <path d="M 560,512 L 560,656" fill="none" stroke="black"></path>
+              <path d="M 560,704 L 560,736" fill="none" stroke="black"></path>
+              <path d="M 560,800 L 560,912" fill="none" stroke="black"></path>
+              <path d="M 560,976 L 560,1040" fill="none" stroke="black"></path>
+              <path d="M 560,1104 L 560,1168" fill="none" stroke="black"></path>
+              <path d="M 560,1232 L 560,1296" fill="none" stroke="black"></path>
+              <path d="M 560,1360 L 560,1424" fill="none" stroke="black"></path>
+              <path d="M 560,1488 L 560,1600" fill="none" stroke="black"></path>
+              <path d="M 560,1664 L 560,1712" fill="none" stroke="black"></path>
+              <path d="M 560,1776 L 560,1840" fill="none" stroke="black"></path>
+              <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
               <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-              <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-              <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-              <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-              <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+              <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+              <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+              <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+              <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
               <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-              <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-              <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-              <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-              <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-              <path d="M 40,160 L 160,160" fill="none" stroke="black"></path>
-              <path d="M 40,176 L 160,176" fill="none" stroke="black"></path>
-              <path d="M 40,272 L 56,272" fill="none" stroke="black"></path>
-              <path d="M 144,272 L 160,272" fill="none" stroke="black"></path>
-              <path d="M 40,288 L 72,288" fill="none" stroke="black"></path>
-              <path d="M 128,288 L 160,288" fill="none" stroke="black"></path>
-              <path d="M 40,304 L 72,304" fill="none" stroke="black"></path>
-              <path d="M 120,304 L 160,304" fill="none" stroke="black"></path>
-              <path d="M 40,400 L 56,400" fill="none" stroke="black"></path>
-              <path d="M 144,400 L 160,400" fill="none" stroke="black"></path>
-              <path d="M 40,416 L 72,416" fill="none" stroke="black"></path>
-              <path d="M 128,416 L 160,416" fill="none" stroke="black"></path>
-              <path d="M 40,432 L 72,432" fill="none" stroke="black"></path>
-              <path d="M 120,432 L 160,432" fill="none" stroke="black"></path>
-              <path d="M 176,528 L 208,528" fill="none" stroke="black"></path>
-              <path d="M 264,528 L 304,528" fill="none" stroke="black"></path>
-              <path d="M 176,576 L 208,576" fill="none" stroke="black"></path>
+              <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+              <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+              <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+              <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+              <path d="M 24,160 L 160,160" fill="none" stroke="black"></path>
+              <path d="M 24,176 L 160,176" fill="none" stroke="black"></path>
+              <path d="M 24,272 L 56,272" fill="none" stroke="black"></path>
+              <path d="M 128,272 L 160,272" fill="none" stroke="black"></path>
+              <path d="M 24,288 L 72,288" fill="none" stroke="black"></path>
+              <path d="M 112,288 L 160,288" fill="none" stroke="black"></path>
+              <path d="M 24,304 L 80,304" fill="none" stroke="black"></path>
+              <path d="M 112,304 L 160,304" fill="none" stroke="black"></path>
+              <path d="M 24,400 L 56,400" fill="none" stroke="black"></path>
+              <path d="M 128,400 L 160,400" fill="none" stroke="black"></path>
+              <path d="M 24,416 L 72,416" fill="none" stroke="black"></path>
+              <path d="M 112,416 L 160,416" fill="none" stroke="black"></path>
+              <path d="M 24,432 L 80,432" fill="none" stroke="black"></path>
+              <path d="M 112,432 L 160,432" fill="none" stroke="black"></path>
+              <path d="M 176,528 L 216,528" fill="none" stroke="black"></path>
+              <path d="M 256,528 L 304,528" fill="none" stroke="black"></path>
+              <path d="M 176,576 L 224,576" fill="none" stroke="black"></path>
               <path d="M 256,576 L 304,576" fill="none" stroke="black"></path>
-              <path d="M 320,640 L 400,640" fill="none" stroke="black"></path>
-              <path d="M 456,640 L 528,640" fill="none" stroke="black"></path>
-              <path d="M 320,656 L 408,656" fill="none" stroke="black"></path>
-              <path d="M 456,656 L 528,656" fill="none" stroke="black"></path>
-              <path d="M 320,704 L 392,704" fill="none" stroke="black"></path>
-              <path d="M 472,704 L 528,704" fill="none" stroke="black"></path>
-              <path d="M 176,720 L 200,720" fill="none" stroke="black"></path>
-              <path d="M 280,720 L 304,720" fill="none" stroke="black"></path>
-              <path d="M 176,816 L 208,816" fill="none" stroke="black"></path>
-              <path d="M 264,816 L 304,816" fill="none" stroke="black"></path>
-              <path d="M 176,832 L 208,832" fill="none" stroke="black"></path>
+              <path d="M 320,640 L 416,640" fill="none" stroke="black"></path>
+              <path d="M 456,640 L 552,640" fill="none" stroke="black"></path>
+              <path d="M 320,656 L 424,656" fill="none" stroke="black"></path>
+              <path d="M 456,656 L 552,656" fill="none" stroke="black"></path>
+              <path d="M 320,704 L 408,704" fill="none" stroke="black"></path>
+              <path d="M 472,704 L 552,704" fill="none" stroke="black"></path>
+              <path d="M 176,720 L 208,720" fill="none" stroke="black"></path>
+              <path d="M 272,720 L 304,720" fill="none" stroke="black"></path>
+              <path d="M 176,816 L 216,816" fill="none" stroke="black"></path>
+              <path d="M 256,816 L 304,816" fill="none" stroke="black"></path>
+              <path d="M 176,832 L 224,832" fill="none" stroke="black"></path>
               <path d="M 256,832 L 304,832" fill="none" stroke="black"></path>
-              <path d="M 320,848 L 344,848" fill="none" stroke="black"></path>
-              <path d="M 400,848 L 424,848" fill="none" stroke="black"></path>
-              <path d="M 320,864 L 344,864" fill="none" stroke="black"></path>
-              <path d="M 392,864 L 424,864" fill="none" stroke="black"></path>
+              <path d="M 320,848 L 360,848" fill="none" stroke="black"></path>
+              <path d="M 400,848 L 448,848" fill="none" stroke="black"></path>
+              <path d="M 320,864 L 368,864" fill="none" stroke="black"></path>
+              <path d="M 400,864 L 448,864" fill="none" stroke="black"></path>
+              <path d="M 320,880 L 336,880" fill="none" stroke="black"></path>
+              <path d="M 432,880 L 448,880" fill="none" stroke="black"></path>
               <path d="M 176,896 L 192,896" fill="none" stroke="black"></path>
               <path d="M 288,896 L 304,896" fill="none" stroke="black"></path>
-              <path d="M 288,992 L 304,992" fill="none" stroke="black"></path>
+              <path d="M 176,992 L 216,992" fill="none" stroke="black"></path>
+              <path d="M 256,992 L 304,992" fill="none" stroke="black"></path>
               <path d="M 176,1008 L 192,1008" fill="none" stroke="black"></path>
-              <path d="M 40,1104 L 56,1104" fill="none" stroke="black"></path>
-              <path d="M 136,1104 L 160,1104" fill="none" stroke="black"></path>
-              <path d="M 40,1120 L 64,1120" fill="none" stroke="black"></path>
-              <path d="M 144,1120 L 160,1120" fill="none" stroke="black"></path>
-              <path d="M 40,1136 L 64,1136" fill="none" stroke="black"></path>
-              <path d="M 144,1136 L 160,1136" fill="none" stroke="black"></path>
-              <path d="M 40,1232 L 56,1232" fill="none" stroke="black"></path>
-              <path d="M 136,1232 L 160,1232" fill="none" stroke="black"></path>
-              <path d="M 40,1248 L 64,1248" fill="none" stroke="black"></path>
-              <path d="M 144,1248 L 160,1248" fill="none" stroke="black"></path>
-              <path d="M 40,1264 L 56,1264" fill="none" stroke="black"></path>
-              <path d="M 136,1264 L 160,1264" fill="none" stroke="black"></path>
-              <path d="M 40,1360 L 56,1360" fill="none" stroke="black"></path>
-              <path d="M 40,1376 L 56,1376" fill="none" stroke="black"></path>
-              <path d="M 136,1376 L 160,1376" fill="none" stroke="black"></path>
-              <path d="M 176,1472 L 208,1472" fill="none" stroke="black"></path>
-              <path d="M 264,1472 L 304,1472" fill="none" stroke="black"></path>
-              <path d="M 176,1488 L 200,1488" fill="none" stroke="black"></path>
-              <path d="M 280,1488 L 304,1488" fill="none" stroke="black"></path>
-              <path d="M 320,1504 L 336,1504" fill="none" stroke="black"></path>
-              <path d="M 512,1504 L 528,1504" fill="none" stroke="black"></path>
-              <path d="M 320,1520 L 352,1520" fill="none" stroke="black"></path>
-              <path d="M 504,1520 L 528,1520" fill="none" stroke="black"></path>
-              <path d="M 176,1632 L 200,1632" fill="none" stroke="black"></path>
-              <path d="M 280,1632 L 304,1632" fill="none" stroke="black"></path>
-              <path d="M 40,1728 L 56,1728" fill="none" stroke="black"></path>
-              <polygon class="arrowhead" points="536,1504 524,1498.4 524,1509.6" fill="black" transform="rotate(0,528,1504)"></polygon>
-              <polygon class="arrowhead" points="536,656 524,650.4 524,661.6" fill="black" transform="rotate(0,528,656)"></polygon>
-              <polygon class="arrowhead" points="536,640 524,634.4 524,645.6" fill="black" transform="rotate(0,528,640)"></polygon>
-              <polygon class="arrowhead" points="432,864 420,858.4 420,869.6" fill="black" transform="rotate(0,424,864)"></polygon>
-              <polygon class="arrowhead" points="432,848 420,842.4 420,853.6" fill="black" transform="rotate(0,424,848)"></polygon>
-              <polygon class="arrowhead" points="328,1520 316,1514.4 316,1525.6" fill="black" transform="rotate(180,320,1520)"></polygon>
+              <path d="M 280,1008 L 304,1008" fill="none" stroke="black"></path>
+              <path d="M 176,1024 L 192,1024" fill="none" stroke="black"></path>
+              <path d="M 288,1024 L 304,1024" fill="none" stroke="black"></path>
+              <path d="M 24,1120 L 56,1120" fill="none" stroke="black"></path>
+              <path d="M 128,1120 L 160,1120" fill="none" stroke="black"></path>
+              <path d="M 24,1136 L 64,1136" fill="none" stroke="black"></path>
+              <path d="M 128,1136 L 160,1136" fill="none" stroke="black"></path>
+              <path d="M 24,1152 L 64,1152" fill="none" stroke="black"></path>
+              <path d="M 128,1152 L 160,1152" fill="none" stroke="black"></path>
+              <path d="M 24,1248 L 56,1248" fill="none" stroke="black"></path>
+              <path d="M 128,1248 L 160,1248" fill="none" stroke="black"></path>
+              <path d="M 24,1264 L 64,1264" fill="none" stroke="black"></path>
+              <path d="M 128,1264 L 160,1264" fill="none" stroke="black"></path>
+              <path d="M 24,1280 L 64,1280" fill="none" stroke="black"></path>
+              <path d="M 128,1280 L 160,1280" fill="none" stroke="black"></path>
+              <path d="M 24,1376 L 56,1376" fill="none" stroke="black"></path>
+              <path d="M 128,1376 L 160,1376" fill="none" stroke="black"></path>
+              <path d="M 24,1392 L 48,1392" fill="none" stroke="black"></path>
+              <path d="M 144,1392 L 160,1392" fill="none" stroke="black"></path>
+              <path d="M 24,1408 L 56,1408" fill="none" stroke="black"></path>
+              <path d="M 120,1408 L 160,1408" fill="none" stroke="black"></path>
+              <path d="M 176,1504 L 216,1504" fill="none" stroke="black"></path>
+              <path d="M 256,1504 L 304,1504" fill="none" stroke="black"></path>
+              <path d="M 176,1520 L 208,1520" fill="none" stroke="black"></path>
+              <path d="M 272,1520 L 304,1520" fill="none" stroke="black"></path>
+              <path d="M 320,1536 L 416,1536" fill="none" stroke="black"></path>
+              <path d="M 456,1536 L 552,1536" fill="none" stroke="black"></path>
+              <path d="M 320,1552 L 352,1552" fill="none" stroke="black"></path>
+              <path d="M 520,1552 L 552,1552" fill="none" stroke="black"></path>
+              <path d="M 320,1568 L 368,1568" fill="none" stroke="black"></path>
+              <path d="M 504,1568 L 552,1568" fill="none" stroke="black"></path>
+              <path d="M 176,1680 L 216,1680" fill="none" stroke="black"></path>
+              <path d="M 256,1680 L 304,1680" fill="none" stroke="black"></path>
+              <path d="M 176,1696 L 208,1696" fill="none" stroke="black"></path>
+              <path d="M 272,1696 L 304,1696" fill="none" stroke="black"></path>
+              <path d="M 24,1792 L 56,1792" fill="none" stroke="black"></path>
+              <path d="M 128,1792 L 160,1792" fill="none" stroke="black"></path>
+              <path d="M 24,1808 L 64,1808" fill="none" stroke="black"></path>
+              <path d="M 128,1808 L 160,1808" fill="none" stroke="black"></path>
+              <path d="M 24,1824 L 64,1824" fill="none" stroke="black"></path>
+              <path d="M 128,1824 L 160,1824" fill="none" stroke="black"></path>
+              <polygon class="arrowhead" points="560,1552 548,1546.4 548,1557.6" fill="black" transform="rotate(0,552,1552)"></polygon>
+              <polygon class="arrowhead" points="560,1536 548,1530.4 548,1541.6" fill="black" transform="rotate(0,552,1536)"></polygon>
+              <polygon class="arrowhead" points="560,656 548,650.4 548,661.6" fill="black" transform="rotate(0,552,656)"></polygon>
+              <polygon class="arrowhead" points="560,640 548,634.4 548,645.6" fill="black" transform="rotate(0,552,640)"></polygon>
+              <polygon class="arrowhead" points="456,864 444,858.4 444,869.6" fill="black" transform="rotate(0,448,864)"></polygon>
+              <polygon class="arrowhead" points="456,848 444,842.4 444,853.6" fill="black" transform="rotate(0,448,848)"></polygon>
+              <polygon class="arrowhead" points="328,1568 316,1562.4 316,1573.6" fill="black" transform="rotate(180,320,1568)"></polygon>
+              <polygon class="arrowhead" points="328,1536 316,1530.4 316,1541.6" fill="black" transform="rotate(180,320,1536)"></polygon>
+              <polygon class="arrowhead" points="328,880 316,874.4 316,885.6" fill="black" transform="rotate(180,320,880)"></polygon>
               <polygon class="arrowhead" points="328,848 316,842.4 316,853.6" fill="black" transform="rotate(180,320,848)"></polygon>
               <polygon class="arrowhead" points="328,704 316,698.4 316,709.6" fill="black" transform="rotate(180,320,704)"></polygon>
               <polygon class="arrowhead" points="328,640 316,634.4 316,645.6" fill="black" transform="rotate(180,320,640)"></polygon>
-              <polygon class="arrowhead" points="312,1632 300,1626.4 300,1637.6" fill="black" transform="rotate(0,304,1632)"></polygon>
-              <polygon class="arrowhead" points="312,1488 300,1482.4 300,1493.6" fill="black" transform="rotate(0,304,1488)"></polygon>
-              <polygon class="arrowhead" points="312,1472 300,1466.4 300,1477.6" fill="black" transform="rotate(0,304,1472)"></polygon>
+              <polygon class="arrowhead" points="312,1696 300,1690.4 300,1701.6" fill="black" transform="rotate(0,304,1696)"></polygon>
+              <polygon class="arrowhead" points="312,1680 300,1674.4 300,1685.6" fill="black" transform="rotate(0,304,1680)"></polygon>
+              <polygon class="arrowhead" points="312,1520 300,1514.4 300,1525.6" fill="black" transform="rotate(0,304,1520)"></polygon>
+              <polygon class="arrowhead" points="312,1504 300,1498.4 300,1509.6" fill="black" transform="rotate(0,304,1504)"></polygon>
+              <polygon class="arrowhead" points="312,1008 300,1002.4 300,1013.6" fill="black" transform="rotate(0,304,1008)"></polygon>
               <polygon class="arrowhead" points="312,992 300,986.4 300,997.6" fill="black" transform="rotate(0,304,992)"></polygon>
               <polygon class="arrowhead" points="312,832 300,826.4 300,837.6" fill="black" transform="rotate(0,304,832)"></polygon>
               <polygon class="arrowhead" points="312,816 300,810.4 300,821.6" fill="black" transform="rotate(0,304,816)"></polygon>
               <polygon class="arrowhead" points="312,576 300,570.4 300,581.6" fill="black" transform="rotate(0,304,576)"></polygon>
               <polygon class="arrowhead" points="312,528 300,522.4 300,533.6" fill="black" transform="rotate(0,304,528)"></polygon>
-              <polygon class="arrowhead" points="184,1472 172,1466.4 172,1477.6" fill="black" transform="rotate(180,176,1472)"></polygon>
-              <polygon class="arrowhead" points="184,1008 172,1002.4 172,1013.6" fill="black" transform="rotate(180,176,1008)"></polygon>
+              <polygon class="arrowhead" points="184,1680 172,1674.4 172,1685.6" fill="black" transform="rotate(180,176,1680)"></polygon>
+              <polygon class="arrowhead" points="184,1504 172,1498.4 172,1509.6" fill="black" transform="rotate(180,176,1504)"></polygon>
+              <polygon class="arrowhead" points="184,1024 172,1018.4 172,1029.6" fill="black" transform="rotate(180,176,1024)"></polygon>
+              <polygon class="arrowhead" points="184,992 172,986.4 172,997.6" fill="black" transform="rotate(180,176,992)"></polygon>
               <polygon class="arrowhead" points="184,896 172,890.4 172,901.6" fill="black" transform="rotate(180,176,896)"></polygon>
               <polygon class="arrowhead" points="184,816 172,810.4 172,821.6" fill="black" transform="rotate(180,176,816)"></polygon>
               <polygon class="arrowhead" points="184,720 172,714.4 172,725.6" fill="black" transform="rotate(180,176,720)"></polygon>
               <polygon class="arrowhead" points="184,528 172,522.4 172,533.6" fill="black" transform="rotate(180,176,528)"></polygon>
+              <polygon class="arrowhead" points="168,1824 156,1818.4 156,1829.6" fill="black" transform="rotate(0,160,1824)"></polygon>
+              <polygon class="arrowhead" points="168,1792 156,1786.4 156,1797.6" fill="black" transform="rotate(0,160,1792)"></polygon>
+              <polygon class="arrowhead" points="168,1408 156,1402.4 156,1413.6" fill="black" transform="rotate(0,160,1408)"></polygon>
               <polygon class="arrowhead" points="168,1376 156,1370.4 156,1381.6" fill="black" transform="rotate(0,160,1376)"></polygon>
-              <polygon class="arrowhead" points="168,1264 156,1258.4 156,1269.6" fill="black" transform="rotate(0,160,1264)"></polygon>
-              <polygon class="arrowhead" points="168,1232 156,1226.4 156,1237.6" fill="black" transform="rotate(0,160,1232)"></polygon>
-              <polygon class="arrowhead" points="168,1136 156,1130.4 156,1141.6" fill="black" transform="rotate(0,160,1136)"></polygon>
-              <polygon class="arrowhead" points="168,1104 156,1098.4 156,1109.6" fill="black" transform="rotate(0,160,1104)"></polygon>
+              <polygon class="arrowhead" points="168,1280 156,1274.4 156,1285.6" fill="black" transform="rotate(0,160,1280)"></polygon>
+              <polygon class="arrowhead" points="168,1248 156,1242.4 156,1253.6" fill="black" transform="rotate(0,160,1248)"></polygon>
+              <polygon class="arrowhead" points="168,1152 156,1146.4 156,1157.6" fill="black" transform="rotate(0,160,1152)"></polygon>
+              <polygon class="arrowhead" points="168,1120 156,1114.4 156,1125.6" fill="black" transform="rotate(0,160,1120)"></polygon>
               <polygon class="arrowhead" points="168,432 156,426.4 156,437.6" fill="black" transform="rotate(0,160,432)"></polygon>
               <polygon class="arrowhead" points="168,400 156,394.4 156,405.6" fill="black" transform="rotate(0,160,400)"></polygon>
               <polygon class="arrowhead" points="168,304 156,298.4 156,309.6" fill="black" transform="rotate(0,160,304)"></polygon>
               <polygon class="arrowhead" points="168,272 156,266.4 156,277.6" fill="black" transform="rotate(0,160,272)"></polygon>
               <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
-              <polygon class="arrowhead" points="48,1728 36,1722.4 36,1733.6" fill="black" transform="rotate(180,40,1728)"></polygon>
-              <polygon class="arrowhead" points="48,1360 36,1354.4 36,1365.6" fill="black" transform="rotate(180,40,1360)"></polygon>
-              <polygon class="arrowhead" points="48,1248 36,1242.4 36,1253.6" fill="black" transform="rotate(180,40,1248)"></polygon>
-              <polygon class="arrowhead" points="48,1232 36,1226.4 36,1237.6" fill="black" transform="rotate(180,40,1232)"></polygon>
-              <polygon class="arrowhead" points="48,1120 36,1114.4 36,1125.6" fill="black" transform="rotate(180,40,1120)"></polygon>
-              <polygon class="arrowhead" points="48,1104 36,1098.4 36,1109.6" fill="black" transform="rotate(180,40,1104)"></polygon>
-              <polygon class="arrowhead" points="48,416 36,410.4 36,421.6" fill="black" transform="rotate(180,40,416)"></polygon>
-              <polygon class="arrowhead" points="48,400 36,394.4 36,405.6" fill="black" transform="rotate(180,40,400)"></polygon>
-              <polygon class="arrowhead" points="48,288 36,282.4 36,293.6" fill="black" transform="rotate(180,40,288)"></polygon>
-              <polygon class="arrowhead" points="48,272 36,266.4 36,277.6" fill="black" transform="rotate(180,40,272)"></polygon>
-              <polygon class="arrowhead" points="48,160 36,154.4 36,165.6" fill="black" transform="rotate(180,40,160)"></polygon>
+              <polygon class="arrowhead" points="32,1808 20,1802.4 20,1813.6" fill="black" transform="rotate(180,24,1808)"></polygon>
+              <polygon class="arrowhead" points="32,1792 20,1786.4 20,1797.6" fill="black" transform="rotate(180,24,1792)"></polygon>
+              <polygon class="arrowhead" points="32,1392 20,1386.4 20,1397.6" fill="black" transform="rotate(180,24,1392)"></polygon>
+              <polygon class="arrowhead" points="32,1376 20,1370.4 20,1381.6" fill="black" transform="rotate(180,24,1376)"></polygon>
+              <polygon class="arrowhead" points="32,1264 20,1258.4 20,1269.6" fill="black" transform="rotate(180,24,1264)"></polygon>
+              <polygon class="arrowhead" points="32,1248 20,1242.4 20,1253.6" fill="black" transform="rotate(180,24,1248)"></polygon>
+              <polygon class="arrowhead" points="32,1136 20,1130.4 20,1141.6" fill="black" transform="rotate(180,24,1136)"></polygon>
+              <polygon class="arrowhead" points="32,1120 20,1114.4 20,1125.6" fill="black" transform="rotate(180,24,1120)"></polygon>
+              <polygon class="arrowhead" points="32,416 20,410.4 20,421.6" fill="black" transform="rotate(180,24,416)"></polygon>
+              <polygon class="arrowhead" points="32,400 20,394.4 20,405.6" fill="black" transform="rotate(180,24,400)"></polygon>
+              <polygon class="arrowhead" points="32,288 20,282.4 20,293.6" fill="black" transform="rotate(180,24,288)"></polygon>
+              <polygon class="arrowhead" points="32,272 20,266.4 20,277.6" fill="black" transform="rotate(180,24,272)"></polygon>
+              <polygon class="arrowhead" points="32,160 20,154.4 20,165.6" fill="black" transform="rotate(180,24,160)"></polygon>
               <g class="text">
                 <text x="44" y="52">Pledge</text>
-                <text x="164" y="52">Registrar-</text>
-                <text x="276" y="52">Domain</text>
-                <text x="412" y="52">Domain</text>
-                <text x="500" y="52">MASA</text>
-                <text x="144" y="68">Agent</text>
-                <text x="288" y="68">Registrar</text>
-                <text x="396" y="68">CA</text>
-                <text x="492" y="100">Internet</text>
+                <text x="172" y="52">Registrar-</text>
+                <text x="308" y="52">Domain</text>
+                <text x="436" y="52">Domain</text>
+                <text x="540" y="52">MASA</text>
+                <text x="168" y="68">Agent</text>
+                <text x="312" y="68">Registrar</text>
+                <text x="436" y="68">CA</text>
+                <text x="516" y="100">Internet</text>
                 <text x="92" y="116">discover</text>
                 <text x="92" y="132">pledge</text>
-                <text x="60" y="148">mDNS</text>
-                <text x="104" y="148">query</text>
-                <text x="32" y="212">~</text>
+                <text x="68" y="148">mDNS</text>
+                <text x="112" y="148">query</text>
+                <text x="16" y="212">~</text>
                 <text x="168" y="212">~</text>
                 <text x="312" y="212">~</text>
-                <text x="432" y="212">~</text>
-                <text x="536" y="212">~</text>
-                <text x="40" y="228">(1)</text>
-                <text x="88" y="228">Trigger</text>
-                <text x="148" y="228">Pledge</text>
-                <text x="240" y="228">Voucher-Request</text>
-                <text x="32" y="244">~</text>
+                <text x="456" y="212">~</text>
+                <text x="560" y="212">~</text>
+                <text x="16" y="228">(1)</text>
+                <text x="64" y="228">Trigger</text>
+                <text x="124" y="228">Pledge</text>
+                <text x="216" y="228">Voucher-Request</text>
+                <text x="16" y="244">~</text>
                 <text x="168" y="244">~</text>
                 <text x="312" y="244">~</text>
-                <text x="432" y="244">~</text>
-                <text x="536" y="244">~</text>
-                <text x="84" y="276">opt.</text>
-                <text x="120" y="276">TLS</text>
-                <text x="100" y="292">tPVR</text>
+                <text x="456" y="244">~</text>
+                <text x="560" y="244">~</text>
+                <text x="76" y="276">opt.</text>
+                <text x="112" y="276">TLS</text>
+                <text x="92" y="292">tPVR</text>
                 <text x="96" y="308">PVR</text>
-                <text x="32" y="340">~</text>
+                <text x="16" y="340">~</text>
                 <text x="168" y="340">~</text>
                 <text x="312" y="340">~</text>
-                <text x="432" y="340">~</text>
-                <text x="536" y="340">~</text>
-                <text x="40" y="356">(2)</text>
-                <text x="88" y="356">Trigger</text>
-                <text x="148" y="356">Pledge</text>
-                <text x="236" y="356">Enroll-Request</text>
-                <text x="32" y="372">~</text>
+                <text x="456" y="340">~</text>
+                <text x="560" y="340">~</text>
+                <text x="16" y="356">(2)</text>
+                <text x="64" y="356">Trigger</text>
+                <text x="124" y="356">Pledge</text>
+                <text x="212" y="356">Enroll-Request</text>
+                <text x="16" y="372">~</text>
                 <text x="168" y="372">~</text>
                 <text x="312" y="372">~</text>
-                <text x="432" y="372">~</text>
-                <text x="536" y="372">~</text>
-                <text x="84" y="404">opt.</text>
-                <text x="120" y="404">TLS</text>
-                <text x="100" y="420">tPER</text>
+                <text x="456" y="372">~</text>
+                <text x="560" y="372">~</text>
+                <text x="76" y="404">opt.</text>
+                <text x="112" y="404">TLS</text>
+                <text x="92" y="420">tPER</text>
                 <text x="96" y="436">PER</text>
-                <text x="32" y="468">~</text>
+                <text x="16" y="468">~</text>
                 <text x="168" y="468">~</text>
                 <text x="312" y="468">~</text>
-                <text x="432" y="468">~</text>
-                <text x="536" y="468">~</text>
-                <text x="40" y="484">(3)</text>
-                <text x="84" y="484">Supply</text>
-                <text x="128" y="484">PVR</text>
-                <text x="156" y="484">to</text>
-                <text x="208" y="484">Registrar</text>
-                <text x="292" y="484">(including</text>
-                <text x="368" y="484">backend</text>
-                <text x="452" y="484">interaction)</text>
-                <text x="32" y="500">~</text>
+                <text x="456" y="468">~</text>
+                <text x="560" y="468">~</text>
+                <text x="16" y="484">(3)</text>
+                <text x="60" y="484">Supply</text>
+                <text x="104" y="484">PVR</text>
+                <text x="132" y="484">to</text>
+                <text x="184" y="484">Registrar</text>
+                <text x="268" y="484">(including</text>
+                <text x="344" y="484">backend</text>
+                <text x="428" y="484">interaction)</text>
+                <text x="16" y="500">~</text>
                 <text x="168" y="500">~</text>
                 <text x="312" y="500">~</text>
-                <text x="432" y="500">~</text>
-                <text x="536" y="500">~</text>
+                <text x="456" y="500">~</text>
+                <text x="560" y="500">~</text>
                 <text x="236" y="532">mTLS</text>
                 <text x="308" y="548">[Registrar-Agent</text>
                 <text x="308" y="564">authenticated&amp;authorized?]</text>
-                <text x="232" y="580">PVR</text>
+                <text x="240" y="580">PVR</text>
                 <text x="312" y="580">|</text>
-                <text x="272" y="596">[accept</text>
-                <text x="340" y="596">device?]</text>
-                <text x="276" y="612">[contact</text>
-                <text x="344" y="612">vendor]</text>
-                <text x="428" y="644">mTLS</text>
-                <text x="432" y="660">RVR</text>
-                <text x="436" y="676">[extract</text>
-                <text x="512" y="676">DomainID]</text>
-                <text x="432" y="692">[update</text>
-                <text x="488" y="692">audit</text>
-                <text x="532" y="692">log]</text>
-                <text x="432" y="708">Voucher</text>
+                <text x="280" y="596">[accept</text>
+                <text x="348" y="596">device?]</text>
+                <text x="284" y="612">[contact</text>
+                <text x="352" y="612">vendor]</text>
+                <text x="436" y="644">mTLS</text>
+                <text x="440" y="660">RVR</text>
+                <text x="460" y="676">[extract</text>
+                <text x="536" y="676">DomainID]</text>
+                <text x="456" y="692">[update</text>
+                <text x="512" y="692">audit</text>
+                <text x="556" y="692">log]</text>
+                <text x="440" y="708">Voucher</text>
                 <text x="240" y="724">Voucher</text>
-                <text x="32" y="756">~</text>
+                <text x="16" y="756">~</text>
                 <text x="168" y="756">~</text>
                 <text x="312" y="756">~</text>
-                <text x="432" y="756">~</text>
-                <text x="536" y="756">~</text>
-                <text x="40" y="772">(4)</text>
-                <text x="84" y="772">Supply</text>
-                <text x="128" y="772">PER</text>
-                <text x="156" y="772">to</text>
-                <text x="208" y="772">Registrar</text>
-                <text x="292" y="772">(including</text>
-                <text x="368" y="772">backend</text>
-                <text x="452" y="772">interaction)</text>
-                <text x="32" y="788">~</text>
+                <text x="456" y="756">~</text>
+                <text x="560" y="756">~</text>
+                <text x="16" y="772">(4)</text>
+                <text x="60" y="772">Supply</text>
+                <text x="104" y="772">PER</text>
+                <text x="132" y="772">to</text>
+                <text x="184" y="772">Registrar</text>
+                <text x="268" y="772">(including</text>
+                <text x="344" y="772">backend</text>
+                <text x="428" y="772">interaction)</text>
+                <text x="16" y="788">~</text>
                 <text x="168" y="788">~</text>
                 <text x="312" y="788">~</text>
-                <text x="432" y="788">~</text>
-                <text x="536" y="788">~</text>
+                <text x="456" y="788">~</text>
+                <text x="560" y="788">~</text>
                 <text x="236" y="820">mTLS</text>
-                <text x="232" y="836">PER</text>
-                <text x="372" y="852">mTLS</text>
-                <text x="368" y="868">RER</text>
-                <text x="348" y="884">&lt;-Enroll</text>
-                <text x="408" y="884">Resp-</text>
-                <text x="220" y="900">Enroll</text>
-                <text x="268" y="900">Resp</text>
-                <text x="32" y="932">~</text>
+                <text x="240" y="836">PER</text>
+                <text x="380" y="852">mTLS</text>
+                <text x="384" y="868">RER</text>
+                <text x="384" y="884">Enroll-Resp</text>
+                <text x="240" y="900">Enroll-Resp</text>
+                <text x="16" y="932">~</text>
                 <text x="168" y="932">~</text>
                 <text x="312" y="932">~</text>
-                <text x="432" y="932">~</text>
-                <text x="536" y="932">~</text>
-                <text x="40" y="948">(5)</text>
-                <text x="88" y="948">Request</text>
-                <text x="132" y="948">CA</text>
-                <text x="196" y="948">Certificates</text>
-                <text x="32" y="964">~</text>
+                <text x="456" y="932">~</text>
+                <text x="560" y="932">~</text>
+                <text x="16" y="948">(5)</text>
+                <text x="64" y="948">Request</text>
+                <text x="108" y="948">CA</text>
+                <text x="172" y="948">Certificates</text>
+                <text x="16" y="964">~</text>
                 <text x="168" y="964">~</text>
                 <text x="312" y="964">~</text>
-                <text x="432" y="964">~</text>
-                <text x="536" y="964">~</text>
-                <text x="180" y="996">--</text>
-                <text x="236" y="996">cACert-Req</text>
-                <text x="256" y="1012">cACert-Resp--</text>
-                <text x="32" y="1044">~</text>
-                <text x="168" y="1044">~</text>
-                <text x="312" y="1044">~</text>
-                <text x="432" y="1044">~</text>
-                <text x="536" y="1044">~</text>
-                <text x="40" y="1060">(6)</text>
-                <text x="84" y="1060">Supply</text>
-                <text x="144" y="1060">Voucher</text>
-                <text x="188" y="1060">to</text>
-                <text x="228" y="1060">Pledge</text>
-                <text x="32" y="1076">~</text>
-                <text x="168" y="1076">~</text>
-                <text x="312" y="1076">~</text>
-                <text x="432" y="1076">~</text>
-                <text x="536" y="1076">~</text>
-                <text x="76" y="1108">opt.</text>
-                <text x="112" y="1108">TLS</text>
-                <text x="104" y="1124">Voucher</text>
-                <text x="104" y="1140">vStatus</text>
-                <text x="32" y="1172">~</text>
-                <text x="168" y="1172">~</text>
-                <text x="312" y="1172">~</text>
-                <text x="432" y="1172">~</text>
-                <text x="536" y="1172">~</text>
-                <text x="40" y="1188">(7)</text>
-                <text x="84" y="1188">Supply</text>
-                <text x="124" y="1188">CA</text>
-                <text x="188" y="1188">certificates</text>
-                <text x="252" y="1188">to</text>
-                <text x="292" y="1188">Pledge</text>
-                <text x="32" y="1204">~</text>
-                <text x="168" y="1204">~</text>
-                <text x="312" y="1204">~</text>
-                <text x="432" y="1204">~</text>
-                <text x="536" y="1204">~</text>
-                <text x="76" y="1236">opt.</text>
-                <text x="112" y="1236">TLS</text>
-                <text x="104" y="1252">cACerts</text>
+                <text x="456" y="964">~</text>
+                <text x="560" y="964">~</text>
+                <text x="236" y="996">mTLS</text>
+                <text x="236" y="1012">cACert-Req</text>
+                <text x="240" y="1028">cACert-Resp</text>
+                <text x="16" y="1060">~</text>
+                <text x="168" y="1060">~</text>
+                <text x="312" y="1060">~</text>
+                <text x="456" y="1060">~</text>
+                <text x="560" y="1060">~</text>
+                <text x="16" y="1076">(6)</text>
+                <text x="60" y="1076">Supply</text>
+                <text x="120" y="1076">Voucher</text>
+                <text x="164" y="1076">to</text>
+                <text x="204" y="1076">Pledge</text>
+                <text x="16" y="1092">~</text>
+                <text x="168" y="1092">~</text>
+                <text x="312" y="1092">~</text>
+                <text x="456" y="1092">~</text>
+                <text x="560" y="1092">~</text>
+                <text x="76" y="1124">opt.</text>
+                <text x="112" y="1124">TLS</text>
+                <text x="96" y="1140">Voucher</text>
+                <text x="96" y="1156">vStatus</text>
+                <text x="16" y="1188">~</text>
+                <text x="168" y="1188">~</text>
+                <text x="312" y="1188">~</text>
+                <text x="456" y="1188">~</text>
+                <text x="560" y="1188">~</text>
+                <text x="16" y="1204">(7)</text>
+                <text x="60" y="1204">Supply</text>
+                <text x="100" y="1204">CA</text>
+                <text x="164" y="1204">Certificates</text>
+                <text x="228" y="1204">to</text>
+                <text x="268" y="1204">Pledge</text>
+                <text x="16" y="1220">~</text>
+                <text x="168" y="1220">~</text>
+                <text x="312" y="1220">~</text>
+                <text x="456" y="1220">~</text>
+                <text x="560" y="1220">~</text>
+                <text x="76" y="1252">opt.</text>
+                <text x="112" y="1252">TLS</text>
                 <text x="96" y="1268">cACerts</text>
-                <text x="32" y="1300">~</text>
-                <text x="168" y="1300">~</text>
-                <text x="312" y="1300">~</text>
-                <text x="432" y="1300">~</text>
-                <text x="536" y="1300">~</text>
-                <text x="40" y="1316">(8)</text>
-                <text x="84" y="1316">Supply</text>
-                <text x="176" y="1316">Enroll-Response</text>
-                <text x="252" y="1316">to</text>
-                <text x="292" y="1316">Pledge</text>
-                <text x="32" y="1332">~</text>
-                <text x="168" y="1332">~</text>
-                <text x="312" y="1332">~</text>
-                <text x="432" y="1332">~</text>
-                <text x="536" y="1332">~</text>
-                <text x="84" y="1364">Enroll</text>
-                <text x="140" y="1364">Resp--</text>
-                <text x="96" y="1380">eStatus</text>
-                <text x="32" y="1412">~</text>
-                <text x="168" y="1412">~</text>
-                <text x="312" y="1412">~</text>
-                <text x="432" y="1412">~</text>
-                <text x="536" y="1412">~</text>
-                <text x="40" y="1428">(9)</text>
-                <text x="88" y="1428">Voucher</text>
-                <text x="148" y="1428">Status</text>
-                <text x="216" y="1428">Telemetry</text>
-                <text x="32" y="1444">~</text>
+                <text x="96" y="1284">cACerts</text>
+                <text x="16" y="1316">~</text>
+                <text x="168" y="1316">~</text>
+                <text x="312" y="1316">~</text>
+                <text x="456" y="1316">~</text>
+                <text x="560" y="1316">~</text>
+                <text x="16" y="1332">(8)</text>
+                <text x="60" y="1332">Supply</text>
+                <text x="152" y="1332">Enroll-Response</text>
+                <text x="228" y="1332">to</text>
+                <text x="268" y="1332">Pledge</text>
+                <text x="16" y="1348">~</text>
+                <text x="168" y="1348">~</text>
+                <text x="312" y="1348">~</text>
+                <text x="456" y="1348">~</text>
+                <text x="560" y="1348">~</text>
+                <text x="76" y="1380">opt.</text>
+                <text x="112" y="1380">TLS</text>
+                <text x="96" y="1396">Enroll-Resp</text>
+                <text x="88" y="1412">eStatus</text>
+                <text x="16" y="1444">~</text>
                 <text x="168" y="1444">~</text>
                 <text x="312" y="1444">~</text>
-                <text x="432" y="1444">~</text>
-                <text x="536" y="1444">~</text>
-                <text x="236" y="1476">mTLS</text>
-                <text x="240" y="1492">vStatus</text>
-                <text x="360" y="1508">req</text>
-                <text x="404" y="1508">device</text>
-                <text x="456" y="1508">audit</text>
-                <text x="496" y="1508">log</text>
-                <text x="388" y="1524">device</text>
-                <text x="440" y="1524">audit</text>
-                <text x="480" y="1524">log</text>
-                <text x="288" y="1540">[verify</text>
-                <text x="344" y="1540">audit</text>
-                <text x="388" y="1540">log]</text>
-                <text x="312" y="1556">|</text>
-                <text x="432" y="1556">|</text>
-                <text x="536" y="1556">|</text>
-                <text x="32" y="1572">~</text>
-                <text x="168" y="1572">~</text>
-                <text x="312" y="1572">~</text>
-                <text x="432" y="1572">~</text>
-                <text x="536" y="1572">~</text>
-                <text x="44" y="1588">(10)</text>
-                <text x="92" y="1588">Enroll</text>
-                <text x="148" y="1588">Status</text>
-                <text x="216" y="1588">Telemetry</text>
-                <text x="32" y="1604">~</text>
-                <text x="168" y="1604">~</text>
-                <text x="312" y="1604">~</text>
-                <text x="432" y="1604">~</text>
-                <text x="536" y="1604">~</text>
-                <text x="240" y="1636">eStatus</text>
-                <text x="32" y="1668">~</text>
-                <text x="168" y="1668">~</text>
-                <text x="312" y="1668">~</text>
-                <text x="432" y="1668">~</text>
-                <text x="536" y="1668">~</text>
-                <text x="44" y="1684">(11)</text>
-                <text x="88" y="1684">Query</text>
-                <text x="140" y="1684">Pledge</text>
-                <text x="196" y="1684">Status</text>
-                <text x="32" y="1700">~</text>
-                <text x="168" y="1700">~</text>
-                <text x="312" y="1700">~</text>
-                <text x="432" y="1700">~</text>
-                <text x="536" y="1700">~</text>
-                <text x="112" y="1732">pStatus-Req--</text>
-                <text x="100" y="1748">--pStatus-Resp-&gt;</text>
-                <text x="32" y="1780">~</text>
-                <text x="168" y="1780">~</text>
-                <text x="312" y="1780">~</text>
-                <text x="432" y="1780">~</text>
-                <text x="536" y="1780">~</text>
+                <text x="456" y="1444">~</text>
+                <text x="560" y="1444">~</text>
+                <text x="16" y="1460">(9)</text>
+                <text x="64" y="1460">Voucher</text>
+                <text x="124" y="1460">Status</text>
+                <text x="192" y="1460">Telemetry</text>
+                <text x="276" y="1460">(including</text>
+                <text x="352" y="1460">backend</text>
+                <text x="436" y="1460">interaction)</text>
+                <text x="16" y="1476">~</text>
+                <text x="168" y="1476">~</text>
+                <text x="312" y="1476">~</text>
+                <text x="456" y="1476">~</text>
+                <text x="560" y="1476">~</text>
+                <text x="236" y="1508">mTLS</text>
+                <text x="240" y="1524">vStatus</text>
+                <text x="436" y="1540">mTLS</text>
+                <text x="368" y="1556">req</text>
+                <text x="412" y="1556">device</text>
+                <text x="464" y="1556">audit</text>
+                <text x="504" y="1556">log</text>
+                <text x="396" y="1572">device</text>
+                <text x="448" y="1572">audit</text>
+                <text x="488" y="1572">log</text>
+                <text x="264" y="1588">[verify</text>
+                <text x="320" y="1588">audit</text>
+                <text x="364" y="1588">log]</text>
+                <text x="312" y="1604">|</text>
+                <text x="16" y="1620">~</text>
+                <text x="168" y="1620">~</text>
+                <text x="312" y="1620">~</text>
+                <text x="456" y="1620">~</text>
+                <text x="560" y="1620">~</text>
+                <text x="20" y="1636">(10)</text>
+                <text x="68" y="1636">Enroll</text>
+                <text x="124" y="1636">Status</text>
+                <text x="192" y="1636">Telemetry</text>
+                <text x="16" y="1652">~</text>
+                <text x="168" y="1652">~</text>
+                <text x="312" y="1652">~</text>
+                <text x="456" y="1652">~</text>
+                <text x="560" y="1652">~</text>
+                <text x="236" y="1684">mTLS</text>
+                <text x="240" y="1700">eStatus</text>
+                <text x="16" y="1732">~</text>
+                <text x="168" y="1732">~</text>
+                <text x="312" y="1732">~</text>
+                <text x="456" y="1732">~</text>
+                <text x="560" y="1732">~</text>
+                <text x="20" y="1748">(11)</text>
+                <text x="64" y="1748">Query</text>
+                <text x="116" y="1748">Pledge</text>
+                <text x="172" y="1748">Status</text>
+                <text x="16" y="1764">~</text>
+                <text x="168" y="1764">~</text>
+                <text x="312" y="1764">~</text>
+                <text x="456" y="1764">~</text>
+                <text x="560" y="1764">~</text>
+                <text x="76" y="1796">opt.</text>
+                <text x="112" y="1796">TLS</text>
+                <text x="96" y="1812">qStatus</text>
+                <text x="96" y="1828">pStatus</text>
+                <text x="16" y="1860">~</text>
+                <text x="168" y="1860">~</text>
+                <text x="312" y="1860">~</text>
+                <text x="456" y="1860">~</text>
+                <text x="560" y="1860">~</text>
               </g>
-            </svg><a href="#section-7-5.1.1" class="pilcrow">¶</a>
+            </svg><a href="#section-7-4.1.1" class="pilcrow">¶</a>
 </div>
 </div>
 <figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
 <a href="#name-overview-pledge-responder-m" class="selfRef">Overview pledge-responder-mode exchanges</a>
         </figcaption></figure>
 </div>
-<p id="section-7-6">The following sub sections split the interactions shown in <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> between the different components into:<a href="#section-7-6" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-7-7">
-<li id="section-7-7.1">
-          <p id="section-7-7.1.1"><a href="#tpvr" class="auto internal xref">Section 7.1</a> describes the request object acquisition for the Pledge Voucher-Request by the Registrar-Agent.<a href="#section-7-7.1.1" class="pilcrow">¶</a></p>
+<p id="section-7-5">The following sub sections split the interactions shown in <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> between the different components into:<a href="#section-7-5" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-7-6">
+<li id="section-7-6.1">
+          <p id="section-7-6.1.1"><a href="#tpvr" class="auto internal xref">Section 7.1</a> describes the acquisition exchange for the Pledge Voucher-Request initiated by the Registrar-Agent to the pledge.<a href="#section-7-6.1.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-7.2">
-          <p id="section-7-7.2.1"><a href="#tper" class="auto internal xref">Section 7.2</a> describes the request object acquisition for the Pledge Enroll-Request by the Registrar-Agent.<a href="#section-7-7.2.1" class="pilcrow">¶</a></p>
+        <li id="section-7-6.2">
+          <p id="section-7-6.2.1"><a href="#tper" class="auto internal xref">Section 7.2</a> describes the acquisition exchange for the Pledge Enroll-Request initiated by the Registrar-Agent to the pledge.<a href="#section-7-6.2.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-7.3">
-          <p id="section-7-7.3.1"><a href="#pvr" class="auto internal xref">Section 7.3</a> describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA using the RVR <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a> including the response object processing by these entities.<a href="#section-7-7.3.1" class="pilcrow">¶</a></p>
+        <li id="section-7-6.3">
+          <p id="section-7-6.3.1"><a href="#pvr" class="auto internal xref">Section 7.3</a> describes the issuing exchange for the Voucher initiated by the Registrar-Agent to the registrar, including the interaction of the registrar with the MASA using the RVR <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a>, as well as the artifact processing by these entities.<a href="#section-7-6.3.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-7.4">
-          <p id="section-7-7.4.1"><a href="#per" class="auto internal xref">Section 7.4</a> describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the CA using the PER including the response object processing by these entities.<a href="#section-7-7.4.1" class="pilcrow">¶</a></p>
+        <li id="section-7-6.4">
+          <p id="section-7-6.4.1"><a href="#per" class="auto internal xref">Section 7.4</a> describes the enroll exchange initiated by the Registrar-Agent to the registrar including the interaction of the registrar with the CA using the PER as well as the artifact processing by these entities.<a href="#section-7-6.4.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-7.5">
-          <p id="section-7-7.5.1"><a href="#req_cacerts" class="auto internal xref">Section 7.5</a> describes the object acquisition for the optional CA certificate provisioning to the Pledge initiated by the Registrar-Agent to the CA.<a href="#section-7-7.5.1" class="pilcrow">¶</a></p>
+        <li id="section-7-6.5">
+          <p id="section-7-6.5.1"><a href="#req_cacerts" class="auto internal xref">Section 7.5</a> describes the retrival exchange for the optional CA certificate provisioning to the pledge initiated by the Registrar-Agent to the CA.<a href="#section-7-6.5.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-7.6">
-          <p id="section-7-7.6.1"><a href="#voucher" class="auto internal xref">Section 7.6</a> describes the supply of the Voucher from the Registrar-Agent to the pledge including the returned status information.<a href="#section-7-7.6.1" class="pilcrow">¶</a></p>
+        <li id="section-7-6.6">
+          <p id="section-7-6.6.1"><a href="#voucher" class="auto internal xref">Section 7.6</a> describes the Voucher exchange initiated by the Registrar-Agent to the pledge and the returned status information.<a href="#section-7-6.6.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-7.7">
-          <p id="section-7-7.7.1"><a href="#cacerts" class="auto internal xref">Section 7.7</a> describes the supply of CA certificates to the Pledge by the Registrar-Agent.<a href="#section-7-7.7.1" class="pilcrow">¶</a></p>
+        <li id="section-7-6.7">
+          <p id="section-7-6.7.1"><a href="#cacerts" class="auto internal xref">Section 7.7</a> describes the certificate provisioning exchange initiated by the Registrar-Agent to the pledge.<a href="#section-7-6.7.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-7.8">
-          <p id="section-7-7.8.1"><a href="#enroll_response" class="auto internal xref">Section 7.8</a> describes the supply of the Enroll Reponse (containing the LDevID (Pledge) certificate) from the Registrar-Agent to the pledge including the returned status information.<a href="#section-7-7.8.1" class="pilcrow">¶</a></p>
+        <li id="section-7-6.8">
+          <p id="section-7-6.8.1"><a href="#enroll_response" class="auto internal xref">Section 7.8</a> describes the Enroll-Response exchange (containing the LDevID (Pledge) certificate) initiated by the Registrar-Agent to the pledge and the returned status information.<a href="#section-7-6.8.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-7.9">
-          <p id="section-7-7.9.1"><a href="#vstatus" class="auto internal xref">Section 7.9</a> describes the status handling for the pledge processing of the voucher and addresses corresponding exchanges between the Registrar-Agent and the registrar as well as between the registrar and the MASA.<a href="#section-7-7.9.1" class="pilcrow">¶</a></p>
+        <li id="section-7-6.9">
+          <p id="section-7-6.9.1"><a href="#vstatus" class="auto internal xref">Section 7.9</a> describes the Voucher status telemetry exchange initiated by the Registrar-Agent to the registrar, including the interaction of the registrar with the MASA.<a href="#section-7-6.9.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-7.10">
-          <p id="section-7-7.10.1"><a href="#estatus" class="auto internal xref">Section 7.10</a> describes the status handling for the pledge processing of the enrollment response  and addresses the corresponding exchange between the Registrar-Agent and the registrar.<a href="#section-7-7.10.1" class="pilcrow">¶</a></p>
+        <li id="section-7-6.10">
+          <p id="section-7-6.10.1"><a href="#estatus" class="auto internal xref">Section 7.10</a> describes the Enroll Status telemetry exchange initiated by the Registrar-Agent to the registrar.<a href="#section-7-6.10.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-7-7.11">
-          <p id="section-7-7.11.1"><a href="#query" class="auto internal xref">Section 7.11</a> describes the general status handling to query information about the bootstrapping state from the pledge initiated by the Registrar-Agent.<a href="#section-7-7.11.1" class="pilcrow">¶</a></p>
+        <li id="section-7-6.11">
+          <p id="section-7-6.11.1"><a href="#query" class="auto internal xref">Section 7.11</a> describes the Pledge Status exchange about the general bootstrapping state initiated by the Registrar-Agent to the pledge.<a href="#section-7-6.11.1" class="pilcrow">¶</a></p>
 </li>
       </ol>
 <div id="tpvr">
@@ -3157,114 +3187,211 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
         </h3>
 <p id="section-7.1-1">This exchange assumes that the Registrar-Agent has already discovered the pledge.
 This may be done as described in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 6.2.2</a> and <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> based on DNS-SD or similar.<a href="#section-7.1-1" class="pilcrow">¶</a></p>
-<p id="section-7.1-2">TLS <span class="bcp14">MAY</span> be optionally used to provide privacy for this exchange between the Registrar-Agent and the pledge, see <a href="#pledgehttps" class="auto internal xref">Appendix B</a>.<a href="#section-7.1-2" class="pilcrow">¶</a></p>
-<p id="section-7.1-3"><a href="#exchangesfig_uc2_1" class="auto internal xref">Figure 5</a> shows the Pledge Voucher-Request aquisition and the following subsections describe the corresponding artifacts.<a href="#section-7.1-3" class="pilcrow">¶</a></p>
-<span id="name-pvr-aquisition-exchanges"></span><div id="exchangesfig_uc2_1">
+<p id="section-7.1-2">Optionally, TLS <span class="bcp14">MAY</span> be used to provide privacy for this exchange between the Registrar-Agent and the pledge, see <a href="#pledgehttps" class="auto internal xref">Appendix B</a>.<a href="#section-7.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.1-3"><a href="#exchangesfig_uc2_1" class="auto internal xref">Figure 5</a> shows the acquisition of the Pledge Voucher-Request (PVR) and the following subsections describe the corresponding artifacts.<a href="#section-7.1-3" class="pilcrow">¶</a></p>
+<span id="name-pvr-acquisition-exchange"></span><div id="exchangesfig_uc2_1">
 <figure id="figure-5">
           <div id="section-7.1-4.1">
-            <div class="alignLeft art-svg artwork" id="section-7.1-4.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="560" viewBox="0 0 560 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+            <div class="alignCenter art-svg artwork" id="section-7.1-4.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="576" viewBox="0 0 576 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 32,160 L 32,224" fill="none" stroke="black"></path>
+                <path d="M 16,160 L 16,224" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
                 <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
-                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
                 <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
-                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 432,160 L 432,224" fill="none" stroke="black"></path>
-                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+                <path d="M 456,160 L 456,224" fill="none" stroke="black"></path>
                 <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-                <path d="M 536,160 L 536,224" fill="none" stroke="black"></path>
-                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+                <path d="M 560,160 L 560,224" fill="none" stroke="black"></path>
+                <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
-                <path d="M 144,176 L 160,176" fill="none" stroke="black"></path>
-                <path d="M 40,192 L 72,192" fill="none" stroke="black"></path>
-                <path d="M 128,192 L 160,192" fill="none" stroke="black"></path>
-                <path d="M 40,208 L 72,208" fill="none" stroke="black"></path>
-                <path d="M 120,208 L 160,208" fill="none" stroke="black"></path>
+                <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+                <path d="M 24,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 128,176 L 160,176" fill="none" stroke="black"></path>
+                <path d="M 24,192 L 72,192" fill="none" stroke="black"></path>
+                <path d="M 112,192 L 160,192" fill="none" stroke="black"></path>
+                <path d="M 24,208 L 80,208" fill="none" stroke="black"></path>
+                <path d="M 112,208 L 160,208" fill="none" stroke="black"></path>
                 <polygon class="arrowhead" points="168,208 156,202.4 156,213.6" fill="black" transform="rotate(0,160,208)"></polygon>
                 <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
-                <polygon class="arrowhead" points="48,192 36,186.4 36,197.6" fill="black" transform="rotate(180,40,192)"></polygon>
-                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <polygon class="arrowhead" points="32,192 20,186.4 20,197.6" fill="black" transform="rotate(180,24,192)"></polygon>
+                <polygon class="arrowhead" points="32,176 20,170.4 20,181.6" fill="black" transform="rotate(180,24,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="164" y="52">Registrar-</text>
-                  <text x="276" y="52">Domain</text>
-                  <text x="412" y="52">Domain</text>
-                  <text x="500" y="52">MASA</text>
-                  <text x="144" y="68">Agent</text>
-                  <text x="288" y="68">Registrar</text>
-                  <text x="396" y="68">CA</text>
-                  <text x="32" y="100">|</text>
+                  <text x="172" y="52">Registrar-</text>
+                  <text x="308" y="52">Domain</text>
+                  <text x="436" y="52">Domain</text>
+                  <text x="540" y="52">MASA</text>
+                  <text x="168" y="68">Agent</text>
+                  <text x="312" y="68">Registrar</text>
+                  <text x="436" y="68">CA</text>
+                  <text x="16" y="100">|</text>
                   <text x="168" y="100">|</text>
                   <text x="312" y="100">|</text>
-                  <text x="432" y="100">|</text>
-                  <text x="492" y="100">Internet</text>
-                  <text x="536" y="100">|</text>
-                  <text x="32" y="116">~</text>
+                  <text x="456" y="100">|</text>
+                  <text x="516" y="100">Internet</text>
+                  <text x="560" y="100">|</text>
+                  <text x="16" y="116">~</text>
                   <text x="168" y="116">~</text>
                   <text x="312" y="116">~</text>
-                  <text x="432" y="116">~</text>
-                  <text x="536" y="116">~</text>
-                  <text x="40" y="132">(1)</text>
-                  <text x="88" y="132">Trigger</text>
-                  <text x="148" y="132">Pledge</text>
-                  <text x="240" y="132">Voucher-Request</text>
-                  <text x="32" y="148">~</text>
+                  <text x="456" y="116">~</text>
+                  <text x="560" y="116">~</text>
+                  <text x="16" y="132">(1)</text>
+                  <text x="64" y="132">Trigger</text>
+                  <text x="124" y="132">Pledge</text>
+                  <text x="216" y="132">Voucher-Request</text>
+                  <text x="16" y="148">~</text>
                   <text x="168" y="148">~</text>
                   <text x="312" y="148">~</text>
-                  <text x="432" y="148">~</text>
-                  <text x="536" y="148">~</text>
-                  <text x="84" y="180">opt.</text>
-                  <text x="120" y="180">TLS</text>
-                  <text x="100" y="196">tPVR</text>
+                  <text x="456" y="148">~</text>
+                  <text x="560" y="148">~</text>
+                  <text x="76" y="180">opt.</text>
+                  <text x="112" y="180">TLS</text>
+                  <text x="92" y="196">tPVR</text>
                   <text x="96" y="212">PVR</text>
-                  <text x="32" y="244">~</text>
+                  <text x="16" y="244">~</text>
                   <text x="168" y="244">~</text>
                   <text x="312" y="244">~</text>
-                  <text x="432" y="244">~</text>
-                  <text x="536" y="244">~</text>
+                  <text x="456" y="244">~</text>
+                  <text x="560" y="244">~</text>
                 </g>
               </svg><a href="#section-7.1-4.1.1" class="pilcrow">¶</a>
 </div>
 </div>
 <figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
-<a href="#name-pvr-aquisition-exchanges" class="selfRef">PVR aquisition exchanges</a>
+<a href="#name-pvr-acquisition-exchange" class="selfRef">PVR acquisition exchange</a>
           </figcaption></figure>
 </div>
+<p id="section-7.1-5">The Registrar-Agent triggers the pledge to create the PVR via HTTP POST on the well-known pledge endpoint <code>/.well-known/brski/tpvr</code>.
+The request body <span class="bcp14">MUST</span> contain the JSON-based Pledge Voucher-Request Trigger (tPVR) artifact.
+The request header <span class="bcp14">MUST</span> set the Content-Type field to <code>application/json</code>.<a href="#section-7.1-5" class="pilcrow">¶</a></p>
+<p id="section-7.1-6">Upon receiving a valid tPVR, the pledge <span class="bcp14">MUST</span> reply with the PVR artifact in the body of a 200 OK response.
+The response header <span class="bcp14">MUST</span> have the Content-Type field set to <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.1-6" class="pilcrow">¶</a></p>
+<p id="section-7.1-7">TODO: Confirm that the media type goes into the HTTP response Content-Type header, not some JSON member inside the artifact (was unclear).<a href="#section-7.1-7" class="pilcrow">¶</a></p>
+<p id="section-7.1-8">If the pledge is unable to create the PVR, it <span class="bcp14">SHOULD</span> respond with an HTTP error code. The following client error responses <span class="bcp14">MAY</span> be used:<a href="#section-7.1-8" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7.1-9.1">
+            <p id="section-7.1-9.1.1">400 Bad Request: if the pledge detected an error in the format of the request, e.g. missing field, wrong data types, etc. or if the request is not valid JSON even though the PVR media type was set to <code>application/json</code>.<a href="#section-7.1-9.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-7.1-9.2">
+            <p id="section-7.1-9.2.1">403 Forbidden: if the pledge detected that one or more security parameters from the trigger message to create the PVR were not valid.<a href="#section-7.1-9.2.1" class="pilcrow">¶</a></p>
+</li>
+        </ul>
+<p id="section-7.1-10">TODO: There is even a note that the pledge cannot validate any security parameters at this point (in particular the originally given LDevID (Reg) cert). When is 403 really a choice?<a href="#section-7.1-10" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7.1-11.1">
+            <p id="section-7.1-11.1.1">406 Not Acceptable: if the Accept request header field indicates a type that is unknown or unsupported, e.g., a type other than <code>application/jose+json</code>.<a href="#section-7.1-11.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-7.1-11.2">
+            <p id="section-7.1-11.2.1">415 Unsupported Media Type: if the Content-Type request header field indicates a type that is unknown or unsupported, e.g., a type other than <code>application/json</code>.<a href="#section-7.1-11.2.1" class="pilcrow">¶</a></p>
+</li>
+        </ul>
 <div id="request-artifact-pledge-voucher-request-trigger-tpvr">
 <section id="section-7.1.1">
           <h4 id="name-request-artifact-pledge-vou">
 <a href="#section-7.1.1" class="section-number selfRef">7.1.1. </a><a href="#name-request-artifact-pledge-vou" class="section-name selfRef">Request Artifact: Pledge Voucher-Request Trigger (tPVR)</a>
           </h4>
-<p id="section-7.1.1-1">Triggering the pledge to create the PVR is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tpvr"<a href="#section-7.1.1-1" class="pilcrow">¶</a></p>
-<p id="section-7.1.1-2">The Registrar-Agent PVR trigger Content-Type header is: <code>application/json</code>.
-Following parameters are provided in the JSON object:<a href="#section-7.1.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-1">The Pledge Voucher-Request Trigger (tPVR) artifact is an unsigned JSON structure providing the following trigger parameters:<a href="#section-7.1.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-2">TODO: Why not CDDL here? It's a format defined here just like status-query.<a href="#section-7.1.1-2" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.1.1-3.1">
-              <p id="section-7.1.1-3.1.1">agent-provided-proximity-registrar-cert: base64-encoded registrar EE TLS certificate.<a href="#section-7.1.1-3.1.1" class="pilcrow">¶</a></p>
+              <p id="section-7.1.1-3.1.1"><code>agent-provided-proximity-registrar-cert</code>: X.509 v3 certificate structure of the domain registrar EE certificate (base64-encoded value); may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar<a href="#section-7.1.1-3.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.1.1-3.2">
-              <p id="section-7.1.1-3.2.1">agent-signed-data: base64-encoded JSON-in-JWS object.<a href="#section-7.1.1-3.2.1" class="pilcrow">¶</a></p>
+              <p id="section-7.1.1-3.2.1"><code>agent-signed-data</code>: base64-encoded JWS structure containing the SubjectKeyIdentifier of the EE (RegAgt) certificate and signing Data including the serial number of the pledge<a href="#section-7.1.1-3.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.1.1-4">The trigger for the pledge to create a PVR is depicted in the following figure:<a href="#section-7.1.1-4" class="pilcrow">¶</a></p>
-<span id="name-representation-of-trigger-t"></span><div id="pavrt">
+<span id="name-jws-structure-for-the-agent"></span><div id="asd">
 <figure id="figure-6">
-            <div class="alignLeft art-text artwork" id="section-7.1.1-5.1">
+            <div class="alignLeft art-text artwork" id="section-7.1.1-4.1">
+<pre>
+# The agent-signed-data in General JWS Serialization syntax
+{
+  "payload": BASE64URL(UTF8(Data)),
+  "signatures": [
+    {
+      "protected": BASE64URL(UTF8(JWS Protected Header)),
+      "signature": BASE64URL(JWS Signature)
+    }
+  ]
+}
+</pre>
+</div>
+<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
+<a href="#name-jws-structure-for-the-agent" class="selfRef">JWS structure for the agent-sigend-data member in General JWS Serialization syntax</a>
+            </figcaption></figure>
+</div>
+<p id="section-7.1.1-5">TODO: ietf-voucher-request:agent-signed-data is only defined as binary in YANG! No definition of the fields! /* "ietf-voucher-request:agent-signed-data" element (defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>): */<a href="#section-7.1.1-5" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-6">The Data <span class="bcp14">MUST</span> be UTF-8 encoded to become the octet-based JWS Payload defined in <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>.
+The JWS Payload is further base64url-encoded to become the string value of the <code>payload</code> member as described in <span><a href="https://rfc-editor.org/rfc/rfc7515#section-3.2" class="relref">Section 3.2</a> of [<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>.<a href="#section-7.1.1-6" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-7">The Data <span class="bcp14">MUST</span> be a JSON object with two members (see <a href="#asd_payload" class="auto internal xref">Figure 7</a> for an example):<a href="#section-7.1.1-7" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7.1.1-8.1">
+              <p id="section-7.1.1-8.1.1"><code>created-on</code>: creation date and time in yang:date-and-time format<a href="#section-7.1.1-8.1.1" class="pilcrow">¶</a></p>
+</li>
+            <li class="normal" id="section-7.1.1-8.2">
+              <p id="section-7.1.1-8.2.1"><code>serial-number</code>: product-serial-number in the X520SerialNumber field of the IDevID certificate of the pledge as string as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-2.3.1" class="relref">Section 2.3.1</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span><a href="#section-7.1.1-8.2.1" class="pilcrow">¶</a></p>
+</li>
+          </ul>
+<span id="name-data-example-inside-agent-s"></span><div id="asd_payload">
+<figure id="figure-7">
+            <div class="alignLeft art-text artwork" id="section-7.1.1-9.1">
+<pre>
+TODO: Even unclearer if there is this wrapper, as this element is not defined in YANG!
+"ietf-voucher-request-prm:agent-signed-data": {
+  "created-on": "2021-04-16T00:00:01.000Z",
+  "serial-number": "callee4711"
+}
+</pre>
+</div>
+<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
+<a href="#name-data-example-inside-agent-s" class="selfRef">Data example inside agent-signed-data</a>
+            </figcaption></figure>
+</div>
+<p id="section-7.1.1-10">The JWS Protected Header of the <code>agent-signed-data</code> JWS structure <span class="bcp14">MUST</span> contain the following parameters (see <a href="#asd_header" class="auto internal xref">Figure 8</a> for an example):<a href="#section-7.1.1-10" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7.1.1-11.1">
+              <p id="section-7.1.1-11.1.1"><code>alg</code>: algorithm type used to create the signature, e.g., <code>ES256</code> as defined in <span><a href="https://rfc-editor.org/rfc/rfc7515#section-4.1.1" class="relref">Section 4.1.1</a> of [<a href="#RFC7515" class="cite xref">RFC7515</a>]</span><a href="#section-7.1.1-11.1.1" class="pilcrow">¶</a></p>
+</li>
+            <li class="normal" id="section-7.1.1-11.2">
+              <p id="section-7.1.1-11.2.1"><code>kid</code>: base64-encoded bytes of the SubjectKeyIdentifier (the "KeyIdentifier" OCTET STRING value) of the EE (RegAgt) certificate.<a href="#section-7.1.1-11.2.1" class="pilcrow">¶</a></p>
+</li>
+          </ul>
+<span id="name-protected-header-example-in"></span><div id="asd_header">
+<figure id="figure-8">
+            <div class="alignLeft art-text artwork" id="section-7.1.1-12.1">
+<pre>
+{
+  "alg": "ES256",
+  "kid": "base64encodedvalue=="
+}
+</pre>
+</div>
+<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<a href="#name-protected-header-example-in" class="selfRef">Protected Header example inside agent-signed-data</a>
+            </figcaption></figure>
+</div>
+<p id="section-7.1.1-13">Note that at the time of receiving the PVR trigger, the pledge cannot verify the registrar LDevID certificate and has no proof-of-possession of the corresponding private key for the certificate.
+Hence, the tPVR is an unsigned artifact and the pledge only accepts the registrar LDevID certificate provisionally until it receives the voucher as described in <a href="#voucher" class="auto internal xref">Section 7.6</a>.<a href="#section-7.1.1-13" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-14">The pledge will also be unable to verify the agent-signed-data itself as it does not possess the EE (RegAgt) certificate and the domain trust has not been established at this point of the communication.
+Verification <span class="bcp14">SHOULD</span> be done, after the voucher has been received.<a href="#section-7.1.1-14" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-15">The trigger for the pledge to create a PVR is depicted in the following figure:<a href="#section-7.1.1-15" class="pilcrow">¶</a></p>
+<span id="name-representation-of-trigger-t"></span><div id="pavrt">
+<figure id="figure-9">
+            <div class="alignLeft art-text artwork" id="section-7.1.1-16.1">
 <pre>
 {
   "agent-provided-proximity-registrar-cert": "base64encodedvalue==",
@@ -3272,66 +3399,8 @@ Following parameters are provided in the JSON object:<a href="#section-7.1.1-2" 
 }
 </pre>
 </div>
-<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
+<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
 <a href="#name-representation-of-trigger-t" class="selfRef">Representation of trigger to create PVR</a>
-            </figcaption></figure>
-</div>
-<p id="section-7.1.1-6">Note that at the time of receiving the PVR trigger, the pledge cannot verify the registrar LDevID certificate and has no proof-of-possession of the corresponding private key for the certificate. The pledge therefore accepts the registrar LDevID certificate provisionally until it receives the voucher as described in <a href="#voucher" class="auto internal xref">Section 7.6</a>.<a href="#section-7.1.1-6" class="pilcrow">¶</a></p>
-<p id="section-7.1.1-7">The pledge will also be unable to verify the agent-signed-data itself as it does not possess the EE (RegAgt) certificate and the domain trust has not been established at this point of the communication.
-Verification <span class="bcp14">SHOULD</span> be done, after the voucher has been received.<a href="#section-7.1.1-7" class="pilcrow">¶</a></p>
-<p id="section-7.1.1-8">The agent-signed-data is a JSON-in-JWS object and contains the following information:<a href="#section-7.1.1-8" class="pilcrow">¶</a></p>
-<p id="section-7.1.1-9">The header of the agent-signed-data contains:<a href="#section-7.1.1-9" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-7.1.1-10.1">
-              <p id="section-7.1.1-10.1.1">alg: algorithm used for creating the object signature.<a href="#section-7.1.1-10.1.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.1.1-10.2">
-              <p id="section-7.1.1-10.2.1">kid: <span class="bcp14">MUST</span> contain the base64-encoded bytes of the SubjectKeyIdentifier (the "KeyIdentifier" OCTET STRING value) of the EE (RegAgt) certificate.<a href="#section-7.1.1-10.2.1" class="pilcrow">¶</a></p>
-</li>
-          </ul>
-<p id="section-7.1.1-11">The body of the agent-signed-data contains an "ietf-voucher-request:agent-signed-data" element (defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>):<a href="#section-7.1.1-11" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-7.1.1-12.1">
-              <p id="section-7.1.1-12.1.1">created-on: <span class="bcp14">MUST</span> contain the creation date and time in yang:date-and-time format.<a href="#section-7.1.1-12.1.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.1.1-12.2">
-              <p id="section-7.1.1-12.2.1">serial-number: <span class="bcp14">MUST</span> contain the product serial number as type string as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-2.3.1" class="relref">Section 2.3.1</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-The serial-number corresponds with the product-serial-number contained in the X520SerialNumber field of the IDevID certificate of the pledge.<a href="#section-7.1.1-12.2.1" class="pilcrow">¶</a></p>
-</li>
-          </ul>
-<span id="name-representation-of-agent-sig"></span><div id="asd">
-<figure id="figure-7">
-            <div class="alignLeft art-text artwork" id="section-7.1.1-13.1">
-<pre>
-# The agent-signed-data in General JWS Serialization syntax
-{
-  "payload": "BASE64URL(ietf-voucher-request-prm:agent-signed-data)",
-  "signatures": [
-    {
-      "protected": "BASE64URL(UTF8(JWS Protected Header))",
-      "signature": BASE64URL(JWS Signature)
-    }
-  ]
-}
-
-# Example: Decoded payload representation in JSON syntax of
-  "ietf-voucher-request-prm:agent-signed-data"
-
-"ietf-voucher-request-prm:agent-signed-data": {
-  "created-on": "2021-04-16T00:00:01.000Z",
-  "serial-number": "callee4711"
-}
-
-# Example: Decoded "JWS Protected Header" representation
-  in JSON syntax
-{
-  "alg": "ES256",
-  "kid": "base64encodedvalue=="
-}
-</pre>
-</div>
-<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
-<a href="#name-representation-of-agent-sig" class="selfRef">Representation of agent-signed-data in General JWS Serialization syntax</a>
             </figcaption></figure>
 </div>
 </section>
@@ -3341,59 +3410,40 @@ The serial-number corresponds with the product-serial-number contained in the X5
           <h4 id="name-response-artifact-pledge-vo">
 <a href="#section-7.1.2" class="section-number selfRef">7.1.2. </a><a href="#name-response-artifact-pledge-vo" class="section-name selfRef">Response Artifact: Pledge Voucher-Request (PVR)</a>
           </h4>
-<p id="section-7.1.2-1">Upon receiving the voucher-request trigger, the pledge <span class="bcp14">SHALL</span> construct the body of the PVR as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-It will contain additional information provided by the Registrar-Agent as specified in the following.
-This PVR becomes a JSON-in-JWS object as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
-If the pledge is unable to construct the PVR it <span class="bcp14">SHOULD</span> respond with a HTTP error code to the Registrar-Agent to indicate that it is not able to create the PVR.<a href="#section-7.1.2-1" class="pilcrow">¶</a></p>
-<p id="section-7.1.2-2">The following client error responses <span class="bcp14">MAY</span> be used:<a href="#section-7.1.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-1">The Pledge Voucher-Request (PVR) artifact is a JWS Voucher Request as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
+Its unsigned data <span class="bcp14">SHALL</span> be constructed similar to the Voucher-Request artifact defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+It will contain additional data provided by the Registrar-Agent as specified in the following.<a href="#section-7.1.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-2">The payload of the PVR <span class="bcp14">MUST</span> contain the following parameters as part of the ietf-voucher-request-prm:voucher as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>:<a href="#section-7.1.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-3">TODO: ietf-voucher-request-prm:voucher does not exist.<a href="#section-7.1.2-3" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-7.1.2-3.1">
-              <p id="section-7.1.2-3.1.1">400 Bad Request: if the pledge detected an error in the format of the request, e.g. missing field, wrong data types, etc. or if the request is not valid JSON even though the PVR media type was set to <code>application/json</code>.<a href="#section-7.1.2-3.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.1.2-4.1">
+              <p id="section-7.1.2-4.1.1"><code>created-on</code>: <span class="bcp14">SHALL</span> contain the current date and time in yang:date-and-time format.
+If the pledge does not have synchronized time, it <span class="bcp14">SHALL</span> use the created-on time from the agent-signed-data, received in the trigger to create a PVR.<a href="#section-7.1.2-4.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.1.2-3.2">
-              <p id="section-7.1.2-3.2.1">403 Forbidden: if the pledge detected that one or more security parameters from the trigger message to create the PVR were not valid, e.g., the LDevID (Reg) certificate.<a href="#section-7.1.2-3.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.2-4.2">
+              <p id="section-7.1.2-4.2.1"><code>nonce</code>: <span class="bcp14">SHALL</span> contain a cryptographically strong pseudo-random number.<a href="#section-7.1.2-4.2.1" class="pilcrow">¶</a></p>
+</li>
+            <li class="normal" id="section-7.1.2-4.3">
+              <p id="section-7.1.2-4.3.1"><code>serial-number</code>: <span class="bcp14">SHALL</span> contain the pledge product-serial-number as X520SerialNumber.<a href="#section-7.1.2-4.3.1" class="pilcrow">¶</a></p>
+</li>
+            <li class="normal" id="section-7.1.2-4.4">
+              <p id="section-7.1.2-4.4.1"><code>assertion</code>: <span class="bcp14">SHALL</span> contain the requested voucher assertion "agent-proximity" (different value as in RFC 8995)..<a href="#section-7.1.2-4.4.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.1.2-4">The header of the PVR <span class="bcp14">SHALL</span> contain the following parameters as defined in <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span> to support JWS signing of the object:<a href="#section-7.1.2-4" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-5">The ietf-voucher-request:voucher data is extended with two additional parameters that <span class="bcp14">MUST</span> be included:<a href="#section-7.1.2-5" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-7.1.2-5.1">
-              <p id="section-7.1.2-5.1.1">alg: algorithm used for creating the object signature.<a href="#section-7.1.2-5.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.1.2-6.1">
+              <p id="section-7.1.2-6.1.1"><code>agent-provided-proximity-registrar-cert</code>: base64-encoded registrar EE certificate (provided in tPVR by the Registrar-Agent); enables the registrar to verify that it is the desired registrar for handling the PVR<a href="#section-7.1.2-6.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.1.2-5.2">
-              <p id="section-7.1.2-5.2.1">x5c: contains the base64-encoded pledge IDevID certificate.
-It <span class="bcp14">MAY</span> optionally contain the certificate chain for this certificate. If the certificate chain is not included it <span class="bcp14">MUST</span> be available at the registrar for verification of the IDevID certificate.<a href="#section-7.1.2-5.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.2-6.2">
+              <p id="section-7.1.2-6.2.1"><code>agent-signed-data</code>: base64-encoded agent-signed-data (provided in tPVR by the Registrar-Agent); enables the registrar to verify and log, which Registrar-Agent was in contact with the pledge, when verifying the PVR<a href="#section-7.1.2-6.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.1.2-6">The payload of the PVR <span class="bcp14">MUST</span> contain the following parameters as part of the ietf-voucher-request-prm:voucher as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>:<a href="#section-7.1.2-6" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-7.1.2-7.1">
-              <p id="section-7.1.2-7.1.1">created-on: <span class="bcp14">SHALL</span> contain the current date and time in yang:date-and-time format.
-If the pledge does not have synchronized time, it <span class="bcp14">SHALL</span> use the created-on time from the agent-signed-data, received in the trigger to create a PVR.<a href="#section-7.1.2-7.1.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.1.2-7.2">
-              <p id="section-7.1.2-7.2.1">nonce: <span class="bcp14">SHALL</span> contain a cryptographically strong pseudo-random number.<a href="#section-7.1.2-7.2.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.1.2-7.3">
-              <p id="section-7.1.2-7.3.1">serial-number: <span class="bcp14">SHALL</span> contain the pledge product-serial-number as X520SerialNumber.<a href="#section-7.1.2-7.3.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.1.2-7.4">
-              <p id="section-7.1.2-7.4.1">assertion: <span class="bcp14">SHALL</span> contain the requested voucher assertion "agent-proximity" (different value as in RFC 8995)..<a href="#section-7.1.2-7.4.1" class="pilcrow">¶</a></p>
-</li>
-          </ul>
-<p id="section-7.1.2-8">The ietf-voucher-request:voucher is extended with additional parameters:<a href="#section-7.1.2-8" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-7.1.2-9.1">
-              <p id="section-7.1.2-9.1.1">agent-provided-proximity-registrar-cert: <span class="bcp14">MUST</span> be included and contains the base64-encoded registrar LDevID certificate (provided as PVR trigger parameter by the Registrar-Agent).<a href="#section-7.1.2-9.1.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.1.2-9.2">
-              <p id="section-7.1.2-9.2.1">agent-signed-data: <span class="bcp14">MUST</span> contain the base64-encoded agent-signed-data (as defined in <a href="#asd" class="auto internal xref">Figure 7</a>) and provided as a PVR trigger parameter by the Registrar-Agent.<a href="#section-7.1.2-9.2.1" class="pilcrow">¶</a></p>
-</li>
-          </ul>
-<p id="section-7.1.2-10">The enhancements of the YANG module for the ietf-voucher-request with these new leaves are defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>.<a href="#section-7.1.2-10" class="pilcrow">¶</a></p>
-<p id="section-7.1.2-11">The PVR is signed using the pledge's IDevID credential contained as x5c parameter of the JOSE header.<a href="#section-7.1.2-11" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-7">The enhancements of the YANG module for the ietf-voucher-request with these new leaves are defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>.<a href="#section-7.1.2-7" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-8">The PVR is signed using the pledge's IDevID credential contained as x5c parameter of the JOSE header.<a href="#section-7.1.2-8" class="pilcrow">¶</a></p>
 <span id="name-representation-of-pvr"></span><div id="pvr_example">
-<figure id="figure-8">
-            <div class="alignLeft art-text artwork" id="section-7.1.2-12.1">
+<figure id="figure-10">
+            <div class="alignLeft art-text artwork" id="section-7.1.2-9.1">
 <pre>
 # The PVR in General JWS Serialization syntax
 {
@@ -3429,13 +3479,10 @@ If the pledge does not have synchronized time, it <span class="bcp14">SHALL</spa
 }
 </pre>
 </div>
-<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
 <a href="#name-representation-of-pvr" class="selfRef">Representation of PVR</a>
             </figcaption></figure>
 </div>
-<p id="section-7.1.2-13">The PVR Media-Type is defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span> as <code>application/voucher-jws+json</code>.<a href="#section-7.1.2-13" class="pilcrow">¶</a></p>
-<p id="section-7.1.2-14">The pledge <span class="bcp14">MUST</span> include this Media-Type header field indicating the included media type for the PVR.
-The PVR is included by the registrar in its RVR as described in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-7.1.2-14" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -3445,122 +3492,128 @@ The PVR is included by the registrar in its RVR as described in <a href="#pvr" c
         <h3 id="name-trigger-pledge-enroll-reque">
 <a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-trigger-pledge-enroll-reque" class="section-name selfRef">Trigger Pledge Enroll-Request</a>
         </h3>
-<p id="section-7.2-1"><a href="#exchangesfig_uc2_2" class="auto internal xref">Figure 9</a> shows the the aquisition of the Pledge Enroll-Request aquisition and the following subsections describe the corresponding artifacts.<a href="#section-7.2-1" class="pilcrow">¶</a></p>
-<span id="name-per-aquisition-exchanges"></span><div id="exchangesfig_uc2_2">
-<figure id="figure-9">
-          <div id="section-7.2-2.1">
-            <div class="alignLeft art-svg artwork" id="section-7.2-2.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="560" viewBox="0 0 560 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+<p id="section-7.2-1">Once the Registrar-Agent has received the PVR it can trigger the pledge to generate a Pledge Enroll-Request (PER).<a href="#section-7.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.2-2">Optionally, TLS <span class="bcp14">MAY</span> be used to provide privacy for this exchange between the Registrar-Agent and the pledge, see <a href="#pledgehttps" class="auto internal xref">Appendix B</a>.<a href="#section-7.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.2-3"><a href="#exchangesfig_uc2_2" class="auto internal xref">Figure 11</a> shows the the acquisition of the PER and the following subsections describe the corresponding artifacts.<a href="#section-7.2-3" class="pilcrow">¶</a></p>
+<span id="name-per-acquisition-exchange"></span><div id="exchangesfig_uc2_2">
+<figure id="figure-11">
+          <div id="section-7.2-4.1">
+            <div class="alignCenter art-svg artwork" id="section-7.2-4.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="576" viewBox="0 0 576 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 32,160 L 32,224" fill="none" stroke="black"></path>
+                <path d="M 16,160 L 16,224" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
                 <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
-                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
                 <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
-                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 432,160 L 432,224" fill="none" stroke="black"></path>
-                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+                <path d="M 456,160 L 456,224" fill="none" stroke="black"></path>
                 <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-                <path d="M 536,160 L 536,224" fill="none" stroke="black"></path>
-                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+                <path d="M 560,160 L 560,224" fill="none" stroke="black"></path>
+                <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
-                <path d="M 144,176 L 160,176" fill="none" stroke="black"></path>
-                <path d="M 40,192 L 72,192" fill="none" stroke="black"></path>
-                <path d="M 128,192 L 160,192" fill="none" stroke="black"></path>
-                <path d="M 40,208 L 72,208" fill="none" stroke="black"></path>
-                <path d="M 120,208 L 160,208" fill="none" stroke="black"></path>
+                <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+                <path d="M 24,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 128,176 L 160,176" fill="none" stroke="black"></path>
+                <path d="M 24,192 L 72,192" fill="none" stroke="black"></path>
+                <path d="M 112,192 L 160,192" fill="none" stroke="black"></path>
+                <path d="M 24,208 L 80,208" fill="none" stroke="black"></path>
+                <path d="M 112,208 L 160,208" fill="none" stroke="black"></path>
                 <polygon class="arrowhead" points="168,208 156,202.4 156,213.6" fill="black" transform="rotate(0,160,208)"></polygon>
                 <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
-                <polygon class="arrowhead" points="48,192 36,186.4 36,197.6" fill="black" transform="rotate(180,40,192)"></polygon>
-                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <polygon class="arrowhead" points="32,192 20,186.4 20,197.6" fill="black" transform="rotate(180,24,192)"></polygon>
+                <polygon class="arrowhead" points="32,176 20,170.4 20,181.6" fill="black" transform="rotate(180,24,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="164" y="52">Registrar-</text>
-                  <text x="276" y="52">Domain</text>
-                  <text x="412" y="52">Domain</text>
-                  <text x="500" y="52">MASA</text>
-                  <text x="144" y="68">Agent</text>
-                  <text x="288" y="68">Registrar</text>
-                  <text x="396" y="68">CA</text>
-                  <text x="32" y="100">|</text>
+                  <text x="172" y="52">Registrar-</text>
+                  <text x="308" y="52">Domain</text>
+                  <text x="436" y="52">Domain</text>
+                  <text x="540" y="52">MASA</text>
+                  <text x="168" y="68">Agent</text>
+                  <text x="312" y="68">Registrar</text>
+                  <text x="436" y="68">CA</text>
+                  <text x="16" y="100">|</text>
                   <text x="168" y="100">|</text>
                   <text x="312" y="100">|</text>
-                  <text x="432" y="100">|</text>
-                  <text x="492" y="100">Internet</text>
-                  <text x="536" y="100">|</text>
-                  <text x="24" y="116">~</text>
-                  <text x="160" y="116">~</text>
-                  <text x="304" y="116">~</text>
-                  <text x="424" y="116">~</text>
-                  <text x="528" y="116">~</text>
-                  <text x="40" y="132">(2)</text>
-                  <text x="88" y="132">Trigger</text>
-                  <text x="148" y="132">Pledge</text>
-                  <text x="236" y="132">Enroll-Request</text>
-                  <text x="32" y="148">~</text>
+                  <text x="456" y="100">|</text>
+                  <text x="516" y="100">Internet</text>
+                  <text x="560" y="100">|</text>
+                  <text x="16" y="116">~</text>
+                  <text x="168" y="116">~</text>
+                  <text x="312" y="116">~</text>
+                  <text x="456" y="116">~</text>
+                  <text x="560" y="116">~</text>
+                  <text x="16" y="132">(2)</text>
+                  <text x="64" y="132">Trigger</text>
+                  <text x="124" y="132">Pledge</text>
+                  <text x="212" y="132">Enroll-Request</text>
+                  <text x="16" y="148">~</text>
                   <text x="168" y="148">~</text>
                   <text x="312" y="148">~</text>
-                  <text x="432" y="148">~</text>
-                  <text x="536" y="148">~</text>
-                  <text x="84" y="180">opt.</text>
-                  <text x="120" y="180">TLS</text>
-                  <text x="100" y="196">tPER</text>
+                  <text x="456" y="148">~</text>
+                  <text x="560" y="148">~</text>
+                  <text x="76" y="180">opt.</text>
+                  <text x="112" y="180">TLS</text>
+                  <text x="92" y="196">tPER</text>
                   <text x="96" y="212">PER</text>
-                  <text x="32" y="244">~</text>
+                  <text x="16" y="244">~</text>
                   <text x="168" y="244">~</text>
                   <text x="312" y="244">~</text>
-                  <text x="432" y="244">~</text>
-                  <text x="536" y="244">~</text>
+                  <text x="456" y="244">~</text>
+                  <text x="560" y="244">~</text>
                 </g>
-              </svg><a href="#section-7.2-2.1.1" class="pilcrow">¶</a>
+              </svg><a href="#section-7.2-4.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
-<a href="#name-per-aquisition-exchanges" class="selfRef">PER aquisition exchanges</a>
+<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
+<a href="#name-per-acquisition-exchange" class="selfRef">PER acquisition exchange</a>
           </figcaption></figure>
 </div>
+<p id="section-7.2-5">The Registrar-Agent triggers the pledge to create the PER via HTTP POST on the well-known pledge endpoint <code>/.well-known/brski/tper</code>.
+As the initial enrollment aims to request a generic certificate, no certificate attributes are provided to the pledge.
+Hence, by default, the request body is empty, no artifact is provided.<a href="#section-7.2-5" class="pilcrow">¶</a></p>
+<p id="section-7.2-6">Upon receiving a valid tPER, the pledge <span class="bcp14">MUST</span> reply with the PER artifact in the body of a 200 OK response.
+The response header <span class="bcp14">MUST</span> have the Content-Type field set to <code>application/jose+json</code>.<a href="#section-7.2-6" class="pilcrow">¶</a></p>
+<p id="section-7.2-7">If the pledge is unable to create the PER, it <span class="bcp14">SHOULD</span> respond with an HTTP error code. The following 4xx client error codes <span class="bcp14">MAY</span> be used:<a href="#section-7.2-7" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7.2-8.1">
+            <p id="section-7.2-8.1.1">400 Bad Request: if the pledge detected an error in the format of the request.<a href="#section-7.2-8.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-7.2-8.2">
+            <p id="section-7.2-8.2.1">403 Forbidden: if the pledge detected that one or more security parameters (if provided) from the trigger message to create the PER are not valid.<a href="#section-7.2-8.2.1" class="pilcrow">¶</a></p>
+</li>
+        </ul>
+<p id="section-7.2-9">TODO: Can this make sense? (empty body, note that it cannot validate)<a href="#section-7.2-9" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7.2-10.1">
+            <p id="section-7.2-10.1.1">406 Not Acceptable: if the Accept request header field indicates a type that is unknown or unsupported. For example, a type other than <code>application/jose+json</code>.<a href="#section-7.2-10.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-7.2-10.2">
+            <p id="section-7.2-10.2.1">415 Unsupported Media Type: if the Content-Type request header field indicates a type that is unknown or unsupported, e.g., a type other than <code>application/json</code>.<a href="#section-7.2-10.2.1" class="pilcrow">¶</a></p>
+</li>
+        </ul>
 <div id="request-artifact-pledge-enroll-request-trigger-tper">
 <section id="section-7.2.1">
           <h4 id="name-request-artifact-pledge-enr">
 <a href="#section-7.2.1" class="section-number selfRef">7.2.1. </a><a href="#name-request-artifact-pledge-enr" class="section-name selfRef">Request Artifact: Pledge Enroll-Request Trigger (tPER)</a>
           </h4>
-<p id="section-7.2.1-1">Once the Registrar-Agent has received the PVR it can trigger the pledge to generate a PER.
-As in BRSKI the PER contains a PKCS#10, but additionally signed using the pledge's IDevID.
-Note, as the initial enrollment aims to request a generic certificate, no certificate attributes are provided to the pledge.<a href="#section-7.2.1-1" class="pilcrow">¶</a></p>
-<p id="section-7.2.1-2">Triggering the pledge to create the Enroll-Request is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tper"<a href="#section-7.2.1-2" class="pilcrow">¶</a></p>
-<p id="section-7.2.1-3">The Registrar-Agent PER trigger Content-Type header is: <code>application/json</code> with an empty body by default.
-Note that using HTTP POST allows for an empty body, but also to provide additional data, like CSR attributes or information about the enroll type "enroll-generic-cert" or "re-enroll-generic-cert".
-The "enroll-generic-cert" case is shown in <a href="#raer" class="auto internal xref">Figure 10</a>.<a href="#section-7.2.1-3" class="pilcrow">¶</a></p>
-<span id="name-example-of-trigger-to-creat"></span><div id="raer">
-<figure id="figure-10">
-            <div class="alignLeft art-text artwork" id="section-7.2.1-4.1">
-<pre>
-{
-  "enroll-type" : "enroll-generic-cert"
-}
-</pre>
-</div>
-<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
-<a href="#name-example-of-trigger-to-creat" class="selfRef">Example of trigger to create a PER</a>
-            </figcaption></figure>
-</div>
-<p id="section-7.2.1-5">This document specifies the request of a generic certificate with no CSR attributes provided to the pledge.
-If specific attributes in the certificate are required, they have to be inserted by the issuing RA/CA.
-How the HTTP POST can be used to provide CSR attributes is out of scope for this specification.<a href="#section-7.2.1-5" class="pilcrow">¶</a></p>
-<p id="section-7.2.1-6">In the following the enrollment is described as initial enrollment with an empty HTTP POST body.<a href="#section-7.2.1-6" class="pilcrow">¶</a></p>
+<p id="section-7.2.1-1">This document specifies the trigger for a generic certificate with no CSR attributes provided to the pledge.
+If specific attributes in the certificate are required, they have to be inserted by the issuing RA/CA.<a href="#section-7.2.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.2.1-2">TODO: Unclear if JSON with { "enroll-type" : "enroll-generic-cert" } could be used alternatively to an empty body (i.e., is the assumed default enroll-type). Must update/remove response codes if there is no alternative to empty body.<a href="#section-7.2.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.2.1-3">The Pledge Enroll-Request Trigger (tPER) artifact <span class="bcp14">MAY</span> be used to provide additional data, like CSR attributes or information about the enroll type.
+How to provide and use such additional data is out of scope for this specification.<a href="#section-7.2.1-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="response-artifact-pledge-enroll-request-per">
@@ -3568,57 +3621,47 @@ How the HTTP POST can be used to provide CSR attributes is out of scope for this
           <h4 id="name-response-artifact-pledge-en">
 <a href="#section-7.2.2" class="section-number selfRef">7.2.2. </a><a href="#name-response-artifact-pledge-en" class="section-name selfRef">Response Artifact: Pledge Enroll-Request (PER)</a>
           </h4>
-<p id="section-7.2.2-1">Upon receiving the PER trigger, the pledge <span class="bcp14">SHALL</span> construct the PER as authenticated self-contained object.
+<p id="section-7.2.2-1">The Pledge Enroll-Request (PER) artifact is a JWS-signed PKCS#10 Certificate Signing Request (CSR) utilizing the csr-grouping of the <code>ietf-ztp-types</code> YANG module as defined in <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span>.
 The CSR already assures POP of the private key corresponding to the contained public key.
-In addition, based on the PER signature using the IDevID, POI is provided.
-Here, a JOSE object is being created in which the body utilizes the YANG module ietf-ztp-types with the grouping for csr-grouping for the CSR as defined in <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span>.<a href="#section-7.2.2-1" class="pilcrow">¶</a></p>
-<p id="section-7.2.2-2">Depending on the capability of the pledge, it constructs the Pledge Enroll-Request (PER) as plain PKCS#10.
-Note, the focus in this use case is placed on PKCS#10 as PKCS#10 can be transmitted in different enrollment protocols in the infrastructure like EST, CMP, CMS, and SCEP.
+In addition, based on the PER signature using the IDevID, POI is provided.<a href="#section-7.2.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-2">TODO: What is the next paragraph saying? That PRM could also just use a plain PKCS#10? That it could use some other enrollment protocol? That CMP is also okay?<a href="#section-7.2.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-3">Depending on the capability of the pledge, it constructs the Pledge Enroll-Request (PER) as plain PKCS#10.
+Note, the focus in this use case is placed on PKCS#10, as PKCS#10 can be transmitted in different enrollment protocols in the infrastructure like EST, CMP, CMS, and SCEP.
 If the pledge has already implemented an enrollment protocol, it may leverage that functionality for the creation of the CSR.
-Note, <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span> also allows for inclusion of certification requests in different formats used by CMP or CMC.<a href="#section-7.2.2-2" class="pilcrow">¶</a></p>
-<p id="section-7.2.2-3">The pledge <span class="bcp14">MUST</span> construct the PER as PKCS#10.
-In BRSKI-PRM it <span class="bcp14">MUST</span> sign it additionally with its IDevID credentials to provide proof-of-identity bound to the PKCS#10 as described below.<a href="#section-7.2.2-3" class="pilcrow">¶</a></p>
-<p id="section-7.2.2-4">If the pledge is unable to construct the PER it <span class="bcp14">SHOULD</span> respond with a HTTP 4xx/5xx error code to the Registrar-Agent to indicate that it is not able to create the PER.<a href="#section-7.2.2-4" class="pilcrow">¶</a></p>
-<p id="section-7.2.2-5">The following 4xx client error codes <span class="bcp14">MAY</span> be used:<a href="#section-7.2.2-5" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-7.2.2-6.1">
-              <p id="section-7.2.2-6.1.1">400 Bad Request: if the pledge detected an error in the format of the request or detected invalid JSON even though the PER media type was set to <code>application/json</code>.<a href="#section-7.2.2-6.1.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.2.2-6.2">
-              <p id="section-7.2.2-6.2.1">403 Forbidden: if the pledge detected that one or more security parameters (if provided) from the trigger message to create the PER are not valid.<a href="#section-7.2.2-6.2.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.2.2-6.3">
-              <p id="section-7.2.2-6.3.1">406 Not Acceptable: if the request's Accept header indicates a type that is unknown or unsupported. For example, a type other than <code>application/jose+json</code>.<a href="#section-7.2.2-6.3.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.2.2-6.4">
-              <p id="section-7.2.2-6.4.1">415 Unsupported Media Type: if the request's Content-Type header indicates a type that is unknown or unsupported. For example, a type other than 'application/json'.<a href="#section-7.2.2-6.4.1" class="pilcrow">¶</a></p>
-</li>
-          </ul>
-<p id="section-7.2.2-7">A successful enrollment will result in a generic LDevID certificate for the pledge in the new domain, which can be used to request further (application specific) LDevID certificates if necessary for operation.
-The Registrar-Agent <span class="bcp14">SHALL</span> use the endpoints specified in this document.<a href="#section-7.2.2-7" class="pilcrow">¶</a></p>
-<p id="section-7.2.2-8"><span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span> considers PKCS#10 but also CMP and CMC as certification request format.
-Note that the wrapping of the PER signature is only necessary for plain PKCS#10 as other request formats like CMP and CMS support the signature wrapping as part of their own certificate request format.<a href="#section-7.2.2-8" class="pilcrow">¶</a></p>
-<p id="section-7.2.2-9">The Registrar-Agent Enroll-Request Content-Type header for a signature-wrapped PKCS#10 is: <code>application/jose+json</code><a href="#section-7.2.2-9" class="pilcrow">¶</a></p>
-<p id="section-7.2.2-10">The header of the Pledge Enroll-Request <span class="bcp14">SHALL</span> contain the following parameter as defined in <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>:<a href="#section-7.2.2-10" class="pilcrow">¶</a></p>
+Note, <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span> also allows for inclusion of certification requests in different formats used by CMP or CMC.<a href="#section-7.2.2-3" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-4">The pledge <span class="bcp14">MUST</span> construct the PER as PKCS#10.
+In BRSKI-PRM it <span class="bcp14">MUST</span> sign it additionally with its IDevID credentials to provide proof-of-identity bound to the PKCS#10 as described below.<a href="#section-7.2.2-4" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-5">TODO: Why is the following information given here?<a href="#section-7.2.2-5" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-6">A successful enrollment will result in a generic LDevID certificate for the pledge in the new domain, which can be used to request further (application specific) LDevID certificates if necessary for operation.
+The Registrar-Agent <span class="bcp14">SHALL</span> use the endpoints specified in this document.<a href="#section-7.2.2-6" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-7">TODO: What endpointS? My guess would be use ./tper with a request body to do specific cert enrollment, yes?<a href="#section-7.2.2-7" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-8">TODO: Why is the confusing information even repeated? It does not clarify anything.<a href="#section-7.2.2-8" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-9"><span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span> considers PKCS#10 but also CMP and CMC as certification request format.
+Note that the wrapping of the PER signature is only necessary for plain PKCS#10 as other request formats like CMP and CMS support the signature wrapping as part of their own certificate request format.<a href="#section-7.2.2-9" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-10">The JWS Protected Header of the PER <span class="bcp14">MUST</span> contain the following parameters as defined in <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>:<a href="#section-7.2.2-10" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.2.2-11.1">
-              <p id="section-7.2.2-11.1.1">alg: algorithm used for creating the object signature.<a href="#section-7.2.2-11.1.1" class="pilcrow">¶</a></p>
+              <p id="section-7.2.2-11.1.1"><code>alg</code>: algorithm type used to create the signature, e.g., <code>ES256</code> as defined in <span><a href="https://rfc-editor.org/rfc/rfc7515#section-4.1.1" class="relref">Section 4.1.1</a> of [<a href="#RFC7515" class="cite xref">RFC7515</a>]</span><a href="#section-7.2.2-11.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.2.2-11.2">
-              <p id="section-7.2.2-11.2.1">x5c: contains the base64-encoded pledge IDevID certificate.
-It <span class="bcp14">MAY</span> optionally contain the certificate chain for this certificate. If the certificate chain is not included it <span class="bcp14">MUST</span> be available at the registrar for verification of the IDevID certificate.
-The body of the Pledge Enroll-Request <span class="bcp14">SHOULD</span> contain a P10 parameter (for PKCS#10) as defined for ietf-ztp-types:p10-csr in <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span><a href="#section-7.2.2-11.2.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.2.2-11.3">
-              <p id="section-7.2.2-11.3.1">P10: contains the base64-encoded PKCS#10 of the pledge.<a href="#section-7.2.2-11.3.1" class="pilcrow">¶</a></p>
+              <p id="section-7.2.2-11.2.1"><code>x5c</code>: base64-encoded pledge IDevID certificate;
+it <span class="bcp14">MAY</span> optionally contain the certificate chain for this certificate; if the certificate chain is not included, it <span class="bcp14">MUST</span> be available at the registrar for verification of the IDevID certificate<a href="#section-7.2.2-11.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.2.2-12">The JOSE object is signed using the pledge's IDevID credential, which corresponds to the certificate signaled in the JOSE header.<a href="#section-7.2.2-12" class="pilcrow">¶</a></p>
-<p id="section-7.2.2-13">While BRSKI-PRM targets the initial enrollment, re-enrollment <span class="bcp14">SHOULD</span> be supported as described in a similar way as for enrollment in this document, if no other re-enrollment mechanism is supported.
-Note that in this case the current LDevID credential is used instead of the IDevID credential to create the signature of the PKCS#10 request.<a href="#section-7.2.2-13" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-12">The body of the Pledge Enroll-Request <span class="bcp14">SHOULD</span> contain a P10 parameter (for PKCS#10) as defined for ietf-ztp-types:p10-csr in <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span>:<a href="#section-7.2.2-12" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7.2.2-13.1">
+              <p id="section-7.2.2-13.1.1"><code>p10</code>: base64-encoded PKCS#10 of the pledge.<a href="#section-7.2.2-13.1.1" class="pilcrow">¶</a></p>
+</li>
+          </ul>
+<p id="section-7.2.2-14">TODO: Confirm lowercase p (not "P10")
+TODO: We contain the full CSR that is already in the payload again in the header?!<a href="#section-7.2.2-14" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-15">The JOSE object is signed using the pledge's IDevID credential, which corresponds to the certificate signaled in the JOSE header.<a href="#section-7.2.2-15" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-16">While BRSKI-PRM targets the initial enrollment, re-enrollment <span class="bcp14">SHOULD</span> be supported as described in a similar way as for enrollment in this document, if no other re-enrollment mechanism is supported.
+Note that in this case the current LDevID credential is used instead of the IDevID credential to create the signature of the PKCS#10 request.<a href="#section-7.2.2-16" class="pilcrow">¶</a></p>
 <span id="name-representation-of-per"></span><div id="per_example">
-<figure id="figure-11">
-            <div class="alignLeft art-text artwork" id="section-7.2.2-14.1">
+<figure id="figure-12">
+            <div class="alignLeft art-text artwork" id="section-7.2.2-17.1">
 <pre>
 # The PER in General JWS Serialization syntax
 {
@@ -3650,25 +3693,25 @@ Note that in this case the current LDevID credential is used instead of the IDev
 }
 </pre>
 </div>
-<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
+<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
 <a href="#name-representation-of-per" class="selfRef">Representation of PER</a>
             </figcaption></figure>
 </div>
-<p id="section-7.2.2-15">With the collected PVR and PER, the Registrar-Agent starts the interaction with the domain registrar.<a href="#section-7.2.2-15" class="pilcrow">¶</a></p>
-<p id="section-7.2.2-16">The new protected header field "created-on" is introduced to reflect freshness of the PER.
+<p id="section-7.2.2-18">With the collected PVR and PER, the Registrar-Agent starts the interaction with the domain registrar.<a href="#section-7.2.2-18" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-19">The new protected header field "created-on" is introduced to reflect freshness of the PER.
 The field is marked critical "crit" to ensure that it must be understood and validated by the receiver (here the domain registrar) according to <span><a href="https://rfc-editor.org/rfc/rfc7515#section-4.1.11" class="relref">Section 4.1.11</a> of [<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>.
 It allows the registrar to verify the timely correlation between the PER and previously exchanged messages, i.e., created-on of PER &gt;= created-on of PVR &gt;= created-on of PVR trigger.
-The registrar <span class="bcp14">MAY</span> consider to ignore any but the newest PER from the same pledge in the case the registrar has at any point in time more than one pending PER from the pledge.<a href="#section-7.2.2-16" class="pilcrow">¶</a></p>
-<p id="section-7.2.2-17">As the Registrar-Agent is intended to facilitate communication between the pledge and the domain registrar, a collection of requests from more than one pledge is possible.
-This allows bulk bootstrapping of several pledges using the same connection between the Registrar-Agent and the domain registrar.<a href="#section-7.2.2-17" class="pilcrow">¶</a></p>
+The registrar <span class="bcp14">MAY</span> consider to ignore any but the newest PER from the same pledge in the case the registrar has at any point in time more than one pending PER from the pledge.<a href="#section-7.2.2-19" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-20">As the Registrar-Agent is intended to facilitate communication between the pledge and the domain registrar, a collection of requests from more than one pledge is possible.
+This allows bulk bootstrapping of several pledges using the same connection between the Registrar-Agent and the domain registrar.<a href="#section-7.2.2-20" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="pvr">
 <section id="section-7.3">
-        <h3 id="name-supply-voucher-request-to-r">
-<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-supply-voucher-request-to-r" class="section-name selfRef">Supply Voucher Request to Registrar (including backend interaction)</a>
+        <h3 id="name-supply-pvr-to-registrar-inc">
+<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-supply-pvr-to-registrar-inc" class="section-name selfRef">Supply PVR to Registrar (including backend interaction)</a>
         </h3>
 <p id="section-7.3-1">Similar to BRSKI "requestvoucher" endpoint in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.2" class="relref">Section 5.2</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3-1" class="pilcrow">¶</a></p>
 <p id="section-7.3-2">The Registrar-Agent has acquired one or more PVR and PER object pairs<a href="#section-7.3-2" class="pilcrow">¶</a></p>
@@ -3684,54 +3727,54 @@ If the connection from Registrar-Agent to registrar is established, the authoriz
 This ensures that the pledge has been triggered by an authorized Registrar-Agent.<a href="#section-7.3-4" class="pilcrow">¶</a></p>
 <p id="section-7.3-5">With BRSKI-PRM, the pledge generates PVR and PER as JSON-in-JWS objects and the Registrar-Agent forwards them to the registrar.
 In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the pledge generates PVR as CMS-signed JSON and PER as PKCS#10 or PKCS#7 according to <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> and inherited by <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3-5" class="pilcrow">¶</a></p>
-<p id="section-7.3-6"><a href="#exchangesfig_uc2_3" class="auto internal xref">Figure 12</a> shows the exchanges for the Voucher Request processing and the following subsections describe the corresponding artifacts.<a href="#section-7.3-6" class="pilcrow">¶</a></p>
-<span id="name-voucher-request-processing"></span><div id="exchangesfig_uc2_3">
-<figure id="figure-12">
+<p id="section-7.3-6"><a href="#exchangesfig_uc2_3" class="auto internal xref">Figure 13</a> shows the exchanges for the Voucher Request processing and the following subsections describe the corresponding artifacts.<a href="#section-7.3-6" class="pilcrow">¶</a></p>
+<span id="name-voucher-issuing-exchange"></span><div id="exchangesfig_uc2_3">
+<figure id="figure-13">
           <div id="section-7.3-7.1">
-            <div class="alignLeft art-svg artwork" id="section-7.3-7.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="416" width="560" viewBox="0 0 560 416" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+            <div class="alignCenter art-svg artwork" id="section-7.3-7.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="416" width="576" viewBox="0 0 576 416" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 32,160 L 32,384" fill="none" stroke="black"></path>
+                <path d="M 16,160 L 16,384" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
                 <path d="M 168,160 L 168,384" fill="none" stroke="black"></path>
-                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
                 <path d="M 312,160 L 312,176" fill="none" stroke="black"></path>
                 <path d="M 312,272 L 312,384" fill="none" stroke="black"></path>
-                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 432,160 L 432,272" fill="none" stroke="black"></path>
-                <path d="M 432,368 L 432,384" fill="none" stroke="black"></path>
-                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+                <path d="M 456,160 L 456,280" fill="none" stroke="black"></path>
+                <path d="M 456,368 L 456,384" fill="none" stroke="black"></path>
                 <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-                <path d="M 536,160 L 536,304" fill="none" stroke="black"></path>
-                <path d="M 536,352 L 536,384" fill="none" stroke="black"></path>
-                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+                <path d="M 560,160 L 560,304" fill="none" stroke="black"></path>
+                <path d="M 560,352 L 560,384" fill="none" stroke="black"></path>
+                <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-                <path d="M 176,176 L 208,176" fill="none" stroke="black"></path>
-                <path d="M 264,176 L 304,176" fill="none" stroke="black"></path>
-                <path d="M 176,224 L 208,224" fill="none" stroke="black"></path>
+                <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+                <path d="M 176,176 L 216,176" fill="none" stroke="black"></path>
+                <path d="M 256,176 L 304,176" fill="none" stroke="black"></path>
+                <path d="M 176,224 L 224,224" fill="none" stroke="black"></path>
                 <path d="M 256,224 L 304,224" fill="none" stroke="black"></path>
-                <path d="M 320,288 L 400,288" fill="none" stroke="black"></path>
-                <path d="M 456,288 L 528,288" fill="none" stroke="black"></path>
-                <path d="M 320,304 L 408,304" fill="none" stroke="black"></path>
-                <path d="M 456,304 L 528,304" fill="none" stroke="black"></path>
-                <path d="M 320,352 L 392,352" fill="none" stroke="black"></path>
-                <path d="M 472,352 L 528,352" fill="none" stroke="black"></path>
-                <path d="M 176,368 L 200,368" fill="none" stroke="black"></path>
-                <path d="M 280,368 L 304,368" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="536,304 524,298.4 524,309.6" fill="black" transform="rotate(0,528,304)"></polygon>
-                <polygon class="arrowhead" points="536,288 524,282.4 524,293.6" fill="black" transform="rotate(0,528,288)"></polygon>
+                <path d="M 320,288 L 416,288" fill="none" stroke="black"></path>
+                <path d="M 456,288 L 552,288" fill="none" stroke="black"></path>
+                <path d="M 320,304 L 424,304" fill="none" stroke="black"></path>
+                <path d="M 456,304 L 552,304" fill="none" stroke="black"></path>
+                <path d="M 320,352 L 408,352" fill="none" stroke="black"></path>
+                <path d="M 472,352 L 552,352" fill="none" stroke="black"></path>
+                <path d="M 176,368 L 208,368" fill="none" stroke="black"></path>
+                <path d="M 272,368 L 304,368" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="560,304 548,298.4 548,309.6" fill="black" transform="rotate(0,552,304)"></polygon>
+                <polygon class="arrowhead" points="560,288 548,282.4 548,293.6" fill="black" transform="rotate(0,552,288)"></polygon>
                 <polygon class="arrowhead" points="328,352 316,346.4 316,357.6" fill="black" transform="rotate(180,320,352)"></polygon>
                 <polygon class="arrowhead" points="328,288 316,282.4 316,293.6" fill="black" transform="rotate(180,320,288)"></polygon>
                 <polygon class="arrowhead" points="312,224 300,218.4 300,229.6" fill="black" transform="rotate(0,304,224)"></polygon>
@@ -3740,134 +3783,136 @@ In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the pledge g
                 <polygon class="arrowhead" points="184,176 172,170.4 172,181.6" fill="black" transform="rotate(180,176,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="164" y="52">Registrar-</text>
-                  <text x="276" y="52">Domain</text>
-                  <text x="412" y="52">Domain</text>
-                  <text x="500" y="52">MASA</text>
-                  <text x="144" y="68">Agent</text>
-                  <text x="288" y="68">Registrar</text>
-                  <text x="396" y="68">CA</text>
-                  <text x="32" y="100">|</text>
+                  <text x="172" y="52">Registrar-</text>
+                  <text x="308" y="52">Domain</text>
+                  <text x="436" y="52">Domain</text>
+                  <text x="540" y="52">MASA</text>
+                  <text x="168" y="68">Agent</text>
+                  <text x="312" y="68">Registrar</text>
+                  <text x="436" y="68">CA</text>
+                  <text x="16" y="100">|</text>
                   <text x="168" y="100">|</text>
                   <text x="312" y="100">|</text>
-                  <text x="432" y="100">|</text>
-                  <text x="492" y="100">Internet</text>
-                  <text x="536" y="100">|</text>
-                  <text x="32" y="116">~</text>
+                  <text x="456" y="100">|</text>
+                  <text x="516" y="100">Internet</text>
+                  <text x="560" y="100">|</text>
+                  <text x="16" y="116">~</text>
                   <text x="168" y="116">~</text>
                   <text x="312" y="116">~</text>
-                  <text x="432" y="116">~</text>
-                  <text x="536" y="116">~</text>
-                  <text x="40" y="132">(3)</text>
-                  <text x="84" y="132">Supply</text>
-                  <text x="128" y="132">PVR</text>
-                  <text x="156" y="132">to</text>
-                  <text x="208" y="132">Registrar</text>
-                  <text x="292" y="132">(including</text>
-                  <text x="368" y="132">backend</text>
-                  <text x="452" y="132">interaction)</text>
-                  <text x="32" y="148">~</text>
+                  <text x="456" y="116">~</text>
+                  <text x="560" y="116">~</text>
+                  <text x="16" y="132">(3)</text>
+                  <text x="60" y="132">Supply</text>
+                  <text x="104" y="132">PVR</text>
+                  <text x="132" y="132">to</text>
+                  <text x="184" y="132">Registrar</text>
+                  <text x="268" y="132">(including</text>
+                  <text x="344" y="132">backend</text>
+                  <text x="428" y="132">interaction)</text>
+                  <text x="16" y="148">~</text>
                   <text x="168" y="148">~</text>
                   <text x="312" y="148">~</text>
-                  <text x="432" y="148">~</text>
-                  <text x="536" y="148">~</text>
+                  <text x="456" y="148">~</text>
+                  <text x="560" y="148">~</text>
                   <text x="236" y="180">mTLS</text>
                   <text x="308" y="196">[Registrar-Agent</text>
                   <text x="308" y="212">authenticated&amp;authorized?]</text>
-                  <text x="232" y="228">PVR</text>
+                  <text x="240" y="228">PVR</text>
                   <text x="312" y="228">|</text>
-                  <text x="272" y="244">[accept</text>
-                  <text x="340" y="244">device?]</text>
-                  <text x="276" y="260">[contact</text>
-                  <text x="344" y="260">vendor]</text>
-                  <text x="428" y="292">mTLS</text>
-                  <text x="432" y="308">RVR</text>
-                  <text x="436" y="324">[extract</text>
-                  <text x="512" y="324">DomainID]</text>
-                  <text x="432" y="340">[update</text>
-                  <text x="488" y="340">audit</text>
-                  <text x="532" y="340">log]</text>
-                  <text x="432" y="356">Voucher</text>
+                  <text x="280" y="244">[accept</text>
+                  <text x="348" y="244">device?]</text>
+                  <text x="284" y="260">[contact</text>
+                  <text x="352" y="260">vendor]</text>
+                  <text x="436" y="292">mTLS</text>
+                  <text x="440" y="308">RVR</text>
+                  <text x="460" y="324">[extract</text>
+                  <text x="536" y="324">DomainID]</text>
+                  <text x="456" y="340">[update</text>
+                  <text x="512" y="340">audit</text>
+                  <text x="556" y="340">log]</text>
+                  <text x="440" y="356">Voucher</text>
                   <text x="240" y="372">Voucher</text>
-                  <text x="32" y="404">~</text>
+                  <text x="16" y="404">~</text>
                   <text x="168" y="404">~</text>
                   <text x="312" y="404">~</text>
-                  <text x="432" y="404">~</text>
-                  <text x="536" y="404">~</text>
+                  <text x="456" y="404">~</text>
+                  <text x="560" y="404">~</text>
                 </g>
               </svg><a href="#section-7.3-7.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
-<a href="#name-voucher-request-processing" class="selfRef">Voucher Request processing</a>
+<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
+<a href="#name-voucher-issuing-exchange" class="selfRef">Voucher issuing exchange</a>
           </figcaption></figure>
 </div>
-<div id="request-artifact-pvr">
+<div id="request-artifact-pledge-voucher-request-pvr">
 <section id="section-7.3.1">
-          <h4 id="name-request-artifact-pvr">
-<a href="#section-7.3.1" class="section-number selfRef">7.3.1. </a><a href="#name-request-artifact-pvr" class="section-name selfRef">Request Artifact: PVR</a>
+          <h4 id="name-request-artifact-pledge-vouc">
+<a href="#section-7.3.1" class="section-number selfRef">7.3.1. </a><a href="#name-request-artifact-pledge-vouc" class="section-name selfRef">Request Artifact: Pledge Voucher-Request (PVR)</a>
           </h4>
 <p id="section-7.3.1-1">For BRSKI-PRM, the Registrar-Agent sends the PVR by HTTP POST to the same registrar endpoint as introduced by BRSKI: "/.well-
 known/brski/requestvoucher", but with a Content-Type header field for JSON-in-JWS"<a href="#section-7.3.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.3.1-2">The Content-Type header field for JSON-in-JWS PVR is: <code>application/voucher-jws+json</code> (see <a href="#tpvr" class="auto internal xref">Section 7.1</a> for the content definition), as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.1-2" class="pilcrow">¶</a></p>
-<p id="section-7.3.1-3">The Registrar-Agent sets the Accept field in the request-header indicating the acceptable Content-Type for the voucher-response.
-The voucher-response Content-Type header field is set to <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.1-3" class="pilcrow">¶</a></p>
+<p id="section-7.3.1-3">The Registrar-Agent sets the Accept field in the request-header indicating the acceptable Content-Type for the Voucher.<a href="#section-7.3.1-3" class="pilcrow">¶</a></p>
+<p id="section-7.3.1-4">The voucher-response Content-Type header field is set to <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.1-4" class="pilcrow">¶</a></p>
+<p id="section-7.3.1-5">TODO: conflict with content negotiation (Accept). So you mean "by default"?<a href="#section-7.3.1-5" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="rvr-proc">
 <section id="section-7.3.2">
-          <h4 id="name-registrar-voucher-request-r">
-<a href="#section-7.3.2" class="section-number selfRef">7.3.2. </a><a href="#name-registrar-voucher-request-r" class="section-name selfRef">Registrar Voucher-Request (RVR) Processing (Registrar to MASA)</a>
+          <h4 id="name-supply-rvr-to-masa-backend-">
+<a href="#section-7.3.2" class="section-number selfRef">7.3.2. </a><a href="#name-supply-rvr-to-masa-backend-" class="section-name selfRef">Supply RVR to MASA (backend interaction)</a>
           </h4>
-<p id="section-7.3.2-1">If the MASA address/URI is learned from the IDevID MASA URI extension (<span><a href="https://rfc-editor.org/rfc/rfc8995#section-2.3" class="relref">Section 2.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>), then the MASA on that URI <span class="bcp14">MUST</span> support the procedures defined in this document if the PVR used JSON-JWS encoding.
-If the MASA is only configured on the registrar, then a registrar supporting BRKSI-PRM and other voucher encoding formats (such as those in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>) <span class="bcp14">SHOULD</span> support per-message-format MASA address/URI configuration for the same IDevID trust anchor."<a href="#section-7.3.2-1" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-2">The registrar <span class="bcp14">SHALL</span> construct the payload of the RVR as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, Section 5.5.
-The RVR encoding <span class="bcp14">SHALL</span> be JSON-in-JWS as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.2-2" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-3">The header of the RVR <span class="bcp14">SHALL</span> contain the following parameter as defined for JWS <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>:<a href="#section-7.3.2-3" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-1">The registrar needs to convert the PVR to an RVR and supply it to the MASA.<a href="#section-7.3.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-2">If the MASA address/URI is learned from the IDevID MASA URI extension (<span><a href="https://rfc-editor.org/rfc/rfc8995#section-2.3" class="relref">Section 2.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>), then the MASA on that URI <span class="bcp14">MUST</span> support the procedures defined in this document if the PVR used JSON-JWS encoding.
+If the MASA is only configured on the registrar, then a registrar supporting BRKSI-PRM and other voucher encoding formats (such as those in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>) <span class="bcp14">SHOULD</span> support per-message-format MASA address/URI configuration for the same IDevID trust anchor."<a href="#section-7.3.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-3">The registrar <span class="bcp14">SHALL</span> construct the payload of the RVR as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, Section 5.5.
+The RVR encoding <span class="bcp14">SHALL</span> be JSON-in-JWS as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.2-3" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-4">The header of the RVR <span class="bcp14">SHALL</span> contain the following parameter as defined for JWS <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>:<a href="#section-7.3.2-4" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-7.3.2-4.1">
-              <p id="section-7.3.2-4.1.1">alg: algorithm used to create the object signature<a href="#section-7.3.2-4.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.3.2-5.1">
+              <p id="section-7.3.2-5.1.1">alg: algorithm used to create the object signature<a href="#section-7.3.2-5.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.3.2-4.2">
-              <p id="section-7.3.2-4.2.1">x5c: base64-encoded registrar LDevID certificate(s)
-(It optionally contains the certificate chain for this certificate)<a href="#section-7.3.2-4.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.3.2-5.2">
+              <p id="section-7.3.2-5.2.1">x5c: base64-encoded registrar LDevID certificate(s)
+(It optionally contains the certificate chain for this certificate)<a href="#section-7.3.2-5.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.3.2-5">The payload of the RVR <span class="bcp14">MUST</span> contain the following parameter as part of the voucher-request as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>:<a href="#section-7.3.2-5" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-6">The payload of the RVR <span class="bcp14">MUST</span> contain the following parameter as part of the voucher-request as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>:<a href="#section-7.3.2-6" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-7.3.2-6.1">
-              <p id="section-7.3.2-6.1.1">created-on: current date and time in yang:date-and-time format of RVR creation<a href="#section-7.3.2-6.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.3.2-7.1">
+              <p id="section-7.3.2-7.1.1">created-on: current date and time in yang:date-and-time format of RVR creation<a href="#section-7.3.2-7.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.3.2-6.2">
-              <p id="section-7.3.2-6.2.1">nonce: copied from the PVR<a href="#section-7.3.2-6.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.3.2-7.2">
+              <p id="section-7.3.2-7.2.1">nonce: copied from the PVR<a href="#section-7.3.2-7.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.3.2-6.3">
-              <p id="section-7.3.2-6.3.1">serial-number: product-serial-number of pledge.
+            <li class="normal" id="section-7.3.2-7.3">
+              <p id="section-7.3.2-7.3.1">serial-number: product-serial-number of pledge.
 The registrar <span class="bcp14">MUST</span> verify that the IDevID certificate subject serialNumber of the pledge (X520SerialNumber) matches the serial-number value in the PVR.
-In addition, it <span class="bcp14">MUST</span> be equal to the serial-number value contained in the agent-signed data of PVR.<a href="#section-7.3.2-6.3.1" class="pilcrow">¶</a></p>
+In addition, it <span class="bcp14">MUST</span> be equal to the serial-number value contained in the agent-signed data of PVR.<a href="#section-7.3.2-7.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.3.2-6.4">
-              <p id="section-7.3.2-6.4.1">assertion: voucher assertion requested by the pledge (agent-proximity).
-The registrar provides this information to assure successful verification of Registrar-Agent proximity based on the agent-signed-data.<a href="#section-7.3.2-6.4.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.3.2-7.4">
+              <p id="section-7.3.2-7.4.1">assertion: voucher assertion requested by the pledge (agent-proximity).
+The registrar provides this information to assure successful verification of Registrar-Agent proximity based on the agent-signed-data.<a href="#section-7.3.2-7.4.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.3.2-6.5">
-              <p id="section-7.3.2-6.5.1">prior-signed-voucher-request: PVR as received from Registrar-Agent, see <a href="#tpvr" class="auto internal xref">Section 7.1</a><a href="#section-7.3.2-6.5.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.3.2-7.5">
+              <p id="section-7.3.2-7.5.1">prior-signed-voucher-request: PVR as received from Registrar-Agent, see <a href="#tpvr" class="auto internal xref">Section 7.1</a><a href="#section-7.3.2-7.5.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.3.2-7">The RVR <span class="bcp14">MUST</span> be extended with the following parameter, when the assertion "agent-proximity" is requested, as defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>:<a href="#section-7.3.2-7" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-8">The RVR <span class="bcp14">MUST</span> be extended with the following parameter, when the assertion "agent-proximity" is requested, as defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>:<a href="#section-7.3.2-8" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-7.3.2-8.1">
-              <p id="section-7.3.2-8.1.1">agent-sign-cert: EE (RegAgt) certificate or the EE (RegAgt) certificate including certificate chain.
+<li class="normal" id="section-7.3.2-9.1">
+              <p id="section-7.3.2-9.1.1">agent-sign-cert: EE (RegAgt) certificate or the EE (RegAgt) certificate including certificate chain.
 In the context of this document it is a JSON array of base64encoded certificate information and handled in the same way as x5c header objects.
 If only a single object is contained in the x5c it <span class="bcp14">MUST</span> be the base64-encoded EE (RegAgt) certificate.
-If multiple certificates are included in the x5c, the first <span class="bcp14">MUST</span> be the base64-encoded EE (RegAgt) certificate.<a href="#section-7.3.2-8.1.1" class="pilcrow">¶</a></p>
+If multiple certificates are included in the x5c, the first <span class="bcp14">MUST</span> be the base64-encoded EE (RegAgt) certificate.<a href="#section-7.3.2-9.1.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.3.2-9">The MASA uses this information for verification that the Registrar-Agent is in proximity to the registrar to state the corresponding assertion "agent-proximity".<a href="#section-7.3.2-9" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-10">The object is signed using the registrar LDevID credentials, which corresponds to the certificate referenced in the JOSE header.<a href="#section-7.3.2-10" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-10">The MASA uses this information for verification that the Registrar-Agent is in proximity to the registrar to state the corresponding assertion "agent-proximity".<a href="#section-7.3.2-10" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-11">The object is signed using the registrar LDevID credentials, which corresponds to the certificate referenced in the JOSE header.<a href="#section-7.3.2-11" class="pilcrow">¶</a></p>
 <span id="name-representation-of-rvr"></span><div id="rvr">
-<figure id="figure-13">
-            <div class="alignLeft art-text artwork" id="section-7.3.2-11.1">
+<figure id="figure-14">
+            <div class="alignLeft art-text artwork" id="section-7.3.2-12.1">
 <pre>
 # The RVR in General JWS Serialization syntax
 {
@@ -3907,66 +3952,66 @@ If multiple certificates are included in the x5c, the first <span class="bcp14">
 }
 </pre>
 </div>
-<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
+<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
 <a href="#name-representation-of-rvr" class="selfRef">Representation of RVR</a>
             </figcaption></figure>
 </div>
-<p id="section-7.3.2-12">The registrar <span class="bcp14">SHALL</span> send the RVR to the MASA endpoint by HTTP POST: "/.well-known/brski/requestvoucher"<a href="#section-7.3.2-12" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-13">The RVR Content-Type header field is defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span> as: <code>application/voucher-jws+json</code><a href="#section-7.3.2-13" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-14">The registrar <span class="bcp14">SHOULD</span> set the Accept header of the RVR indicating the desired media type for the voucher-response.
-The media type is <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.2-14" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-15">This document uses the JSON-in-JWS format throughout the definition of exchanges and in the examples.
+<p id="section-7.3.2-13">The registrar <span class="bcp14">SHALL</span> send the RVR to the MASA endpoint by HTTP POST: "/.well-known/brski/requestvoucher"<a href="#section-7.3.2-13" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-14">The RVR Content-Type header field is defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span> as: <code>application/voucher-jws+json</code><a href="#section-7.3.2-14" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-15">The registrar <span class="bcp14">SHOULD</span> set the Accept header of the RVR indicating the desired media type for the voucher-response.
+The media type is <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.2-15" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-16">This document uses the JSON-in-JWS format throughout the definition of exchanges and in the examples.
 Nevertheless, alternative encodings of the voucher as used in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with JSON-in-CMS or CBOR-in-COSE_Sign <span>[<a href="#RFC9052" class="cite xref">RFC9052</a>]</span> for constraint environments are possible as well.
 The assumption is that a pledge typically supports a single encoding variant and creates the PVR in the supported format.
-To ensure that the pledge is able to process the voucher, the registrar <span class="bcp14">MUST</span> use the media type for Accept header in the RVR based on the media type used for the PVR.<a href="#section-7.3.2-15" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-16">Once the MASA receives the RVR it <span class="bcp14">SHALL</span> perform the verification as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.5" class="relref">Section 5.5</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3.2-16" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-17">In addition, the following processing <span class="bcp14">SHALL</span> be performed for PVR contained in RVR "prior-signed-voucher-request" field:<a href="#section-7.3.2-17" class="pilcrow">¶</a></p>
+To ensure that the pledge is able to process the voucher, the registrar <span class="bcp14">MUST</span> use the media type for Accept header in the RVR based on the media type used for the PVR.<a href="#section-7.3.2-16" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-17">Once the MASA receives the RVR it <span class="bcp14">SHALL</span> perform the verification as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.5" class="relref">Section 5.5</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3.2-17" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-18">In addition, the following processing <span class="bcp14">SHALL</span> be performed for PVR contained in RVR "prior-signed-voucher-request" field:<a href="#section-7.3.2-18" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-7.3.2-18.1">
-              <p id="section-7.3.2-18.1.1">agent-provided-proximity-registrar-cert: The MASA <span class="bcp14">MAY</span> verify that this field contains the registrar LDevID certificate.
+<li class="normal" id="section-7.3.2-19.1">
+              <p id="section-7.3.2-19.1.1">agent-provided-proximity-registrar-cert: The MASA <span class="bcp14">MAY</span> verify that this field contains the registrar LDevID certificate.
 If so, it <span class="bcp14">MUST</span> correspond to the registrar LDevID credentials used to sign the RVR.
-Note: Correspond here relates to the case that a single registrar LDevID certificate is used or that different registrar LDevID certificates are used, which are issued by the same CA.<a href="#section-7.3.2-18.1.1" class="pilcrow">¶</a></p>
+Note: Correspond here relates to the case that a single registrar LDevID certificate is used or that different registrar LDevID certificates are used, which are issued by the same CA.<a href="#section-7.3.2-19.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.3.2-18.2">
-              <p id="section-7.3.2-18.2.1">agent-signed-data: The MASA <span class="bcp14">MAY</span> verify this data to issue "agent-proximity" assertion.
+            <li class="normal" id="section-7.3.2-19.2">
+              <p id="section-7.3.2-19.2.1">agent-signed-data: The MASA <span class="bcp14">MAY</span> verify this data to issue "agent-proximity" assertion.
 If so, the agent-signed-data <span class="bcp14">MUST</span> contain the pledge product-serial-number, contained in the "serial-number" field of the PVR (from "prior-signed-voucher-request" field) and also in "serial-number" field of the RVR.
 The EE (RegAgt) certificate to be used for signature verification is identified by the "kid" parameter of the JOSE header.
 If the assertion "agent-proximity" is requested, the RVR <span class="bcp14">MUST</span> contain the corresponding EE (RegAgt) certificate data in the "agent-sign-cert" field of the RVR.
 It <span class="bcp14">MUST</span> be verified by the MASA to the same domain CA as the registrar LDevID certificate.
 If the "agent-sign-cert" field is not set, the MASA <span class="bcp14">MAY</span> state a lower level assertion value, e.g.: "logged" or "verified".
 Note: Sub-CA certificate(s) <span class="bcp14">MUST</span> also be carried by "agent-sign-cert", in case the EE (RegAgt) certificate is issued by a sub-CA and not the domain CA known to the MASA.
-As the "agent-sign-cert" field is defined as array (x5c), it can handle multiple certificates.<a href="#section-7.3.2-18.2.1" class="pilcrow">¶</a></p>
+As the "agent-sign-cert" field is defined as array (x5c), it can handle multiple certificates.<a href="#section-7.3.2-19.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.3.2-19">If validation fails, the MASA <span class="bcp14">SHOULD</span> respond with an HTTP 4xx client error status code to the registrar.
-The HTTP error status codes are kept the same as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> and comprise the codes: 403, 404, 406, and 415.<a href="#section-7.3.2-19" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-20">The registrar provides the EE certificate of the Registrar-Agent identified by the SubjectKeyIdentifier (SKID) in the header of the "agent-signed-data" from the PVR in its RVR (see also <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a>).<a href="#section-7.3.2-20" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-21">The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-certificate" leaf and may assert the PVR as "verified" or "logged".<a href="#section-7.3.2-21" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-22">In addition, the MASA may issue the assertion "agent-proximity" as follows:
+<p id="section-7.3.2-20">If validation fails, the MASA <span class="bcp14">SHOULD</span> respond with an HTTP 4xx client error status code to the registrar.
+The HTTP error status codes are kept the same as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> and comprise the codes: 403, 404, 406, and 415.<a href="#section-7.3.2-20" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-21">The registrar provides the EE certificate of the Registrar-Agent identified by the SubjectKeyIdentifier (SKID) in the header of the "agent-signed-data" from the PVR in its RVR (see also <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a>).<a href="#section-7.3.2-21" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-22">The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-cert" leaf and may assert the PVR as "verified" or "logged".<a href="#section-7.3.2-22" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-23">In addition, the MASA may issue the assertion "agent-proximity" as follows:
 The MASA verifies the signature of the "agent-signed-data" contained in the "prior-signed-voucher-request", based on the provided EE certificate of the Registrar-Agent in the "agent-sign-cert" leaf of the RVR.
 If both can be verified successfully, the MASA can assert "agent-proximity" in the voucher.
 The assertion of "agent-proximity" is similar to the proximity assertion by the MASA when using BRSKI.
-Note that the different assertions do not provide a metric of strength as the security properties are not comparable.<a href="#section-7.3.2-22" class="pilcrow">¶</a></p>
-<p id="section-7.3.2-23">Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx response status codes as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-When successful, the Voucher will then be supplied via the registrar to the Registrar-Agent.<a href="#section-7.3.2-23" class="pilcrow">¶</a></p>
+Note that the different assertions do not provide a metric of strength as the security properties are not comparable.<a href="#section-7.3.2-23" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-24">Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx response status codes as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+When successful, the Voucher will then be supplied via the registrar to the Registrar-Agent.<a href="#section-7.3.2-24" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="exchanges_uc2_2_vc">
 <section id="section-7.3.3">
-          <h4 id="name-voucher-issuance-by-masa">
-<a href="#section-7.3.3" class="section-number selfRef">7.3.3. </a><a href="#name-voucher-issuance-by-masa" class="section-name selfRef">Voucher Issuance by MASA</a>
+          <h4 id="name-issue-voucher-by-masa-backe">
+<a href="#section-7.3.3" class="section-number selfRef">7.3.3. </a><a href="#name-issue-voucher-by-masa-backe" class="section-name selfRef">Issue Voucher by MASA (backend interaction)</a>
           </h4>
 <p id="section-7.3.3-1">The MASA creates a voucher with Media-Type of <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
 If the MASA detects that the Accept header of the PVR does not match <code>application/voucher-jws+json</code> it <span class="bcp14">SHOULD</span> respond with the HTTP status code "406 Not Acceptable" as the pledge will not be able to parse the response.
 The voucher is according to <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> but uses the new assertion value specified <a href="#agt_prx" class="auto internal xref">Section 5.4</a>.<a href="#section-7.3.3-1" class="pilcrow">¶</a></p>
-<p id="section-7.3.3-2"><a href="#MASA-vr" class="auto internal xref">Figure 14</a> shows an example of the contents of a voucher.<a href="#section-7.3.3-2" class="pilcrow">¶</a></p>
+<p id="section-7.3.3-2"><a href="#MASA-vr" class="auto internal xref">Figure 15</a> shows an example of the contents of a voucher.<a href="#section-7.3.3-2" class="pilcrow">¶</a></p>
 <span id="name-representation-of-masa-issu"></span><div id="MASA-vr">
-<figure id="figure-14">
+<figure id="figure-15">
             <div class="alignLeft art-text artwork" id="section-7.3.3-3.1">
 <pre>
 # The MASA issued voucher in General JWS Serialization syntax
 {
-  "payload": BASE64URL(ietf-voucher:voucher),
+  "payload": BASE64URL(UTF8(ietf-voucher:voucher)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -3997,7 +4042,7 @@ The voucher is according to <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="c
 }
 </pre>
 </div>
-<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
+<figcaption><a href="#figure-15" class="selfRef">Figure 15</a>:
 <a href="#name-representation-of-masa-issu" class="selfRef">Representation of MASA issued voucher</a>
             </figcaption></figure>
 </div>
@@ -4007,8 +4052,8 @@ The MASA returns the voucher-response (voucher) to the registrar.<a href="#secti
 </div>
 <div id="exchanges_uc2_2_vs">
 <section id="section-7.3.4">
-          <h4 id="name-masa-issued-voucher-process">
-<a href="#section-7.3.4" class="section-number selfRef">7.3.4. </a><a href="#name-masa-issued-voucher-process" class="section-name selfRef">MASA issued Voucher Processing by Registrar</a>
+          <h4 id="name-supply-voucher-to-registrar">
+<a href="#section-7.3.4" class="section-number selfRef">7.3.4. </a><a href="#name-supply-voucher-to-registrar" class="section-name selfRef">Supply Voucher to Registrar (backend interaction)</a>
           </h4>
 <p id="section-7.3.4-1">After receiving the voucher the registrar <span class="bcp14">SHOULD</span> evaluate it for transparency and logging purposes as outlined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 The registrar <span class="bcp14">MUST</span> add an additional signature to the MASA provided voucher using its registrar EE credentials.<a href="#section-7.3.4-1" class="pilcrow">¶</a></p>
@@ -4019,14 +4064,14 @@ The pinned domain certificate is already contained in the voucher payload ("pinn
 <p id="section-7.3.4-4">In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the Registrar proved possession of the it's credential when the TLS session was setup.
 While the pledge could not, at the time, validate the certificate truly belonged the registrar, it did validate that the certificate it was provided was able to authenticate the TLS connection.<a href="#section-7.3.4-4" class="pilcrow">¶</a></p>
 <p id="section-7.3.4-5">In the BRSKI-PRM mode, with the Registrar-Agent mediating all communication, the Pledge has not as yet been able to witness that the intended Registrar really does possess the relevant private key.
-This second signature provides for the same level of assurance to the pledge, and that it matches the public key that the pledge received in the trigger for the PVR (see <a href="#pavrt" class="auto internal xref">Figure 6</a>).<a href="#section-7.3.4-5" class="pilcrow">¶</a></p>
+This second signature provides for the same level of assurance to the pledge, and that it matches the public key that the pledge received in the trigger for the PVR (see <a href="#pavrt" class="auto internal xref">Figure 9</a>).<a href="#section-7.3.4-5" class="pilcrow">¶</a></p>
 <p id="section-7.3.4-6">The registrar <span class="bcp14">MUST</span> use the same registrar EE credentials used for authentication in the TLS handshake to authenticate towards the Registrar-Agent.
 This has some operational implications when the registrar may be part of a scalable framework as described in <span>[<a href="#I-D.richardson-anima-registrar-considerations" class="cite xref">I-D.richardson-anima-registrar-considerations</a>], <a href="https://datatracker.ietf.org/doc/html/draft-richardson-anima-registrar-considerations-08#section-1.3.1" class="relref">Section 1.3.1</a></span>.<a href="#section-7.3.4-6" class="pilcrow">¶</a></p>
 <p id="section-7.3.4-7">The second signature <span class="bcp14">MUST</span> either be done with the private key associated with the registrar EE certificate provided to the Registrar-Agent, or the use of a certificate chain is necessary.
 This ensures that the same registrar EE certificate can be used to verify the signature as transmitted in the voucher-request as also transferred in the PVR in the "agent-provided-proximity-registrar-cert".<a href="#section-7.3.4-7" class="pilcrow">¶</a></p>
-<p id="section-7.3.4-8"><a href="#MASA-REG-vr" class="auto internal xref">Figure 15</a> below provides an example of the voucher with two signatures.<a href="#section-7.3.4-8" class="pilcrow">¶</a></p>
+<p id="section-7.3.4-8"><a href="#MASA-REG-vr" class="auto internal xref">Figure 16</a> below provides an example of the voucher with two signatures.<a href="#section-7.3.4-8" class="pilcrow">¶</a></p>
 <span id="name-representation-of-masa-issue"></span><div id="MASA-REG-vr">
-<figure id="figure-15">
+<figure id="figure-16">
             <div class="alignLeft art-text artwork" id="section-7.3.4-9.1">
 <pre>
 # The MASA issued voucher with additional registrar signature in
@@ -4077,7 +4122,7 @@ This ensures that the same registrar EE certificate can be used to verify the si
 }
 </pre>
 </div>
-<figcaption><a href="#figure-15" class="selfRef">Figure 15</a>:
+<figcaption><a href="#figure-16" class="selfRef">Figure 16</a>:
 <a href="#name-representation-of-masa-issue" class="selfRef">Representation of MASA issued voucher with additional registrar signature</a>
             </figcaption></figure>
 </div>
@@ -4106,20 +4151,23 @@ This requires, that the registrar has access to the EE (RegAgt) certificate data
 Note, the registrar may have stored the EE (RegAgt) certificate if used during TLS establishment between Registrar-Agent and registrar or it may be provided via a repository.<a href="#section-7.3.5-2.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.3.5-3">If the registrar is unable to validate the PVR it <span class="bcp14">SHOULD</span> respond with a HTTP 4xx/5xx error code to the Registrar-Agent.<a href="#section-7.3.5-3" class="pilcrow">¶</a></p>
+<p id="section-7.3.5-3">If the registrar is unable to validate the PVR, it <span class="bcp14">SHOULD</span> respond with a HTTP 4xx/5xx error code to the Registrar-Agent.<a href="#section-7.3.5-3" class="pilcrow">¶</a></p>
 <p id="section-7.3.5-4">The following 4xx client error codes <span class="bcp14">SHOULD</span> be used:<a href="#section-7.3.5-4" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.3.5-5.1">
               <p id="section-7.3.5-5.1.1">403 Forbidden: if the registrar detected that one or more security related parameters are not valid.<a href="#section-7.3.5-5.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.3.5-5.2">
-              <p id="section-7.3.5-5.2.1">404 Not Found status code if the pledge provided information could not be used with automated allowance, as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.3" class="relref">Section 5.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3.5-5.2.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-7.3.5-5.3">
-              <p id="section-7.3.5-5.3.1">406 Not Acceptable: if the Content-Type indicated by the Accept header is unknown or unsupported.<a href="#section-7.3.5-5.3.1" class="pilcrow">¶</a></p>
+              <p id="section-7.3.5-5.2.1">404 Not Found: if the pledge provided information could not be used with automated allowance, as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.3" class="relref">Section 5.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3.5-5.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.3.5-6">If the validation succeeds, the registrar performs pledge authorization according to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.3" class="relref">Section 5.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> followed by obtaining a voucher from the pledge's MASA according to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.4" class="relref">Section 5.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with the modifications described below in <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a>.<a href="#section-7.3.5-6" class="pilcrow">¶</a></p>
+<p id="section-7.3.5-6">TODO: From EST or BRSKI? Otherwise should be 422 Unprocessable Content, as the resource endpoint must exist and cannot be 404.<a href="#section-7.3.5-6" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7.3.5-7.1">
+              <p id="section-7.3.5-7.1.1">406 Not Acceptable: if the Content-Type indicated by the Accept header is unknown or unsupported.<a href="#section-7.3.5-7.1.1" class="pilcrow">¶</a></p>
+</li>
+          </ul>
+<p id="section-7.3.5-8">If the validation succeeds, the registrar performs pledge authorization according to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.3" class="relref">Section 5.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> followed by obtaining a voucher from the pledge's MASA according to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.4" class="relref">Section 5.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with the modifications described below in <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a>.<a href="#section-7.3.5-8" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -4132,49 +4180,52 @@ Note, the registrar may have stored the EE (RegAgt) certificate if used during T
 <p id="section-7.4-1">After receiving the voucher, the Registrar-Agent sends the PER to the registrar in the same HTTP-over-TLS connection. Which is similar to the PER processing described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.2" class="relref">Section 5.2</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 In case the PER cannot be send in the same HTTP-over-TLS connection the Registrar-Agent may send the PER in a new HTTP-over-TLS connection. The registrar is able to correlate the PVR and the PER based on the signatures and the contained product-serial-number information.
 Note, this also addresses situations in which a nonceless voucher is used and may be pre-provisioned to the pledge.<a href="#section-7.4-1" class="pilcrow">¶</a></p>
-<p id="section-7.4-2"><a href="#exchangesfig_uc2_4" class="auto internal xref">Figure 16</a> depicts exchanges for the PER request handling and the following subsections describe the corresponding artifacts.<a href="#section-7.4-2" class="pilcrow">¶</a></p>
-<span id="name-pledge-enroll-request-proce"></span><div id="exchangesfig_uc2_4">
-<figure id="figure-16">
+<p id="section-7.4-2"><a href="#exchangesfig_uc2_4" class="auto internal xref">Figure 17</a> depicts exchanges for the PER request handling and the following subsections describe the corresponding artifacts.<a href="#section-7.4-2" class="pilcrow">¶</a></p>
+<span id="name-enroll-exchange"></span><div id="exchangesfig_uc2_4">
+<figure id="figure-17">
           <div id="section-7.4-3.1">
-            <div class="alignLeft art-svg artwork" id="section-7.4-3.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="304" width="560" viewBox="0 0 560 304" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+            <div class="alignCenter art-svg artwork" id="section-7.4-3.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="304" width="576" viewBox="0 0 576 304" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 32,160 L 32,272" fill="none" stroke="black"></path>
+                <path d="M 16,160 L 16,272" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
                 <path d="M 168,160 L 168,272" fill="none" stroke="black"></path>
-                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
                 <path d="M 312,160 L 312,272" fill="none" stroke="black"></path>
-                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 432,160 L 432,272" fill="none" stroke="black"></path>
-                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+                <path d="M 456,160 L 456,272" fill="none" stroke="black"></path>
                 <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-                <path d="M 536,160 L 536,272" fill="none" stroke="black"></path>
-                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+                <path d="M 560,160 L 560,272" fill="none" stroke="black"></path>
+                <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-                <path d="M 176,176 L 208,176" fill="none" stroke="black"></path>
-                <path d="M 264,176 L 304,176" fill="none" stroke="black"></path>
-                <path d="M 176,192 L 208,192" fill="none" stroke="black"></path>
+                <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+                <path d="M 176,176 L 216,176" fill="none" stroke="black"></path>
+                <path d="M 256,176 L 304,176" fill="none" stroke="black"></path>
+                <path d="M 176,192 L 224,192" fill="none" stroke="black"></path>
                 <path d="M 256,192 L 304,192" fill="none" stroke="black"></path>
-                <path d="M 320,208 L 344,208" fill="none" stroke="black"></path>
-                <path d="M 400,208 L 424,208" fill="none" stroke="black"></path>
-                <path d="M 320,224 L 344,224" fill="none" stroke="black"></path>
-                <path d="M 392,224 L 424,224" fill="none" stroke="black"></path>
+                <path d="M 320,208 L 360,208" fill="none" stroke="black"></path>
+                <path d="M 400,208 L 448,208" fill="none" stroke="black"></path>
+                <path d="M 320,224 L 368,224" fill="none" stroke="black"></path>
+                <path d="M 400,224 L 448,224" fill="none" stroke="black"></path>
+                <path d="M 320,240 L 336,240" fill="none" stroke="black"></path>
+                <path d="M 432,240 L 448,240" fill="none" stroke="black"></path>
                 <path d="M 176,256 L 192,256" fill="none" stroke="black"></path>
                 <path d="M 288,256 L 304,256" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="432,224 420,218.4 420,229.6" fill="black" transform="rotate(0,424,224)"></polygon>
-                <polygon class="arrowhead" points="432,208 420,202.4 420,213.6" fill="black" transform="rotate(0,424,208)"></polygon>
+                <polygon class="arrowhead" points="456,224 444,218.4 444,229.6" fill="black" transform="rotate(0,448,224)"></polygon>
+                <polygon class="arrowhead" points="456,208 444,202.4 444,213.6" fill="black" transform="rotate(0,448,208)"></polygon>
+                <polygon class="arrowhead" points="328,240 316,234.4 316,245.6" fill="black" transform="rotate(180,320,240)"></polygon>
                 <polygon class="arrowhead" points="328,208 316,202.4 316,213.6" fill="black" transform="rotate(180,320,208)"></polygon>
                 <polygon class="arrowhead" points="312,192 300,186.4 300,197.6" fill="black" transform="rotate(0,304,192)"></polygon>
                 <polygon class="arrowhead" points="312,176 300,170.4 300,181.6" fill="black" transform="rotate(0,304,176)"></polygon>
@@ -4182,65 +4233,64 @@ Note, this also addresses situations in which a nonceless voucher is used and ma
                 <polygon class="arrowhead" points="184,176 172,170.4 172,181.6" fill="black" transform="rotate(180,176,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="164" y="52">Registrar-</text>
-                  <text x="276" y="52">Domain</text>
-                  <text x="412" y="52">Domain</text>
-                  <text x="500" y="52">MASA</text>
-                  <text x="144" y="68">Agent</text>
-                  <text x="288" y="68">Registrar</text>
-                  <text x="396" y="68">CA</text>
-                  <text x="32" y="100">|</text>
+                  <text x="172" y="52">Registrar-</text>
+                  <text x="308" y="52">Domain</text>
+                  <text x="436" y="52">Domain</text>
+                  <text x="540" y="52">MASA</text>
+                  <text x="168" y="68">Agent</text>
+                  <text x="312" y="68">Registrar</text>
+                  <text x="436" y="68">CA</text>
+                  <text x="16" y="100">|</text>
                   <text x="168" y="100">|</text>
                   <text x="312" y="100">|</text>
-                  <text x="432" y="100">|</text>
-                  <text x="492" y="100">Internet</text>
-                  <text x="536" y="100">|</text>
-                  <text x="32" y="116">~</text>
+                  <text x="456" y="100">|</text>
+                  <text x="516" y="100">Internet</text>
+                  <text x="560" y="100">|</text>
+                  <text x="16" y="116">~</text>
                   <text x="168" y="116">~</text>
                   <text x="312" y="116">~</text>
-                  <text x="432" y="116">~</text>
-                  <text x="536" y="116">~</text>
-                  <text x="40" y="132">(4)</text>
-                  <text x="84" y="132">Supply</text>
-                  <text x="128" y="132">PER</text>
-                  <text x="156" y="132">to</text>
-                  <text x="208" y="132">Registrar</text>
-                  <text x="292" y="132">(including</text>
-                  <text x="368" y="132">backend</text>
-                  <text x="452" y="132">interaction)</text>
-                  <text x="32" y="148">~</text>
+                  <text x="456" y="116">~</text>
+                  <text x="560" y="116">~</text>
+                  <text x="16" y="132">(4)</text>
+                  <text x="60" y="132">Supply</text>
+                  <text x="104" y="132">PER</text>
+                  <text x="132" y="132">to</text>
+                  <text x="184" y="132">Registrar</text>
+                  <text x="268" y="132">(including</text>
+                  <text x="344" y="132">backend</text>
+                  <text x="428" y="132">interaction)</text>
+                  <text x="16" y="148">~</text>
                   <text x="168" y="148">~</text>
                   <text x="312" y="148">~</text>
-                  <text x="432" y="148">~</text>
-                  <text x="536" y="148">~</text>
+                  <text x="456" y="148">~</text>
+                  <text x="560" y="148">~</text>
                   <text x="236" y="180">mTLS</text>
-                  <text x="232" y="196">PER</text>
-                  <text x="372" y="212">mTLS</text>
-                  <text x="368" y="228">RER</text>
-                  <text x="348" y="244">&lt;-Enroll</text>
-                  <text x="408" y="244">Resp-</text>
-                  <text x="220" y="260">Enroll</text>
-                  <text x="268" y="260">Resp</text>
-                  <text x="32" y="292">~</text>
+                  <text x="240" y="196">PER</text>
+                  <text x="380" y="212">mTLS</text>
+                  <text x="384" y="228">RER</text>
+                  <text x="384" y="244">Enroll-Resp</text>
+                  <text x="240" y="260">Enroll-Resp</text>
+                  <text x="16" y="292">~</text>
                   <text x="168" y="292">~</text>
                   <text x="312" y="292">~</text>
-                  <text x="432" y="292">~</text>
-                  <text x="536" y="292">~</text>
+                  <text x="456" y="292">~</text>
+                  <text x="560" y="292">~</text>
                 </g>
               </svg><a href="#section-7.4-3.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-16" class="selfRef">Figure 16</a>:
-<a href="#name-pledge-enroll-request-proce" class="selfRef">Pledge Enroll-Request processing</a>
+<figcaption><a href="#figure-17" class="selfRef">Figure 17</a>:
+<a href="#name-enroll-exchange" class="selfRef">Enroll exchange</a>
           </figcaption></figure>
 </div>
+<p id="section-7.4-4">In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-7.4-4" class="pilcrow">¶</a></p>
 <div id="request-artifact-pledge-enroll-request-per">
 <section id="section-7.4.1">
           <h4 id="name-request-artifact-pledge-enro">
 <a href="#section-7.4.1" class="section-number selfRef">7.4.1. </a><a href="#name-request-artifact-pledge-enro" class="section-name selfRef">Request Artifact: Pledge Enroll-Request (PER)</a>
           </h4>
 <p id="section-7.4.1-1">As specified in <a href="#tper" class="auto internal xref">Section 7.2</a> deviating from BRSKI the PER is not a raw PKCS#10.
-As the Registrar-Agent is involved in the exchange, the PKCS#10 is wrapped in a JWS object by the pledge and signed with pledge's IDevID to ensure proof-of-identity as outlined in <a href="#per_example" class="auto internal xref">Figure 11</a>.<a href="#section-7.4.1-1" class="pilcrow">¶</a></p>
+As the Registrar-Agent is involved in the exchange, the PKCS#10 is wrapped in a JWS object by the pledge and signed with pledge's IDevID to ensure proof-of-identity as outlined in <a href="#per_example" class="auto internal xref">Figure 12</a>.<a href="#section-7.4.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.4.1-2">EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> standard endpoints (/simpleenroll, /simplereenroll, /serverkeygen, /cacerts) on the registrar cannot be used for BRSKI-PRM.
 This is caused by the utilization of signature wrapped-objects in BRSKI-PRM.
 As EST requires to sent a raw PKCS#10 request to e.g., "/.well-known/est/simpleenroll" endpoint, this document makes an enhancement by utilizing EST but with the exception to transport a signature wrapped PKCS#10 request.
@@ -4259,21 +4309,21 @@ Note, the registrar is already aware that the bootstrapping is performed in a pl
           </ul>
 </section>
 </div>
-<div id="enrollment-by-domain-ca">
+<div id="enroll-pledge-by-domain-ca-backend-interaction">
 <section id="section-7.4.2">
-          <h4 id="name-enrollment-by-domain-ca">
-<a href="#section-7.4.2" class="section-number selfRef">7.4.2. </a><a href="#name-enrollment-by-domain-ca" class="section-name selfRef">Enrollment by Domain CA</a>
+          <h4 id="name-enroll-pledge-by-domain-ca-">
+<a href="#section-7.4.2" class="section-number selfRef">7.4.2. </a><a href="#name-enroll-pledge-by-domain-ca-" class="section-name selfRef">Enroll Pledge by Domain CA (backend interaction)</a>
           </h4>
 <p id="section-7.4.2-1">If both succeed, the registrar utilizes the PKCS#10 request contained in the JWS object body as "P10" parameter of "ietf-sztp-csr:csr" for further processing of the Enroll-Request with the corresponding domain CA.
-It creates a registrar-Enroll-Request (RER) by utilizing the protocol expected by the domain CA.<a href="#section-7.4.2-1" class="pilcrow">¶</a></p>
+It creates a Registrar Enroll-Request (RER) by utilizing the protocol expected by the domain CA.<a href="#section-7.4.2-1" class="pilcrow">¶</a></p>
 <p id="section-7.4.2-2">The domain registrar may either directly forward the provided PKCS#10 request to the CA or provide additional information about attributes to be included by the CA into the requested LDevID certificate.<a href="#section-7.4.2-2" class="pilcrow">¶</a></p>
 <p id="section-7.4.2-3">The approach of sending this information to the CA depends on the utilized certificate management protocol between the RA and the CA and is out of scope for this document.<a href="#section-7.4.2-3" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="response-artifact-enroll-response">
+<div id="response-artifact-enroll-response-enroll-resp">
 <section id="section-7.4.3">
           <h4 id="name-response-artifact-enroll-re">
-<a href="#section-7.4.3" class="section-number selfRef">7.4.3. </a><a href="#name-response-artifact-enroll-re" class="section-name selfRef">Response Artifact: Enroll-Response</a>
+<a href="#section-7.4.3" class="section-number selfRef">7.4.3. </a><a href="#name-response-artifact-enroll-re" class="section-name selfRef">Response Artifact: Enroll-Response (Enroll-Resp)</a>
           </h4>
 <p id="section-7.4.3-1">The registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.<a href="#section-7.4.3-1" class="pilcrow">¶</a></p>
 <p id="section-7.4.3-2">A successful interaction with the domain CA will result in a pledge LDevID certificate, which is then forwarded by the registrar to the Registrar-Agent using the Content-Type header: <code>application/pkcs7-mime</code>.<a href="#section-7.4.3-2" class="pilcrow">¶</a></p>
@@ -4292,107 +4342,114 @@ This is done in EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</sp
 BRSKI-PRM requires a signature wrapped CA certificate object, to avoid that the pledge can be provided with arbitrary CA certificates in an authorized way.
 The registrar signed CA certificate object will allow the pledge to verify the authorization to install the received CA certificate(s).
 As the CA certificate(s) are provided to the pledge after the voucher, the pledge has the required information (the domain certificate) to verify the wrapped CA certificate object.<a href="#section-7.5-1" class="pilcrow">¶</a></p>
-<p id="section-7.5-2"><a href="#exchangesfig_uc2_5" class="auto internal xref">Figure 17</a> shows the request and provisioning of CA certificates in the infrastructure. 
+<p id="section-7.5-2"><a href="#exchangesfig_uc2_5" class="auto internal xref">Figure 18</a> shows the request and provisioning of CA certificates in the infrastructure. 
 The following subsections describe the corresponding artifacts.<a href="#section-7.5-2" class="pilcrow">¶</a></p>
-<span id="name-ca-certificate-retrival"></span><div id="exchangesfig_uc2_5">
-<figure id="figure-17">
+<span id="name-ca-certificates-retrival-ex"></span><div id="exchangesfig_uc2_5">
+<figure id="figure-18">
           <div id="section-7.5-3.1">
-            <div class="alignLeft art-svg artwork" id="section-7.5-3.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="240" width="560" viewBox="0 0 560 240" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+            <div class="alignCenter art-svg artwork" id="section-7.5-3.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="576" viewBox="0 0 576 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 32,160 L 32,208" fill="none" stroke="black"></path>
+                <path d="M 16,160 L 16,224" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
-                <path d="M 168,160 L 168,208" fill="none" stroke="black"></path>
-                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
-                <path d="M 312,160 L 312,208" fill="none" stroke="black"></path>
-                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 432,160 L 432,208" fill="none" stroke="black"></path>
-                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
+                <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
+                <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+                <path d="M 456,160 L 456,224" fill="none" stroke="black"></path>
                 <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-                <path d="M 536,160 L 536,208" fill="none" stroke="black"></path>
-                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+                <path d="M 560,160 L 560,224" fill="none" stroke="black"></path>
+                <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-                <path d="M 288,176 L 304,176" fill="none" stroke="black"></path>
+                <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+                <path d="M 176,176 L 216,176" fill="none" stroke="black"></path>
+                <path d="M 256,176 L 304,176" fill="none" stroke="black"></path>
                 <path d="M 176,192 L 192,192" fill="none" stroke="black"></path>
+                <path d="M 280,192 L 304,192" fill="none" stroke="black"></path>
+                <path d="M 176,208 L 192,208" fill="none" stroke="black"></path>
+                <path d="M 288,208 L 304,208" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="312,192 300,186.4 300,197.6" fill="black" transform="rotate(0,304,192)"></polygon>
                 <polygon class="arrowhead" points="312,176 300,170.4 300,181.6" fill="black" transform="rotate(0,304,176)"></polygon>
-                <polygon class="arrowhead" points="184,192 172,186.4 172,197.6" fill="black" transform="rotate(180,176,192)"></polygon>
+                <polygon class="arrowhead" points="184,208 172,202.4 172,213.6" fill="black" transform="rotate(180,176,208)"></polygon>
+                <polygon class="arrowhead" points="184,176 172,170.4 172,181.6" fill="black" transform="rotate(180,176,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="164" y="52">Registrar-</text>
-                  <text x="276" y="52">Domain</text>
-                  <text x="412" y="52">Domain</text>
-                  <text x="500" y="52">MASA</text>
-                  <text x="144" y="68">Agent</text>
-                  <text x="288" y="68">Registrar</text>
-                  <text x="396" y="68">CA</text>
-                  <text x="32" y="100">|</text>
+                  <text x="172" y="52">Registrar-</text>
+                  <text x="308" y="52">Domain</text>
+                  <text x="436" y="52">Domain</text>
+                  <text x="540" y="52">MASA</text>
+                  <text x="168" y="68">Agent</text>
+                  <text x="312" y="68">Registrar</text>
+                  <text x="436" y="68">CA</text>
+                  <text x="16" y="100">|</text>
                   <text x="168" y="100">|</text>
                   <text x="312" y="100">|</text>
-                  <text x="432" y="100">|</text>
-                  <text x="492" y="100">Internet</text>
-                  <text x="536" y="100">|</text>
-                  <text x="32" y="116">~</text>
+                  <text x="456" y="100">|</text>
+                  <text x="516" y="100">Internet</text>
+                  <text x="560" y="100">|</text>
+                  <text x="16" y="116">~</text>
                   <text x="168" y="116">~</text>
                   <text x="312" y="116">~</text>
-                  <text x="432" y="116">~</text>
-                  <text x="536" y="116">~</text>
-                  <text x="40" y="132">(5)</text>
-                  <text x="88" y="132">Request</text>
-                  <text x="132" y="132">CA</text>
-                  <text x="196" y="132">Certificates</text>
-                  <text x="32" y="148">~</text>
+                  <text x="456" y="116">~</text>
+                  <text x="560" y="116">~</text>
+                  <text x="16" y="132">(5)</text>
+                  <text x="64" y="132">Request</text>
+                  <text x="108" y="132">CA</text>
+                  <text x="172" y="132">Certificates</text>
+                  <text x="16" y="148">~</text>
                   <text x="168" y="148">~</text>
                   <text x="312" y="148">~</text>
-                  <text x="432" y="148">~</text>
-                  <text x="536" y="148">~</text>
-                  <text x="180" y="180">--</text>
-                  <text x="236" y="180">cACert-Req</text>
-                  <text x="256" y="196">cACert-Resp--</text>
-                  <text x="32" y="228">~</text>
-                  <text x="168" y="228">~</text>
-                  <text x="312" y="228">~</text>
-                  <text x="432" y="228">~</text>
-                  <text x="536" y="228">~</text>
+                  <text x="456" y="148">~</text>
+                  <text x="560" y="148">~</text>
+                  <text x="236" y="180">mTLS</text>
+                  <text x="236" y="196">cACert-Req</text>
+                  <text x="240" y="212">cACert-Resp</text>
+                  <text x="16" y="244">~</text>
+                  <text x="168" y="244">~</text>
+                  <text x="312" y="244">~</text>
+                  <text x="456" y="244">~</text>
+                  <text x="560" y="244">~</text>
                 </g>
               </svg><a href="#section-7.5-3.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-17" class="selfRef">Figure 17</a>:
-<a href="#name-ca-certificate-retrival" class="selfRef">CA certificate retrival</a>
+<figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
+<a href="#name-ca-certificates-retrival-ex" class="selfRef">CA certificates retrival exchange</a>
           </figcaption></figure>
 </div>
-<div id="request-artifact-cacert-req">
+<p id="section-7.5-4">In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-7.5-4" class="pilcrow">¶</a></p>
+<div id="request-artifact-cacert-request-cacert-req">
 <section id="section-7.5.1">
           <h4 id="name-request-artifact-cacert-req">
-<a href="#section-7.5.1" class="section-number selfRef">7.5.1. </a><a href="#name-request-artifact-cacert-req" class="section-name selfRef">Request Artifact: cACert-Req</a>
+<a href="#section-7.5.1" class="section-number selfRef">7.5.1. </a><a href="#name-request-artifact-cacert-req" class="section-name selfRef">Request Artifact: cACert-Request (cACert-Req)</a>
           </h4>
 <p id="section-7.5.1-1">To support Registrar-Agents requesting a signature wrapped CA certificate(s) object, a new endpoint for BRSKI-PRM is defined on the registrar: "/.well-known/brski/wrappedcacerts"<a href="#section-7.5.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.5.1-2">The Registrar-Agent <span class="bcp14">SHALL</span> requests the EST CA trust anchor database information (in form of CA certificates) by HTTP GET.<a href="#section-7.5.1-2" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="response-artifact-cacert-resp">
+<div id="response-artifact-cacert-response-cacert-resp">
 <section id="section-7.5.2">
           <h4 id="name-response-artifact-cacert-re">
-<a href="#section-7.5.2" class="section-number selfRef">7.5.2. </a><a href="#name-response-artifact-cacert-re" class="section-name selfRef">Response Artifact: cACert-Resp</a>
+<a href="#section-7.5.2" class="section-number selfRef">7.5.2. </a><a href="#name-response-artifact-cacert-re" class="section-name selfRef">Response Artifact: cACert-Response (cACert-Resp)</a>
           </h4>
 <p id="section-7.5.2-1">The Content-Type header of the response <span class="bcp14">SHALL</span> be: <code>application/jose+json</code>.<a href="#section-7.5.2-1" class="pilcrow">¶</a></p>
 <p id="section-7.5.2-2">This is a deviation from the Content-Type header values used in EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> and results in additional processing at the domain registrar (as EST server).
 The additional processing is to sign the CA certificate(s) information using the registrar LDevID credentials.
 This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certificates are provided as base64-encoded "x5bag" (see definition in <span>[<a href="#RFC9360" class="cite xref">RFC9360</a>]</span>) in the JWS payload.<a href="#section-7.5.2-2" class="pilcrow">¶</a></p>
 <span id="name-representation-of-ca-certif"></span><div id="PCAC">
-<figure id="figure-18">
+<figure id="figure-19">
             <div class="alignLeft art-text artwork" id="section-7.5.2-3.1">
 <pre>
 # The CA certificates data with registrar signature in General JWS Serialization syntax
@@ -4426,7 +4483,7 @@ This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certific
 }
 </pre>
 </div>
-<figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
+<figcaption><a href="#figure-19" class="selfRef">Figure 19</a>:
 <a href="#name-representation-of-ca-certif" class="selfRef">Representation of CA certificate(s) data with registrar signature</a>
             </figcaption></figure>
 </div>
@@ -4462,93 +4519,93 @@ The IDevID CA certificate is necessary, when the connection between the Registra
         </ul>
 <p id="section-7.6-6">The Registrar-Agent <span class="bcp14">MAY</span> optionally use TLS to protect the communication as outlined in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.<a href="#section-7.6-6" class="pilcrow">¶</a></p>
 <p id="section-7.6-7">The Registrar-Agent provides the information via distinct pledge endpoints as following.
-<a href="#exchangesfig_uc2_6" class="auto internal xref">Figure 19</a> shows the provisioning of the voucher to the pledge. 
+<a href="#exchangesfig_uc2_6" class="auto internal xref">Figure 20</a> shows the provisioning of the voucher to the pledge. 
 The following subsections describe the corresponding artifacts.<a href="#section-7.6-7" class="pilcrow">¶</a></p>
-<span id="name-supply-voucher-to-pledge-2"></span><div id="exchangesfig_uc2_6">
-<figure id="figure-19">
+<span id="name-voucher-exchange"></span><div id="exchangesfig_uc2_6">
+<figure id="figure-20">
           <div id="section-7.6-8.1">
-            <div class="alignLeft art-svg artwork" id="section-7.6-8.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="560" viewBox="0 0 560 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+            <div class="alignCenter art-svg artwork" id="section-7.6-8.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="576" viewBox="0 0 576 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 32,160 L 32,224" fill="none" stroke="black"></path>
+                <path d="M 16,160 L 16,224" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
                 <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
-                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
                 <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
-                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 432,160 L 432,224" fill="none" stroke="black"></path>
-                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+                <path d="M 456,160 L 456,224" fill="none" stroke="black"></path>
                 <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-                <path d="M 536,160 L 536,224" fill="none" stroke="black"></path>
-                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+                <path d="M 560,160 L 560,224" fill="none" stroke="black"></path>
+                <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
-                <path d="M 136,176 L 160,176" fill="none" stroke="black"></path>
-                <path d="M 40,192 L 64,192" fill="none" stroke="black"></path>
-                <path d="M 144,192 L 160,192" fill="none" stroke="black"></path>
-                <path d="M 40,208 L 64,208" fill="none" stroke="black"></path>
-                <path d="M 144,208 L 160,208" fill="none" stroke="black"></path>
+                <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+                <path d="M 24,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 128,176 L 160,176" fill="none" stroke="black"></path>
+                <path d="M 24,192 L 64,192" fill="none" stroke="black"></path>
+                <path d="M 128,192 L 160,192" fill="none" stroke="black"></path>
+                <path d="M 24,208 L 64,208" fill="none" stroke="black"></path>
+                <path d="M 128,208 L 160,208" fill="none" stroke="black"></path>
                 <polygon class="arrowhead" points="168,208 156,202.4 156,213.6" fill="black" transform="rotate(0,160,208)"></polygon>
                 <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
-                <polygon class="arrowhead" points="48,192 36,186.4 36,197.6" fill="black" transform="rotate(180,40,192)"></polygon>
-                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <polygon class="arrowhead" points="32,192 20,186.4 20,197.6" fill="black" transform="rotate(180,24,192)"></polygon>
+                <polygon class="arrowhead" points="32,176 20,170.4 20,181.6" fill="black" transform="rotate(180,24,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="164" y="52">Registrar-</text>
-                  <text x="276" y="52">Domain</text>
-                  <text x="412" y="52">Domain</text>
-                  <text x="500" y="52">MASA</text>
-                  <text x="144" y="68">Agent</text>
-                  <text x="288" y="68">Registrar</text>
-                  <text x="396" y="68">CA</text>
-                  <text x="32" y="100">|</text>
+                  <text x="172" y="52">Registrar-</text>
+                  <text x="308" y="52">Domain</text>
+                  <text x="436" y="52">Domain</text>
+                  <text x="540" y="52">MASA</text>
+                  <text x="168" y="68">Agent</text>
+                  <text x="312" y="68">Registrar</text>
+                  <text x="436" y="68">CA</text>
+                  <text x="16" y="100">|</text>
                   <text x="168" y="100">|</text>
                   <text x="312" y="100">|</text>
-                  <text x="432" y="100">|</text>
-                  <text x="492" y="100">Internet</text>
-                  <text x="536" y="100">|</text>
-                  <text x="32" y="116">~</text>
+                  <text x="456" y="100">|</text>
+                  <text x="516" y="100">Internet</text>
+                  <text x="560" y="100">|</text>
+                  <text x="16" y="116">~</text>
                   <text x="168" y="116">~</text>
                   <text x="312" y="116">~</text>
-                  <text x="432" y="116">~</text>
-                  <text x="536" y="116">~</text>
-                  <text x="40" y="132">(6)</text>
-                  <text x="84" y="132">Supply</text>
-                  <text x="144" y="132">Voucher</text>
-                  <text x="188" y="132">to</text>
-                  <text x="228" y="132">Pledge</text>
-                  <text x="32" y="148">~</text>
+                  <text x="456" y="116">~</text>
+                  <text x="560" y="116">~</text>
+                  <text x="16" y="132">(6)</text>
+                  <text x="60" y="132">Supply</text>
+                  <text x="120" y="132">Voucher</text>
+                  <text x="164" y="132">to</text>
+                  <text x="204" y="132">Pledge</text>
+                  <text x="16" y="148">~</text>
                   <text x="168" y="148">~</text>
                   <text x="312" y="148">~</text>
-                  <text x="432" y="148">~</text>
-                  <text x="536" y="148">~</text>
+                  <text x="456" y="148">~</text>
+                  <text x="560" y="148">~</text>
                   <text x="76" y="180">opt.</text>
                   <text x="112" y="180">TLS</text>
-                  <text x="104" y="196">Voucher</text>
-                  <text x="104" y="212">vStatus</text>
-                  <text x="32" y="244">~</text>
+                  <text x="96" y="196">Voucher</text>
+                  <text x="96" y="212">vStatus</text>
+                  <text x="16" y="244">~</text>
                   <text x="168" y="244">~</text>
                   <text x="312" y="244">~</text>
-                  <text x="432" y="244">~</text>
-                  <text x="536" y="244">~</text>
+                  <text x="456" y="244">~</text>
+                  <text x="560" y="244">~</text>
                 </g>
               </svg><a href="#section-7.6-8.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-19" class="selfRef">Figure 19</a>:
-<a href="#name-supply-voucher-to-pledge-2" class="selfRef">Supply voucher to pledge</a>
+<figcaption><a href="#figure-20" class="selfRef">Figure 20</a>:
+<a href="#name-voucher-exchange" class="selfRef">Voucher exchange</a>
           </figcaption></figure>
 </div>
 <div id="request-artifact-voucher">
@@ -4557,7 +4614,7 @@ The following subsections describe the corresponding artifacts.<a href="#section
 <a href="#section-7.6.1" class="section-number selfRef">7.6.1. </a><a href="#name-request-artifact-voucher" class="section-name selfRef">Request Artifact: Voucher</a>
           </h4>
 <p id="section-7.6.1-1">The Registrar-Agent <span class="bcp14">SHALL</span> send the voucher-response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/svr".<a href="#section-7.6.1-1" class="pilcrow">¶</a></p>
-<p id="section-7.6.1-2">The Registrar-Agent voucher-response Content-Type header is <code>application/voucher-jws+json</code> and contains the voucher as provided by the MASA. An example is given in <a href="#MASA-vr" class="auto internal xref">Figure 14</a> for a MASA  signed voucher and in <a href="#MASA-REG-vr" class="auto internal xref">Figure 15</a> for the voucher with the additional signature of the registrar.<a href="#section-7.6.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.6.1-2">The Registrar-Agent voucher-response Content-Type header is <code>application/voucher-jws+json</code> and contains the voucher as provided by the MASA. An example is given in <a href="#MASA-vr" class="auto internal xref">Figure 15</a> for a MASA  signed voucher and in <a href="#MASA-REG-vr" class="auto internal xref">Figure 16</a> for the voucher with the additional signature of the registrar.<a href="#section-7.6.1-2" class="pilcrow">¶</a></p>
 <p id="section-7.6.1-3">A nonceless voucher may be accepted as in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> and may be allowed by a manufacture's pledge implementation.<a href="#section-7.6.1-3" class="pilcrow">¶</a></p>
 <p id="section-7.6.1-4">To perform the validation of several signatures on the voucher object, the pledge <span class="bcp14">SHALL</span> perform the signature verification in the following order:<a href="#section-7.6.1-4" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-7.6.1-5">
@@ -4586,10 +4643,10 @@ If all steps stated above have been performed successfully, the pledge <span cla
           </h4>
 <p id="section-7.6.2-1">After voucher verification and validation the pledge <span class="bcp14">MUST</span> reply with a status telemetry message as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.7" class="relref">Section 5.7</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 The pledge generates the voucher-status and provides it as signed JSON-in-JWS object in response to the Registrar-Agent.<a href="#section-7.6.2-1" class="pilcrow">¶</a></p>
-<p id="section-7.6.2-2">The response has the Content-Type <code>application/jose+json</code> and is signed using the IDevID of the pledge as shown in <a href="#vstat" class="auto internal xref">Figure 20</a>.
+<p id="section-7.6.2-2">The response has the Content-Type <code>application/jose+json</code> and is signed using the IDevID of the pledge as shown in <a href="#vstat" class="auto internal xref">Figure 21</a>.
 As the reason field is optional (see <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>), it <span class="bcp14">MAY</span> be omitted in case of success.<a href="#section-7.6.2-2" class="pilcrow">¶</a></p>
 <span id="name-representation-of-pledge-vo"></span><div id="vstat">
-<figure id="figure-20">
+<figure id="figure-21">
             <div class="alignLeft art-text artwork" id="section-7.6.2-3.1">
 <pre>
 # The "pledge-voucher-status" telemetry in general JWS
@@ -4638,7 +4695,7 @@ As the reason field is optional (see <span>[<a href="#RFC8995" class="cite xref"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-20" class="selfRef">Figure 20</a>:
+<figcaption><a href="#figure-21" class="selfRef">Figure 21</a>:
 <a href="#name-representation-of-pledge-vo" class="selfRef">Representation of pledge voucher status telemetry</a>
             </figcaption></figure>
 </div>
@@ -4650,96 +4707,107 @@ As the reason field is optional (see <span>[<a href="#RFC8995" class="cite xref"
 <div id="cacerts">
 <section id="section-7.7">
         <h3 id="name-supply-ca-certificates-to-p">
-<a href="#section-7.7" class="section-number selfRef">7.7. </a><a href="#name-supply-ca-certificates-to-p" class="section-name selfRef">Supply CA certificates to Pledge</a>
+<a href="#section-7.7" class="section-number selfRef">7.7. </a><a href="#name-supply-ca-certificates-to-p" class="section-name selfRef">Supply CA Certificates to Pledge</a>
         </h3>
-<p id="section-7.7-1"><a href="#exchangesfig_uc2_7" class="auto internal xref">Figure 21</a> shows the provisioning of the CA certificates aquired by the pledge-agent to the pledge. 
+<p id="section-7.7-1"><a href="#exchangesfig_uc2_7" class="auto internal xref">Figure 22</a> shows the provisioning of the CA certificates aquired by the pledge-agent to the pledge. 
 The following subsections describe the corresponding artifacts.<a href="#section-7.7-1" class="pilcrow">¶</a></p>
-<span id="name-supply-ca-certificates-to-pl"></span><div id="exchangesfig_uc2_7">
-<figure id="figure-21">
+<span id="name-certificate-provisioning-ex"></span><div id="exchangesfig_uc2_7">
+<figure id="figure-22">
           <div id="section-7.7-2.1">
-            <div class="alignLeft art-svg artwork" id="section-7.7-2.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="560" viewBox="0 0 560 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+            <div class="alignCenter art-svg artwork" id="section-7.7-2.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="272" width="576" viewBox="0 0 576 272" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 32,160 L 32,224" fill="none" stroke="black"></path>
+                <path d="M 16,160 L 16,192" fill="none" stroke="black"></path>
+                <path d="M 16,224 L 16,240" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
-                <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
-                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
-                <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
-                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 432,160 L 432,224" fill="none" stroke="black"></path>
-                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,192" fill="none" stroke="black"></path>
+                <path d="M 168,224 L 168,240" fill="none" stroke="black"></path>
+                <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,192" fill="none" stroke="black"></path>
+                <path d="M 312,224 L 312,240" fill="none" stroke="black"></path>
+                <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+                <path d="M 456,160 L 456,192" fill="none" stroke="black"></path>
+                <path d="M 456,224 L 456,240" fill="none" stroke="black"></path>
                 <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-                <path d="M 536,160 L 536,224" fill="none" stroke="black"></path>
-                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+                <path d="M 560,160 L 560,192" fill="none" stroke="black"></path>
+                <path d="M 560,224 L 560,240" fill="none" stroke="black"></path>
+                <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
-                <path d="M 136,176 L 160,176" fill="none" stroke="black"></path>
-                <path d="M 40,192 L 64,192" fill="none" stroke="black"></path>
-                <path d="M 144,192 L 160,192" fill="none" stroke="black"></path>
-                <path d="M 40,208 L 56,208" fill="none" stroke="black"></path>
-                <path d="M 136,208 L 160,208" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="168,208 156,202.4 156,213.6" fill="black" transform="rotate(0,160,208)"></polygon>
+                <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+                <path d="M 24,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 128,176 L 160,176" fill="none" stroke="black"></path>
+                <path d="M 24,192 L 64,192" fill="none" stroke="black"></path>
+                <path d="M 128,192 L 160,192" fill="none" stroke="black"></path>
+                <path d="M 24,224 L 64,224" fill="none" stroke="black"></path>
+                <path d="M 128,224 L 160,224" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="168,224 156,218.4 156,229.6" fill="black" transform="rotate(0,160,224)"></polygon>
                 <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
-                <polygon class="arrowhead" points="48,192 36,186.4 36,197.6" fill="black" transform="rotate(180,40,192)"></polygon>
-                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <polygon class="arrowhead" points="32,192 20,186.4 20,197.6" fill="black" transform="rotate(180,24,192)"></polygon>
+                <polygon class="arrowhead" points="32,176 20,170.4 20,181.6" fill="black" transform="rotate(180,24,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="164" y="52">Registrar-</text>
-                  <text x="276" y="52">Domain</text>
-                  <text x="412" y="52">Domain</text>
-                  <text x="500" y="52">MASA</text>
-                  <text x="144" y="68">Agent</text>
-                  <text x="288" y="68">Registrar</text>
-                  <text x="396" y="68">CA</text>
-                  <text x="32" y="100">|</text>
+                  <text x="172" y="52">Registrar-</text>
+                  <text x="308" y="52">Domain</text>
+                  <text x="436" y="52">Domain</text>
+                  <text x="540" y="52">MASA</text>
+                  <text x="168" y="68">Agent</text>
+                  <text x="312" y="68">Registrar</text>
+                  <text x="436" y="68">CA</text>
+                  <text x="16" y="100">|</text>
                   <text x="168" y="100">|</text>
                   <text x="312" y="100">|</text>
-                  <text x="432" y="100">|</text>
-                  <text x="492" y="100">Internet</text>
-                  <text x="536" y="100">|</text>
-                  <text x="32" y="116">~</text>
+                  <text x="456" y="100">|</text>
+                  <text x="516" y="100">Internet</text>
+                  <text x="560" y="100">|</text>
+                  <text x="16" y="116">~</text>
                   <text x="168" y="116">~</text>
                   <text x="312" y="116">~</text>
-                  <text x="432" y="116">~</text>
-                  <text x="536" y="116">~</text>
-                  <text x="40" y="132">(7)</text>
-                  <text x="84" y="132">Supply</text>
-                  <text x="124" y="132">CA</text>
-                  <text x="188" y="132">certificates</text>
-                  <text x="252" y="132">to</text>
-                  <text x="292" y="132">Pledge</text>
-                  <text x="32" y="148">~</text>
+                  <text x="456" y="116">~</text>
+                  <text x="560" y="116">~</text>
+                  <text x="16" y="132">(7)</text>
+                  <text x="60" y="132">Supply</text>
+                  <text x="100" y="132">CA</text>
+                  <text x="164" y="132">Certificates</text>
+                  <text x="228" y="132">to</text>
+                  <text x="268" y="132">Pledge</text>
+                  <text x="16" y="148">~</text>
                   <text x="168" y="148">~</text>
                   <text x="312" y="148">~</text>
-                  <text x="432" y="148">~</text>
-                  <text x="536" y="148">~</text>
+                  <text x="456" y="148">~</text>
+                  <text x="560" y="148">~</text>
                   <text x="76" y="180">opt.</text>
                   <text x="112" y="180">TLS</text>
-                  <text x="104" y="196">cACerts</text>
-                  <text x="96" y="212">cACerts</text>
-                  <text x="32" y="244">~</text>
-                  <text x="168" y="244">~</text>
-                  <text x="312" y="244">~</text>
-                  <text x="432" y="244">~</text>
-                  <text x="536" y="244">~</text>
+                  <text x="96" y="196">cACerts</text>
+                  <text x="24" y="212">TODO:</text>
+                  <text x="72" y="212">certs</text>
+                  <text x="116" y="212">sent</text>
+                  <text x="156" y="212">back</text>
+                  <text x="188" y="212">in</text>
+                  <text x="240" y="212">response?</text>
+                  <text x="96" y="228">cACerts</text>
+                  <text x="16" y="260">~</text>
+                  <text x="168" y="260">~</text>
+                  <text x="312" y="260">~</text>
+                  <text x="456" y="260">~</text>
+                  <text x="560" y="260">~</text>
                 </g>
               </svg><a href="#section-7.7-2.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-21" class="selfRef">Figure 21</a>:
-<a href="#name-supply-ca-certificates-to-pl" class="selfRef">Supply CA certificates to pledge</a>
+<figcaption><a href="#figure-22" class="selfRef">Figure 22</a>:
+<a href="#name-certificate-provisioning-ex" class="selfRef">Certificate provisioning exchange</a>
           </figcaption></figure>
 </div>
 <div id="request-artifact">
@@ -4749,15 +4817,15 @@ The following subsections describe the corresponding artifacts.<a href="#section
           </h4>
 <p id="section-7.7.1-1">The Registrar-Agent <span class="bcp14">SHALL</span> provide the set of CA certificates requested from the registrar to the pledge by HTTP POST to the endpoint: "/.well-known/brski/scac".<a href="#section-7.7.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.7.1-2">As the CA certificate provisioning is crucial from a security perspective, this provisioning <span class="bcp14">SHOULD</span> only be done, if the voucher-response has been successfully processed by pledge as reflected in the voucher status telemetry.<a href="#section-7.7.1-2" class="pilcrow">¶</a></p>
-<p id="section-7.7.1-3">The CA certificates message has the Content-Type <code>application/jose+json</code> and is signed using the credential of the registrar as shown in <a href="#PCAC" class="auto internal xref">Figure 18</a>.<a href="#section-7.7.1-3" class="pilcrow">¶</a></p>
+<p id="section-7.7.1-3">The CA certificates message has the Content-Type <code>application/jose+json</code> and is signed using the credential of the registrar as shown in <a href="#PCAC" class="auto internal xref">Figure 19</a>.<a href="#section-7.7.1-3" class="pilcrow">¶</a></p>
 <p id="section-7.7.1-4">The CA certificates are provided as base64-encoded "x5bag".
 The pledge <span class="bcp14">SHALL</span> install the received CA certificates as trust anchor after successful verification of the registrar's signature.<a href="#section-7.7.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="response">
+<div id="response-no-artifact">
 <section id="section-7.7.2">
-          <h4 id="name-response">
-<a href="#section-7.7.2" class="section-number selfRef">7.7.2. </a><a href="#name-response" class="section-name selfRef">Response</a>
+          <h4 id="name-response-no-artifact">
+<a href="#section-7.7.2" class="section-number selfRef">7.7.2. </a><a href="#name-response-no-artifact" class="section-name selfRef">Response (no artifact)</a>
           </h4>
 <p id="section-7.7.2-1">The verification comprises the following steps the pledge <span class="bcp14">MUST</span> perform. Maintaining the order of versification steps as indicated allows to determine, which verification has already been passed:<a href="#section-7.7.2-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-7.7.2-2">
@@ -4771,12 +4839,13 @@ The pledge <span class="bcp14">SHALL</span> install the received CA certificates
               <p id="section-7.7.2-2.3.1">Verify that the wrapped CA certificate object is signed using the registrar certificate against the pinned-domain certificate. This <span class="bcp14">MAY</span> be done by comparing the hash that is indicating the certificate used to sign the message is that of the pinned-domain certificate. If the validation against the pinned domain-certificate fails, the client <span class="bcp14">SHOULD</span> reply with a 401 Unauthorized error code. It signals that the authentication has failed and therefore the object was not accepted.<a href="#section-7.7.2-2.3.1" class="pilcrow">¶</a></p>
 </li>
             <li id="section-7.7.2-2.4">
-              <p id="section-7.7.2-2.4.1">Verify signature of the the received wrapped CA certificate object. If the validation of the signature fails, the pledge <span class="bcp14">SHOULD</span> reply with a 406 Not Acceptable. It signals that the object has not been accepted.<a href="#section-7.7.2-2.4.1" class="pilcrow">¶</a></p>
+              <p id="section-7.7.2-2.4.1">Verify signature of the the received wrapped CA certificate object [TODO: against what?]. If the validation of the signature fails, the pledge <span class="bcp14">SHOULD</span> reply with a TODO [406 Not Acceptable --&gt; 409 Conflict? 422 Unprocessable Content?; Acceptable code is for Accept header]. It signals that the object has not been TODO accepted.<a href="#section-7.7.2-2.4.1" class="pilcrow">¶</a></p>
 </li>
             <li id="section-7.7.2-2.5">
               <p id="section-7.7.2-2.5.1">If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span>.<a href="#section-7.7.2-2.5.1" class="pilcrow">¶</a></p>
 </li>
           </ol>
+<p id="section-7.7.2-3">TODO: Not clear what the success response code and what the response payload should be. Figure illustrates sending back the same certs, which does not make sense.<a href="#section-7.7.2-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -4786,100 +4855,107 @@ The pledge <span class="bcp14">SHALL</span> install the received CA certificates
         <h3 id="name-supply-enroll-response-to-p">
 <a href="#section-7.8" class="section-number selfRef">7.8. </a><a href="#name-supply-enroll-response-to-p" class="section-name selfRef">Supply Enroll-Response to Pledge</a>
         </h3>
-<p id="section-7.8-1"><a href="#exchangesfig_uc2_8" class="auto internal xref">Figure 22</a> shows the supply of the Enroll-Response to the pledge.
+<p id="section-7.8-1"><a href="#exchangesfig_uc2_8" class="auto internal xref">Figure 23</a> shows the supply of the Enroll-Response to the pledge.
 The following subsections describe the corresponding artifacts.<a href="#section-7.8-1" class="pilcrow">¶</a></p>
-<span id="name-supply-enroll-response-to-pl"></span><div id="exchangesfig_uc2_8">
-<figure id="figure-22">
+<span id="name-enroll-response-exchange"></span><div id="exchangesfig_uc2_8">
+<figure id="figure-23">
           <div id="section-7.8-2.1">
-            <div class="alignLeft art-svg artwork" id="section-7.8-2.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="240" width="560" viewBox="0 0 560 240" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+            <div class="alignCenter art-svg artwork" id="section-7.8-2.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="576" viewBox="0 0 576 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 32,160 L 32,208" fill="none" stroke="black"></path>
+                <path d="M 16,160 L 16,224" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
-                <path d="M 168,160 L 168,208" fill="none" stroke="black"></path>
-                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
-                <path d="M 312,160 L 312,208" fill="none" stroke="black"></path>
-                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 432,160 L 432,208" fill="none" stroke="black"></path>
-                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
+                <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
+                <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+                <path d="M 456,160 L 456,224" fill="none" stroke="black"></path>
                 <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-                <path d="M 536,160 L 536,208" fill="none" stroke="black"></path>
-                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+                <path d="M 560,160 L 560,224" fill="none" stroke="black"></path>
+                <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
-                <path d="M 40,192 L 56,192" fill="none" stroke="black"></path>
-                <path d="M 136,192 L 160,192" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="168,192 156,186.4 156,197.6" fill="black" transform="rotate(0,160,192)"></polygon>
-                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+                <path d="M 24,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 128,176 L 160,176" fill="none" stroke="black"></path>
+                <path d="M 24,192 L 48,192" fill="none" stroke="black"></path>
+                <path d="M 144,192 L 160,192" fill="none" stroke="black"></path>
+                <path d="M 24,208 L 56,208" fill="none" stroke="black"></path>
+                <path d="M 120,208 L 160,208" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="168,208 156,202.4 156,213.6" fill="black" transform="rotate(0,160,208)"></polygon>
+                <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
+                <polygon class="arrowhead" points="32,192 20,186.4 20,197.6" fill="black" transform="rotate(180,24,192)"></polygon>
+                <polygon class="arrowhead" points="32,176 20,170.4 20,181.6" fill="black" transform="rotate(180,24,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="164" y="52">Registrar-</text>
-                  <text x="276" y="52">Domain</text>
-                  <text x="412" y="52">Domain</text>
-                  <text x="500" y="52">MASA</text>
-                  <text x="144" y="68">Agent</text>
-                  <text x="288" y="68">Registrar</text>
-                  <text x="396" y="68">CA</text>
-                  <text x="32" y="100">|</text>
+                  <text x="172" y="52">Registrar-</text>
+                  <text x="308" y="52">Domain</text>
+                  <text x="436" y="52">Domain</text>
+                  <text x="540" y="52">MASA</text>
+                  <text x="168" y="68">Agent</text>
+                  <text x="312" y="68">Registrar</text>
+                  <text x="436" y="68">CA</text>
+                  <text x="16" y="100">|</text>
                   <text x="168" y="100">|</text>
                   <text x="312" y="100">|</text>
-                  <text x="432" y="100">|</text>
-                  <text x="492" y="100">Internet</text>
-                  <text x="536" y="100">|</text>
-                  <text x="32" y="116">~</text>
+                  <text x="456" y="100">|</text>
+                  <text x="516" y="100">Internet</text>
+                  <text x="560" y="100">|</text>
+                  <text x="16" y="116">~</text>
                   <text x="168" y="116">~</text>
                   <text x="312" y="116">~</text>
-                  <text x="432" y="116">~</text>
-                  <text x="536" y="116">~</text>
-                  <text x="40" y="132">(8)</text>
-                  <text x="84" y="132">Supply</text>
-                  <text x="176" y="132">Enroll-Response</text>
-                  <text x="252" y="132">to</text>
-                  <text x="292" y="132">Pledge</text>
-                  <text x="32" y="148">~</text>
+                  <text x="456" y="116">~</text>
+                  <text x="560" y="116">~</text>
+                  <text x="16" y="132">(8)</text>
+                  <text x="60" y="132">Supply</text>
+                  <text x="152" y="132">Enroll-Response</text>
+                  <text x="228" y="132">to</text>
+                  <text x="268" y="132">Pledge</text>
+                  <text x="16" y="148">~</text>
                   <text x="168" y="148">~</text>
                   <text x="312" y="148">~</text>
-                  <text x="432" y="148">~</text>
-                  <text x="536" y="148">~</text>
-                  <text x="84" y="180">Enroll</text>
-                  <text x="140" y="180">Resp--</text>
-                  <text x="96" y="196">eStatus</text>
-                  <text x="32" y="228">~</text>
-                  <text x="168" y="228">~</text>
-                  <text x="312" y="228">~</text>
-                  <text x="432" y="228">~</text>
-                  <text x="536" y="228">~</text>
+                  <text x="456" y="148">~</text>
+                  <text x="560" y="148">~</text>
+                  <text x="76" y="180">opt.</text>
+                  <text x="112" y="180">TLS</text>
+                  <text x="96" y="196">Enroll-Resp</text>
+                  <text x="88" y="212">eStatus</text>
+                  <text x="16" y="244">~</text>
+                  <text x="168" y="244">~</text>
+                  <text x="312" y="244">~</text>
+                  <text x="456" y="244">~</text>
+                  <text x="560" y="244">~</text>
                 </g>
               </svg><a href="#section-7.8-2.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-22" class="selfRef">Figure 22</a>:
-<a href="#name-supply-enroll-response-to-pl" class="selfRef">Supply Enroll-Response to pledge</a>
+<figcaption><a href="#figure-23" class="selfRef">Figure 23</a>:
+<a href="#name-enroll-response-exchange" class="selfRef">Enroll-Response exchange</a>
           </figcaption></figure>
 </div>
-<div id="request-artifact-enroll-response">
+<div id="request-artifact-enroll-response-enroll-resp">
 <section id="section-7.8.1">
           <h4 id="name-request-artifact-enroll-res">
-<a href="#section-7.8.1" class="section-number selfRef">7.8.1. </a><a href="#name-request-artifact-enroll-res" class="section-name selfRef">Request Artifact: Enroll-Response</a>
+<a href="#section-7.8.1" class="section-number selfRef">7.8.1. </a><a href="#name-request-artifact-enroll-res" class="section-name selfRef">Request Artifact: Enroll-Response (Enroll-Resp)</a>
           </h4>
-<p id="section-7.8.1-1">The Registrar-Agent <span class="bcp14">SHALL</span> send the Enroll-Response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/ser".<a href="#section-7.8.1-1" class="pilcrow">¶</a></p>
-<p id="section-7.8.1-2">The Content-Type header when using EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> as enrollment protocol between the Registrar-Agent and the infrastructure is <code>application/pkcs7-mime</code>.
-Note: It only contains the LDevID certificate for the pledge, not the certificate chain.<a href="#section-7.8.1-2" class="pilcrow">¶</a></p>
-<p id="section-7.8.1-3">Upon reception, the pledge <span class="bcp14">SHALL</span> verify the received LDevID certificate.
+<p id="section-7.8.1-1">The Registrar-Agent <span class="bcp14">SHALL</span> send the Enroll-Response to the pledge by HTTP(S) POST to the endpoint: "/.well-known/brski/ser".<a href="#section-7.8.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.8.1-2">TODO: Confirm "opt. TLS", which was missing.<a href="#section-7.8.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.8.1-3">The Content-Type header when using EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> as enrollment protocol between the Registrar-Agent and the infrastructure is <code>application/pkcs7-mime</code>.
+Note: It only contains the LDevID certificate for the pledge, not the certificate chain.<a href="#section-7.8.1-3" class="pilcrow">¶</a></p>
+<p id="section-7.8.1-4">Upon reception, the pledge <span class="bcp14">SHALL</span> verify the received LDevID certificate.
 The pledge <span class="bcp14">SHALL</span> generate the enroll status and provide it in the response to the Registrar-Agent.
-If the verification of the LDevID certificate succeeds, the status property <span class="bcp14">SHALL</span> be set to "status": true, otherwise to "status": false<a href="#section-7.8.1-3" class="pilcrow">¶</a></p>
+If the verification of the LDevID certificate succeeds, the status property <span class="bcp14">SHALL</span> be set to "status": true, otherwise to "status": false<a href="#section-7.8.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="response-artifact-enroll-status-estatus">
@@ -4889,7 +4965,7 @@ If the verification of the LDevID certificate succeeds, the status property <spa
           </h4>
 <p id="section-7.8.2-1">After enrollment processing the pledge <span class="bcp14">MUST</span> reply with a enrollment status telemetry message as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 The enroll-status is also a signed object in BRSKI-PRM and results in form of JSON-in-JWS here.
-If the pledge verified the received LDevID certificate successfully it <span class="bcp14">SHALL</span> sign the enroll-status using its new LDevID credentials as shown in <a href="#estat" class="auto internal xref">Figure 24</a>.
+If the pledge verified the received LDevID certificate successfully it <span class="bcp14">SHALL</span> sign the enroll-status using its new LDevID credentials as shown in <a href="#estat" class="auto internal xref">Figure 25</a>.
 In failure case, the pledge <span class="bcp14">SHALL</span> use its IDevID credentials.
 <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> specifies the enrollment status telemetry message with two optional fields for "reason" and "reason-context". 
 In BRSKI-PRM the optional fields are mandated to have a clear distinction between other status messages and <span class="bcp14">MUST</span> be provided therefore.
@@ -4897,7 +4973,7 @@ This distinction is intended for better error handling on registrar side, as a s
 <p id="section-7.8.2-2">The following CDDL <span>[<a href="#RFC8610" class="cite xref">RFC8610</a>]</span> explains enroll-status response structure. 
 It is similar as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with the optional fields set to mandatory as described above.<a href="#section-7.8.2-2" class="pilcrow">¶</a></p>
 <span id="name-cddl-for-pledge-enrollment-"></span><div id="e_stat_res_def">
-<figure id="figure-23">
+<figure id="figure-24">
             <div class="sourcecode" id="section-7.8.2-3.1">
 <pre>&lt;CODE BEGINS&gt;
 enrollstatus-post = {
@@ -4909,13 +4985,13 @@ enrollstatus-post = {
 
 &lt;CODE ENDS&gt;</pre>
 </div>
-<figcaption><a href="#figure-23" class="selfRef">Figure 23</a>:
+<figcaption><a href="#figure-24" class="selfRef">Figure 24</a>:
 <a href="#name-cddl-for-pledge-enrollment-" class="selfRef">CDDL for pledge-enrollment-status response</a>
             </figcaption></figure>
 </div>
 <p id="section-7.8.2-4">The response has the Content-Type <code>application/jose+json</code>.<a href="#section-7.8.2-4" class="pilcrow">¶</a></p>
 <span id="name-representation-of-pledge-en"></span><div id="estat">
-<figure id="figure-24">
+<figure id="figure-25">
             <div class="alignLeft art-text artwork" id="section-7.8.2-5.1">
 <pre>
 # The "pledge-enroll-status" telemetry in General JWS Serialization
@@ -4963,7 +5039,7 @@ enrollstatus-post = {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-24" class="selfRef">Figure 24</a>:
+<figcaption><a href="#figure-25" class="selfRef">Figure 25</a>:
 <a href="#name-representation-of-pledge-en" class="selfRef">Representation of pledge enroll status telemetry</a>
             </figcaption></figure>
 </div>
@@ -4974,8 +5050,8 @@ enrollstatus-post = {
 </div>
 <div id="vstatus">
 <section id="section-7.9">
-        <h3 id="name-voucher-status-telemetry">
-<a href="#section-7.9" class="section-number selfRef">7.9. </a><a href="#name-voucher-status-telemetry" class="section-name selfRef">Voucher Status Telemetry</a>
+        <h3 id="name-voucher-status-telemetry-in">
+<a href="#section-7.9" class="section-number selfRef">7.9. </a><a href="#name-voucher-status-telemetry-in" class="section-name selfRef">Voucher Status Telemetry (including backend interaction)</a>
         </h3>
 <p id="section-7.9-1">The following description requires that the Registrar-Agent has collected the status information from the pledge.
 It <span class="bcp14">SHALL</span> provide the status information to the registrar for further processing.<a href="#section-7.9-1" class="pilcrow">¶</a></p>
@@ -4987,108 +5063,115 @@ It <span class="bcp14">SHALL</span> provide the status information to the regist
         </ul>
 <div id="section-7.9-4">
           <div class="alignLeft art-svg artwork" id="section-7.9-4.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="288" width="560" viewBox="0 0 560 288" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="304" width="576" viewBox="0 0 576 304" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
               <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-              <path d="M 32,160 L 32,256" fill="none" stroke="black"></path>
+              <path d="M 16,160 L 16,272" fill="none" stroke="black"></path>
               <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-              <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
-              <path d="M 168,160 L 168,256" fill="none" stroke="black"></path>
-              <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-              <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
-              <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
-              <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-              <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-              <path d="M 432,160 L 432,192" fill="none" stroke="black"></path>
-              <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+              <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
+              <path d="M 168,160 L 168,272" fill="none" stroke="black"></path>
+              <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+              <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
+              <path d="M 312,160 L 312,240" fill="none" stroke="black"></path>
+              <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+              <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+              <path d="M 456,160 L 456,200" fill="none" stroke="black"></path>
+              <path d="M 456,256 L 456,272" fill="none" stroke="black"></path>
               <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-              <path d="M 536,160 L 536,224" fill="none" stroke="black"></path>
-              <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+              <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+              <path d="M 560,160 L 560,272" fill="none" stroke="black"></path>
+              <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
               <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-              <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-              <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-              <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-              <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+              <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+              <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+              <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+              <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
               <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-              <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-              <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-              <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-              <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-              <path d="M 176,176 L 208,176" fill="none" stroke="black"></path>
-              <path d="M 264,176 L 304,176" fill="none" stroke="black"></path>
-              <path d="M 176,192 L 200,192" fill="none" stroke="black"></path>
-              <path d="M 280,192 L 304,192" fill="none" stroke="black"></path>
-              <path d="M 320,208 L 336,208" fill="none" stroke="black"></path>
-              <path d="M 512,208 L 528,208" fill="none" stroke="black"></path>
+              <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+              <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+              <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+              <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+              <path d="M 176,176 L 216,176" fill="none" stroke="black"></path>
+              <path d="M 256,176 L 304,176" fill="none" stroke="black"></path>
+              <path d="M 176,192 L 208,192" fill="none" stroke="black"></path>
+              <path d="M 272,192 L 304,192" fill="none" stroke="black"></path>
+              <path d="M 320,208 L 416,208" fill="none" stroke="black"></path>
+              <path d="M 456,208 L 552,208" fill="none" stroke="black"></path>
               <path d="M 320,224 L 352,224" fill="none" stroke="black"></path>
-              <path d="M 504,224 L 528,224" fill="none" stroke="black"></path>
-              <polygon class="arrowhead" points="536,208 524,202.4 524,213.6" fill="black" transform="rotate(0,528,208)"></polygon>
-              <polygon class="arrowhead" points="328,224 316,218.4 316,229.6" fill="black" transform="rotate(180,320,224)"></polygon>
+              <path d="M 520,224 L 552,224" fill="none" stroke="black"></path>
+              <path d="M 320,240 L 368,240" fill="none" stroke="black"></path>
+              <path d="M 504,240 L 552,240" fill="none" stroke="black"></path>
+              <polygon class="arrowhead" points="560,224 548,218.4 548,229.6" fill="black" transform="rotate(0,552,224)"></polygon>
+              <polygon class="arrowhead" points="560,208 548,202.4 548,213.6" fill="black" transform="rotate(0,552,208)"></polygon>
+              <polygon class="arrowhead" points="328,240 316,234.4 316,245.6" fill="black" transform="rotate(180,320,240)"></polygon>
+              <polygon class="arrowhead" points="328,208 316,202.4 316,213.6" fill="black" transform="rotate(180,320,208)"></polygon>
               <polygon class="arrowhead" points="312,192 300,186.4 300,197.6" fill="black" transform="rotate(0,304,192)"></polygon>
               <polygon class="arrowhead" points="312,176 300,170.4 300,181.6" fill="black" transform="rotate(0,304,176)"></polygon>
               <polygon class="arrowhead" points="184,176 172,170.4 172,181.6" fill="black" transform="rotate(180,176,176)"></polygon>
               <g class="text">
                 <text x="44" y="52">Pledge</text>
-                <text x="164" y="52">Registrar-</text>
-                <text x="276" y="52">Domain</text>
-                <text x="412" y="52">Domain</text>
-                <text x="500" y="52">MASA</text>
-                <text x="144" y="68">Agent</text>
-                <text x="288" y="68">Registrar</text>
-                <text x="396" y="68">CA</text>
-                <text x="32" y="100">|</text>
+                <text x="172" y="52">Registrar-</text>
+                <text x="308" y="52">Domain</text>
+                <text x="436" y="52">Domain</text>
+                <text x="540" y="52">MASA</text>
+                <text x="168" y="68">Agent</text>
+                <text x="312" y="68">Registrar</text>
+                <text x="436" y="68">CA</text>
+                <text x="16" y="100">|</text>
                 <text x="168" y="100">|</text>
                 <text x="312" y="100">|</text>
-                <text x="432" y="100">|</text>
-                <text x="492" y="100">Internet</text>
-                <text x="536" y="100">|</text>
-                <text x="32" y="116">~</text>
+                <text x="456" y="100">|</text>
+                <text x="516" y="100">Internet</text>
+                <text x="560" y="100">|</text>
+                <text x="16" y="116">~</text>
                 <text x="168" y="116">~</text>
                 <text x="312" y="116">~</text>
-                <text x="432" y="116">~</text>
-                <text x="536" y="116">~</text>
-                <text x="40" y="132">(9)</text>
-                <text x="88" y="132">Voucher</text>
-                <text x="148" y="132">Status</text>
-                <text x="216" y="132">Telemetry</text>
-                <text x="32" y="148">~</text>
+                <text x="456" y="116">~</text>
+                <text x="560" y="116">~</text>
+                <text x="16" y="132">(9)</text>
+                <text x="64" y="132">Voucher</text>
+                <text x="124" y="132">Status</text>
+                <text x="192" y="132">Telemetry</text>
+                <text x="276" y="132">(including</text>
+                <text x="352" y="132">backend</text>
+                <text x="436" y="132">interaction)</text>
+                <text x="16" y="148">~</text>
                 <text x="168" y="148">~</text>
                 <text x="312" y="148">~</text>
-                <text x="432" y="148">~</text>
-                <text x="536" y="148">~</text>
+                <text x="456" y="148">~</text>
+                <text x="560" y="148">~</text>
                 <text x="236" y="180">mTLS</text>
                 <text x="240" y="196">vStatus</text>
-                <text x="360" y="212">req</text>
-                <text x="404" y="212">device</text>
-                <text x="456" y="212">audit</text>
-                <text x="496" y="212">log</text>
-                <text x="388" y="228">device</text>
-                <text x="440" y="228">audit</text>
-                <text x="480" y="228">log</text>
-                <text x="288" y="244">[verify</text>
-                <text x="344" y="244">audit</text>
-                <text x="388" y="244">log]</text>
-                <text x="312" y="260">|</text>
-                <text x="432" y="260">|</text>
-                <text x="536" y="260">|</text>
-                <text x="32" y="276">~</text>
-                <text x="168" y="276">~</text>
-                <text x="312" y="276">~</text>
-                <text x="432" y="276">~</text>
-                <text x="536" y="276">~</text>
+                <text x="436" y="212">mTLS</text>
+                <text x="368" y="228">req</text>
+                <text x="412" y="228">device</text>
+                <text x="464" y="228">audit</text>
+                <text x="504" y="228">log</text>
+                <text x="396" y="244">device</text>
+                <text x="448" y="244">audit</text>
+                <text x="488" y="244">log</text>
+                <text x="264" y="260">[verify</text>
+                <text x="320" y="260">audit</text>
+                <text x="364" y="260">log]</text>
+                <text x="312" y="276">|</text>
+                <text x="16" y="292">~</text>
+                <text x="168" y="292">~</text>
+                <text x="312" y="292">~</text>
+                <text x="456" y="292">~</text>
+                <text x="560" y="292">~</text>
               </g>
             </svg><a href="#section-7.9-4.1" class="pilcrow">¶</a>
 </div>
 </div>
-<p id="section-7.9-5">{: #exchangesfig_uc2_9 title='Voucher Status tekemetry handling' artwork-align="left"}~~~~ aasvg<a href="#section-7.9-5" class="pilcrow">¶</a></p>
-<p id="section-7.9-6">The Registrar-Agent <span class="bcp14">MUST</span> provide the collected pledge voucher status to the registrar.
-This status indicates if the pledge could process the voucher successfully or not.<a href="#section-7.9-6" class="pilcrow">¶</a></p>
-<p id="section-7.9-7">In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-7.9-7" class="pilcrow">¶</a></p>
+<p id="section-7.9-5">{: #exchangesfig_uc2_9 title="Voucher Status telemetry exchange" artwork-align="center"}~~~~ aasvg<a href="#section-7.9-5" class="pilcrow">¶</a></p>
+<p id="section-7.9-6">In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-7.9-6" class="pilcrow">¶</a></p>
+<p id="section-7.9-7">The Registrar-Agent <span class="bcp14">MUST</span> provide the collected pledge voucher status to the registrar.
+This status indicates if the pledge could process the voucher successfully or not.<a href="#section-7.9-7" class="pilcrow">¶</a></p>
 <div id="request-artifact-voucher-status-vstatus">
 <section id="section-7.9.1">
           <h4 id="name-request-artifact-voucher-st">
 <a href="#section-7.9.1" class="section-number selfRef">7.9.1. </a><a href="#name-request-artifact-voucher-st" class="section-name selfRef">Request Artifact: Voucher Status (vStatus)</a>
           </h4>
-<p id="section-7.9.1-1">The Registrar-Agent sends the pledge voucher status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/voucher_status". The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#vstat" class="auto internal xref">Figure 20</a>.<a href="#section-7.9.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.9.1-1">The Registrar-Agent sends the pledge voucher status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/voucher_status". The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#vstat" class="auto internal xref">Figure 21</a>.<a href="#section-7.9.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.9.1-2">The registrar <span class="bcp14">SHOULD</span> log the transaction provided for a pledge via Registrar-Agent and include the identity of the Registrar-Agent in these logs. For log analysis the following may be considered:<a href="#section-7.9.1-2" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.9.1-3.1">
@@ -5104,15 +5187,16 @@ This status indicates if the pledge could process the voucher successfully or no
 <p id="section-7.9.1-4">The registrar <span class="bcp14">SHALL</span> verify the signature of the pledge voucher status and validate that it belongs to an accepted device of the domain based on the contained "serial-number" in the IDevID certificate referenced in the header of the voucher status.<a href="#section-7.9.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="response-1">
+<div id="response-no-artifact-1">
 <section id="section-7.9.2">
-          <h4 id="name-response-2">
-<a href="#section-7.9.2" class="section-number selfRef">7.9.2. </a><a href="#name-response-2" class="section-name selfRef">Response</a>
+          <h4 id="name-response-no-artifact-2">
+<a href="#section-7.9.2" class="section-number selfRef">7.9.2. </a><a href="#name-response-no-artifact-2" class="section-name selfRef">Response (no artifact)</a>
           </h4>
-<p id="section-7.9.2-1">According to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.7" class="relref">Section 5.7</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
-The Registrar-Agent may use the response to signal success / failure to the service technician operating the Registrar-Agent.
-Within the server logs the server <span class="bcp14">SHOULD</span> capture this telemetry information.<a href="#section-7.9.2-1" class="pilcrow">¶</a></p>
-<p id="section-7.9.2-2">The registrar <span class="bcp14">SHOULD</span> proceed with collecting and logging status information by requesting the MASA audit-log from the MASA service as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.8" class="relref">Section 5.8</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.9.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.9.2-1">TODO: Clarify if diagnostic payload (and what representation format) may be included "to signal success/failure to the service technician. 200 OK should have payload, otherwise 204 No Content...<a href="#section-7.9.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.9.2-2">According to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.7" class="relref">Section 5.7</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes.
+The Registrar-Agent may use the response to signal success/failure to the service technician operating the Registrar-Agent.
+Within the server logs the server <span class="bcp14">SHOULD</span> capture this telemetry information.<a href="#section-7.9.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.9.2-3">The registrar <span class="bcp14">SHOULD</span> proceed with collecting and logging status information by requesting the MASA audit-log from the MASA service as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.8" class="relref">Section 5.8</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.9.2-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -5124,89 +5208,95 @@ Within the server logs the server <span class="bcp14">SHOULD</span> capture this
         </h3>
 <p id="section-7.10-1">The Registrar-Agent <span class="bcp14">MUST</span> provide the pledge's enroll status to the registrar.
 The status indicates the pledge could process the Enroll-Response (certificate) and holds the corresponding private key.<a href="#section-7.10-1" class="pilcrow">¶</a></p>
-<span id="name-enroll-status-provisioning-"></span><div id="exchangesfig_uc2_10">
-<figure id="figure-25">
+<span id="name-enroll-status-telemetry-exc"></span><div id="exchangesfig_uc2_10">
+<figure id="figure-26">
           <div id="section-7.10-2.1">
-            <div class="alignLeft art-svg artwork" id="section-7.10-2.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="224" width="560" viewBox="0 0 560 224" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+            <div class="alignCenter art-svg artwork" id="section-7.10-2.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="240" width="576" viewBox="0 0 576 240" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 32,160 L 32,192" fill="none" stroke="black"></path>
+                <path d="M 16,160 L 16,208" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
-                <path d="M 168,160 L 168,192" fill="none" stroke="black"></path>
-                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
-                <path d="M 312,160 L 312,192" fill="none" stroke="black"></path>
-                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 432,160 L 432,192" fill="none" stroke="black"></path>
-                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,208" fill="none" stroke="black"></path>
+                <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,208" fill="none" stroke="black"></path>
+                <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+                <path d="M 456,160 L 456,208" fill="none" stroke="black"></path>
                 <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-                <path d="M 536,160 L 536,192" fill="none" stroke="black"></path>
-                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+                <path d="M 560,160 L 560,208" fill="none" stroke="black"></path>
+                <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-                <path d="M 176,176 L 200,176" fill="none" stroke="black"></path>
-                <path d="M 280,176 L 304,176" fill="none" stroke="black"></path>
+                <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+                <path d="M 176,176 L 216,176" fill="none" stroke="black"></path>
+                <path d="M 256,176 L 304,176" fill="none" stroke="black"></path>
+                <path d="M 176,192 L 208,192" fill="none" stroke="black"></path>
+                <path d="M 272,192 L 304,192" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="312,192 300,186.4 300,197.6" fill="black" transform="rotate(0,304,192)"></polygon>
                 <polygon class="arrowhead" points="312,176 300,170.4 300,181.6" fill="black" transform="rotate(0,304,176)"></polygon>
+                <polygon class="arrowhead" points="184,176 172,170.4 172,181.6" fill="black" transform="rotate(180,176,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="164" y="52">Registrar-</text>
-                  <text x="276" y="52">Domain</text>
-                  <text x="412" y="52">Domain</text>
-                  <text x="500" y="52">MASA</text>
-                  <text x="144" y="68">Agent</text>
-                  <text x="288" y="68">Registrar</text>
-                  <text x="396" y="68">CA</text>
-                  <text x="32" y="100">|</text>
+                  <text x="172" y="52">Registrar-</text>
+                  <text x="308" y="52">Domain</text>
+                  <text x="436" y="52">Domain</text>
+                  <text x="540" y="52">MASA</text>
+                  <text x="168" y="68">Agent</text>
+                  <text x="312" y="68">Registrar</text>
+                  <text x="436" y="68">CA</text>
+                  <text x="16" y="100">|</text>
                   <text x="168" y="100">|</text>
                   <text x="312" y="100">|</text>
-                  <text x="432" y="100">|</text>
-                  <text x="492" y="100">Internet</text>
-                  <text x="536" y="100">|</text>
-                  <text x="32" y="116">~</text>
+                  <text x="456" y="100">|</text>
+                  <text x="516" y="100">Internet</text>
+                  <text x="560" y="100">|</text>
+                  <text x="16" y="116">~</text>
                   <text x="168" y="116">~</text>
                   <text x="312" y="116">~</text>
-                  <text x="432" y="116">~</text>
-                  <text x="536" y="116">~</text>
-                  <text x="44" y="132">(10)</text>
-                  <text x="92" y="132">Enroll</text>
-                  <text x="148" y="132">Status</text>
-                  <text x="216" y="132">Telemetry</text>
-                  <text x="32" y="148">~</text>
+                  <text x="456" y="116">~</text>
+                  <text x="560" y="116">~</text>
+                  <text x="20" y="132">(10)</text>
+                  <text x="68" y="132">Enroll</text>
+                  <text x="124" y="132">Status</text>
+                  <text x="192" y="132">Telemetry</text>
+                  <text x="16" y="148">~</text>
                   <text x="168" y="148">~</text>
                   <text x="312" y="148">~</text>
-                  <text x="432" y="148">~</text>
-                  <text x="536" y="148">~</text>
-                  <text x="240" y="180">eStatus</text>
-                  <text x="32" y="212">~</text>
-                  <text x="168" y="212">~</text>
-                  <text x="312" y="212">~</text>
-                  <text x="432" y="212">~</text>
-                  <text x="536" y="212">~</text>
+                  <text x="456" y="148">~</text>
+                  <text x="560" y="148">~</text>
+                  <text x="236" y="180">mTLS</text>
+                  <text x="240" y="196">eStatus</text>
+                  <text x="16" y="228">~</text>
+                  <text x="168" y="228">~</text>
+                  <text x="312" y="228">~</text>
+                  <text x="456" y="228">~</text>
+                  <text x="560" y="228">~</text>
                 </g>
               </svg><a href="#section-7.10-2.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-25" class="selfRef">Figure 25</a>:
-<a href="#name-enroll-status-provisioning-" class="selfRef">Enroll-Status provisioning to domain registrar</a>
+<figcaption><a href="#figure-26" class="selfRef">Figure 26</a>:
+<a href="#name-enroll-status-telemetry-exc" class="selfRef">Enroll Status telemetry exchange</a>
           </figcaption></figure>
 </div>
+<p id="section-7.10-3">In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-7.10-3" class="pilcrow">¶</a></p>
 <div id="request-artifact-enroll-status-estatus">
 <section id="section-7.10.1">
           <h4 id="name-request-artifact-enroll-sta">
 <a href="#section-7.10.1" class="section-number selfRef">7.10.1. </a><a href="#name-request-artifact-enroll-sta" class="section-name selfRef">Request Artifact: Enroll Status (eStatus)</a>
           </h4>
 <p id="section-7.10.1-1">The Registrar-Agent sends the pledge enroll status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/enrollstatus".
-The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#estat" class="auto internal xref">Figure 24</a>.<a href="#section-7.10.1-1" class="pilcrow">¶</a></p>
+The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#estat" class="auto internal xref">Figure 25</a>.<a href="#section-7.10.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.10.1-2">The registrar <span class="bcp14">MUST</span> verify the signature of the pledge enroll status.
 Also, the registrar <span class="bcp14">SHALL</span> validate that the pledge is an accepted device of the domain based on the contained product-serial-number in the LDevID certificate referenced in the header of the enroll status.
 The registrar <span class="bcp14">SHOULD</span> log this event.
@@ -5214,17 +5304,17 @@ In case the pledge enroll status indicates a failure, the pledge was unable to v
 Note that the signature verification of the status information is an addition to the described handling in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, and is replacing the pledges TLS client authentication by DevID credentials in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.10.1-2" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="response-2">
+<div id="response-no-artifact-2">
 <section id="section-7.10.2">
-          <h4 id="name-response-3">
-<a href="#section-7.10.2" class="section-number selfRef">7.10.2. </a><a href="#name-response-3" class="section-name selfRef">Response</a>
+          <h4 id="name-response-no-artifact-3">
+<a href="#section-7.10.2" class="section-number selfRef">7.10.2. </a><a href="#name-response-no-artifact-3" class="section-name selfRef">Response (no artifact)</a>
           </h4>
-<p id="section-7.10.2-1">According to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
-Based on the failure case the registrar <span class="bcp14">MAY</span> decide that for security reasons the pledge is not allowed to reside in the domain. In this case the registrar <span class="bcp14">MUST</span> revoke the certificate.
+<p id="section-7.10.2-1">According to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes.<a href="#section-7.10.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.10.2-2">Based on the failure case the registrar <span class="bcp14">MAY</span> decide that for security reasons the pledge is not allowed to reside in the domain. In this case the registrar <span class="bcp14">MUST</span> revoke the certificate.
 An example case for the registrar revoking the issued LDevID for the pledge is when the pledge was not able to verify the received LDevID certificate and therefore did send a 406 (Not Acceptable) response.
-In this case the registrar may revoke the LDevID certificate as the pledge did no accepted it for installation.<a href="#section-7.10.2-1" class="pilcrow">¶</a></p>
-<p id="section-7.10.2-2">The Registrar-Agent may use the response to signal success / failure to the service technician operating the Registrar-Agent.
-Within the server log the registrar <span class="bcp14">SHOULD</span> capture this telemetry information.<a href="#section-7.10.2-2" class="pilcrow">¶</a></p>
+In this case the registrar may revoke the LDevID certificate as the pledge did no accepted it for installation.<a href="#section-7.10.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.10.2-3">The Registrar-Agent may use the response to signal success / failure to the service technician operating the Registrar-Agent.
+Within the server log the registrar <span class="bcp14">SHOULD</span> capture this telemetry information.<a href="#section-7.10.2-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -5236,126 +5326,158 @@ Within the server log the registrar <span class="bcp14">SHOULD</span> capture th
         </h3>
 <p id="section-7.11-1">The following assumes that a Registrar-Agent may need to query the status of a pledge.
 This information may be useful to solve errors, when the pledge was not able to connect to the target domain during the bootstrapping.
-The pledge <span class="bcp14">MAY</span> provide a dedicated endpoint to accept status-requests.<a href="#section-7.11-1" class="pilcrow">¶</a></p>
-<span id="name-pledge-status-handling-betw"></span><div id="exchangesfig_uc2_11">
-<figure id="figure-26">
+The pledge <span class="bcp14">MAY</span> provide the dedicated endpoint for the Query Pledge Status operation.<a href="#section-7.11-1" class="pilcrow">¶</a></p>
+<span id="name-pledge-status-exchange"></span><div id="exchangesfig_uc2_11">
+<figure id="figure-27">
           <div id="section-7.11-2.1">
-            <div class="alignLeft art-svg artwork" id="section-7.11-2.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="240" width="560" viewBox="0 0 560 240" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+            <div class="alignCenter art-svg artwork" id="section-7.11-2.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="576" viewBox="0 0 576 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 32,160 L 32,208" fill="none" stroke="black"></path>
+                <path d="M 16,160 L 16,224" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
-                <path d="M 168,160 L 168,208" fill="none" stroke="black"></path>
-                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
-                <path d="M 312,160 L 312,208" fill="none" stroke="black"></path>
-                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 432,160 L 432,208" fill="none" stroke="black"></path>
-                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 120,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
+                <path d="M 224,32 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 264,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
+                <path d="M 360,32 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 400,80" fill="none" stroke="black"></path>
+                <path d="M 456,160 L 456,224" fill="none" stroke="black"></path>
                 <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
-                <path d="M 536,160 L 536,208" fill="none" stroke="black"></path>
-                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 512,80" fill="none" stroke="black"></path>
+                <path d="M 560,160 L 560,224" fill="none" stroke="black"></path>
+                <path d="M 568,32 L 568,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
-                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 120,32 L 224,32" fill="none" stroke="black"></path>
+                <path d="M 264,32 L 360,32" fill="none" stroke="black"></path>
+                <path d="M 400,32 L 472,32" fill="none" stroke="black"></path>
+                <path d="M 512,32 L 568,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
-                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
-                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
-                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
-                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <path d="M 120,80 L 224,80" fill="none" stroke="black"></path>
+                <path d="M 264,80 L 360,80" fill="none" stroke="black"></path>
+                <path d="M 400,80 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 512,80 L 568,80" fill="none" stroke="black"></path>
+                <path d="M 24,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 128,176 L 160,176" fill="none" stroke="black"></path>
+                <path d="M 24,192 L 64,192" fill="none" stroke="black"></path>
+                <path d="M 128,192 L 160,192" fill="none" stroke="black"></path>
+                <path d="M 24,208 L 64,208" fill="none" stroke="black"></path>
+                <path d="M 128,208 L 160,208" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="168,208 156,202.4 156,213.6" fill="black" transform="rotate(0,160,208)"></polygon>
+                <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
+                <polygon class="arrowhead" points="32,192 20,186.4 20,197.6" fill="black" transform="rotate(180,24,192)"></polygon>
+                <polygon class="arrowhead" points="32,176 20,170.4 20,181.6" fill="black" transform="rotate(180,24,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="164" y="52">Registrar-</text>
-                  <text x="276" y="52">Domain</text>
-                  <text x="412" y="52">Domain</text>
-                  <text x="500" y="52">MASA</text>
-                  <text x="144" y="68">Agent</text>
-                  <text x="288" y="68">Registrar</text>
-                  <text x="396" y="68">CA</text>
-                  <text x="32" y="100">|</text>
+                  <text x="172" y="52">Registrar-</text>
+                  <text x="308" y="52">Domain</text>
+                  <text x="436" y="52">Domain</text>
+                  <text x="540" y="52">MASA</text>
+                  <text x="168" y="68">Agent</text>
+                  <text x="312" y="68">Registrar</text>
+                  <text x="436" y="68">CA</text>
+                  <text x="16" y="100">|</text>
                   <text x="168" y="100">|</text>
                   <text x="312" y="100">|</text>
-                  <text x="432" y="100">|</text>
-                  <text x="492" y="100">Internet</text>
-                  <text x="536" y="100">|</text>
-                  <text x="32" y="116">~</text>
+                  <text x="456" y="100">|</text>
+                  <text x="516" y="100">Internet</text>
+                  <text x="560" y="100">|</text>
+                  <text x="16" y="116">~</text>
                   <text x="168" y="116">~</text>
                   <text x="312" y="116">~</text>
-                  <text x="432" y="116">~</text>
-                  <text x="536" y="116">~</text>
-                  <text x="44" y="132">(11)</text>
-                  <text x="88" y="132">Query</text>
-                  <text x="140" y="132">Pledge</text>
-                  <text x="196" y="132">Status</text>
-                  <text x="32" y="148">~</text>
+                  <text x="456" y="116">~</text>
+                  <text x="560" y="116">~</text>
+                  <text x="20" y="132">(11)</text>
+                  <text x="64" y="132">Query</text>
+                  <text x="116" y="132">Pledge</text>
+                  <text x="172" y="132">Status</text>
+                  <text x="16" y="148">~</text>
                   <text x="168" y="148">~</text>
                   <text x="312" y="148">~</text>
-                  <text x="432" y="148">~</text>
-                  <text x="536" y="148">~</text>
-                  <text x="112" y="180">pStatus-Req--</text>
-                  <text x="100" y="196">--pStatus-Resp-&gt;</text>
-                  <text x="32" y="228">~</text>
-                  <text x="168" y="228">~</text>
-                  <text x="312" y="228">~</text>
-                  <text x="432" y="228">~</text>
-                  <text x="536" y="228">~</text>
+                  <text x="456" y="148">~</text>
+                  <text x="560" y="148">~</text>
+                  <text x="76" y="180">opt.</text>
+                  <text x="112" y="180">TLS</text>
+                  <text x="96" y="196">qStatus</text>
+                  <text x="96" y="212">pStatus</text>
+                  <text x="16" y="244">~</text>
+                  <text x="168" y="244">~</text>
+                  <text x="312" y="244">~</text>
+                  <text x="456" y="244">~</text>
+                  <text x="560" y="244">~</text>
                 </g>
               </svg><a href="#section-7.11-2.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-26" class="selfRef">Figure 26</a>:
-<a href="#name-pledge-status-handling-betw" class="selfRef">Pledge-status handling between Registrar-Agent and pledge</a>
+<figcaption><a href="#figure-27" class="selfRef">Figure 27</a>:
+<a href="#name-pledge-status-exchange" class="selfRef">Pledge Status exchange</a>
           </figcaption></figure>
 </div>
-<div id="request-artifact-pledge-status-request-pstatus-req">
+<p id="section-7.11-3">The Registrar-Agent queries the Pledge Status via HTTP POST request on the well-known pledge endpoint <code>/.well-known/brski/qps</code>.
+The request body <span class="bcp14">MUST</span> contain the JWS-signed Status Query (qStatus) artifact.
+The request header <span class="bcp14">MUST</span> set the Content-Type field <code>application/jose+json</code>.<a href="#section-7.11-3" class="pilcrow">¶</a></p>
+<p id="section-7.11-4">If the pledge provides the Query Pledge Status endpoint, it <span class="bcp14">MUST</span> reply to this request with the Pledge Status (pStatus) artifact in the body of a 200 OK response.
+The response header <span class="bcp14">MUST</span> have the Content-Type field set to <code>application/jose+json</code>.<a href="#section-7.11-4" class="pilcrow">¶</a></p>
+<div id="request-artifact-status-query-qstatus">
 <section id="section-7.11.1">
-          <h4 id="name-request-artifact-pledge-sta">
-<a href="#section-7.11.1" class="section-number selfRef">7.11.1. </a><a href="#name-request-artifact-pledge-sta" class="section-name selfRef">Request Artifact: Pledge Status Request (pStatus-Req)</a>
+          <h4 id="name-request-artifact-status-que">
+<a href="#section-7.11.1" class="section-number selfRef">7.11.1. </a><a href="#name-request-artifact-status-que" class="section-name selfRef">Request Artifact: Status Query (qStatus)</a>
           </h4>
-<p id="section-7.11.1-1">The Registrar-Agent requests the pledge-status via HTTP POST on the defined pledge endpoint: "/.well-known/brski/qps"<a href="#section-7.11.1-1" class="pilcrow">¶</a></p>
-<p id="section-7.11.1-2">The Registrar-Agent Content-Type header for the pledge-status request is: <code>application/jose+json</code>.
-It contains information on the requested status-type, the time and date the request is created, and the product serial-number of the pledge contacted as shown in <a href="#stat_req_def" class="auto internal xref">Figure 27</a>.
-The pledge-status request is signed by Registrar-Agent using the private key corresponding to the EE (RegAgt) certificate.<a href="#section-7.11.1-2" class="pilcrow">¶</a></p>
-<p id="section-7.11.1-3">The following Concise Data Definition Language (CDDL) <span>[<a href="#RFC8610" class="cite xref">RFC8610</a>]</span> explains the structure of the format for the pledge-status request. It is defined following the status telemetry definitions in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-Consequently, format and semantics of pledge-status requests below are for version 1.
-The version field is included to permit significant changes to the pledge-status request and response in the future.
-A pledge or a Registrar-Agent that receives a pledge-status request with a version larger than it knows about <span class="bcp14">SHOULD</span> log the contents and alert a human.<a href="#section-7.11.1-3" class="pilcrow">¶</a></p>
-<span id="name-cddl-for-pledge-status-requ"></span><div id="stat_req_def">
-<figure id="figure-27">
-            <div class="sourcecode" id="section-7.11.1-4.1">
+<p id="section-7.11.1-1">The Status Query artifact is a JWS structure signing information on the requested status-type, the time and date the request is created, and the product serial-number of the pledge contacted as shown in <a href="#stat_req_def" class="auto internal xref">Figure 28</a>.
+The following Concise Data Definition Language (CDDL) <span>[<a href="#RFC8610" class="cite xref">RFC8610</a>]</span> defines the structure of the unsigned Status Query data (i.e., JWS payload):<a href="#section-7.11.1-1" class="pilcrow">¶</a></p>
+<span id="name-cddl-for-unsigned-status-qu"></span><div id="stat_req_def">
+<figure id="figure-28">
+            <div class="sourcecode" id="section-7.11.1-2.1">
 <pre>&lt;CODE BEGINS&gt;
-  status-request = {
+  status-query = {
       "version": uint,
       "created-on": tdate ttime,
+TODO: Not sure if "ttime" exists. tdate is already a string with CBOR tag 0, i.e., a full datatime string
       "serial-number": text,
       "status-type": text
   }
 
 &lt;CODE ENDS&gt;</pre>
 </div>
-<figcaption><a href="#figure-27" class="selfRef">Figure 27</a>:
-<a href="#name-cddl-for-pledge-status-requ" class="selfRef">CDDL for pledge-status request</a>
+<figcaption><a href="#figure-28" class="selfRef">Figure 28</a>:
+<a href="#name-cddl-for-unsigned-status-qu" class="selfRef">CDDL for unsigned Status Query data (status-query)</a>
             </figcaption></figure>
 </div>
-<p id="section-7.11.1-5">The status-type defined for BRSKI-PRM is "bootstrap".
-This indicates the pledge to provide current status information regarding the bootstrapping status (voucher processing and enrollment of the pledge into the new domain).
-As the pledge-status request is defined generic, it may be used by other specifications to request further status information, e.g., for onboarding to get further information about enrollment of application specific LDevIDs or other parameters.
-This is out of scope for this specification.<a href="#section-7.11.1-5" class="pilcrow">¶</a></p>
-<p id="section-7.11.1-6"><a href="#stat_req" class="auto internal xref">Figure 28</a> below shows an example for querying pledge-status using status-type bootstrap.<a href="#section-7.11.1-6" class="pilcrow">¶</a></p>
-<span id="name-example-of-registrar-agent-"></span><div id="stat_req">
-<figure id="figure-28">
-            <div class="alignLeft art-text artwork" id="section-7.11.1-7.1">
+<p id="section-7.11.1-3">The <code>version</code> field is included to permit significant changes to the pledge status artifacts in the future.
+The format and semantics in this document follow the status telemetry definitions of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+Hence, the version <span class="bcp14">MUST</span> be set to <code>1</code>.
+A pledge (or Registrar-Agent) that receives a version larger than it knows about <span class="bcp14">SHOULD</span> log the contents and alert a human.<a href="#section-7.11.1-3" class="pilcrow">¶</a></p>
+<p id="section-7.11.1-4">The <code>created-on</code> field contains a standard date/time string following <span>[<a href="#RFC3339" class="cite xref">RFC3339</a>]</span>.<a href="#section-7.11.1-4" class="pilcrow">¶</a></p>
+<p id="section-7.11.1-5">The <code>serial-number</code> field takes the product-serial-number corresponding to the X520SerialNumber field of the IDevID certificate of the pledge.<a href="#section-7.11.1-5" class="pilcrow">¶</a></p>
+<p id="section-7.11.1-6">The <code>status-type</code> value defined for BRSKI-PRM Status Query is <code>bootstrap</code>.
+This indicates the pledge to provide current status information regarding the bootstrapping status (voucher processing and enrollment of the pledge into the new domain).<a href="#section-7.11.1-6" class="pilcrow">¶</a></p>
+<p id="section-7.11.1-7">As the Status Query artifact is defined generic, it may be used by other specifications to request further status information using other status types, e.g., for onboarding to get further information about enrollment of application specific LDevIDs or other parameters.
+This is out of scope for this specification.<a href="#section-7.11.1-7" class="pilcrow">¶</a></p>
+<p id="section-7.11.1-8"><a href="#stat_req_data" class="auto internal xref">Figure 29</a> below shows an example for unsigned Status Query data in JSON syntax using status-type <code>bootstrap</code>.<a href="#section-7.11.1-8" class="pilcrow">¶</a></p>
+<span id="name-example-of-unsigned-status-"></span><div id="stat_req_data">
+<figure id="figure-29">
+            <div class="alignLeft art-text artwork" id="section-7.11.1-9.1">
 <pre>
-# The Registrar-Agent request of "pledge-status" in general JWS
-  serialization syntax
 {
-  "payload": BASE64URL(UTF8(status-request)),
+  "version": 1,
+  "created-on": "2022-08-12T02:37:39.235Z",
+  "serial-number": "pledge-callee4711",
+  "status-type": "bootstrap"
+}
+</pre>
+</div>
+<figcaption><a href="#figure-29" class="selfRef">Figure 29</a>:
+<a href="#name-example-of-unsigned-status-" class="selfRef">Example of unsigned Status Query data in JSON syntax using status-type bootstrap for the Status Query artifact</a>
+            </figcaption></figure>
+</div>
+<p id="section-7.11.1-10">The Status Query data <span class="bcp14">MUST</span> be signed by the Registrar-Agent using its private key corresponding to the EE (RegAgt) certificate.
+When using a JWS signature, the Status Query artifact looks as shown in <a href="#stat_req" class="auto internal xref">Figure 30</a> and the Content-Type response header <span class="bcp14">MUST</span> be set to <code>application/jose+json</code>:<a href="#section-7.11.1-10" class="pilcrow">¶</a></p>
+<span id="name-status-query-representation"></span><div id="stat_req">
+<figure id="figure-30">
+            <div class="alignLeft art-text artwork" id="section-7.11.1-11.1">
+<pre>
+{
+  "payload": BASE64URL(UTF8(status-query)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -5363,46 +5485,28 @@ This is out of scope for this specification.<a href="#section-7.11.1-5" class="p
     }
   ]
 }
-
-# Example: Decoded payload "status-request" representation
-  in JSON syntax
-{
-  "version": 1,
-  "created-on": "2022-08-12T02:37:39.235Z",
-  "serial-number": "pledge-callee4711",
-  "status-type": "bootstrap"
-}
-
-# Example: Decoded "JWS Protected Header" representation
-  in JSON syntax
-{
-  "alg": "ES256",
-  "x5c": [
-    "base64encodedvalue==",
-    "base64encodedvalue=="
-  ]
-}
 </pre>
 </div>
-<figcaption><a href="#figure-28" class="selfRef">Figure 28</a>:
-<a href="#name-example-of-registrar-agent-" class="selfRef">Example of Registrar-Agent request of pledge-status using status-type bootstrap</a>
+<figcaption><a href="#figure-30" class="selfRef">Figure 30</a>:
+<a href="#name-status-query-representation" class="selfRef">Status Query Representation in General JWS JSON Serialization Syntax</a>
             </figcaption></figure>
 </div>
+<p id="section-7.11.1-12">For details on <code>JWS Protected Header</code> and <code>JWS Signature</code> see <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span> or <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>.<a href="#section-7.11.1-12" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="response-artifact-pledge-status-response-pstatus-resp">
+<div id="response-artifact-pledge-status-pstatus">
 <section id="section-7.11.2">
           <h4 id="name-response-artifact-pledge-st">
-<a href="#section-7.11.2" class="section-number selfRef">7.11.2. </a><a href="#name-response-artifact-pledge-st" class="section-name selfRef">Response Artifact: Pledge Status Response (pStatus-Resp)</a>
+<a href="#section-7.11.2" class="section-number selfRef">7.11.2. </a><a href="#name-response-artifact-pledge-st" class="section-name selfRef">Response Artifact: Pledge Status (pStatus)</a>
           </h4>
-<p id="section-7.11.2-1">If the pledge receives the pledge-status request with status-type "bootstrap" it <span class="bcp14">SHALL</span> react with a status response message based on previously collected telemetry information (see <a href="#vstatus" class="auto internal xref">Section 7.9</a> and <a href="#estatus" class="auto internal xref">Section 7.10</a>) in a single status-response artifact.<a href="#section-7.11.2-1" class="pilcrow">¶</a></p>
-<p id="section-7.11.2-2">The pledge-status response Content-Type header is <code>application/jose+json</code>.<a href="#section-7.11.2-2" class="pilcrow">¶</a></p>
-<p id="section-7.11.2-3">The following CDDL explains the structure of the format for the status response, which is:<a href="#section-7.11.2-3" class="pilcrow">¶</a></p>
-<span id="name-cddl-for-pledge-status-resp"></span><div id="stat_res_def">
-<figure id="figure-29">
+<p id="section-7.11.2-1">When the pledge receives a Status Query with status-type <code>bootstrap</code> it <span class="bcp14">SHALL</span> respond with previously collected telemetry information (see <a href="#vstatus" class="auto internal xref">Section 7.9</a> and <a href="#estatus" class="auto internal xref">Section 7.10</a>) in a single Pledge Status artifact.<a href="#section-7.11.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-2">The pledge-status response message is signed with IDevID or LDevID, depending on bootstrapping state of the pledge.<a href="#section-7.11.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-3">The following CDDL defines the structure of the Pledge Status (pStatus) data:<a href="#section-7.11.2-3" class="pilcrow">¶</a></p>
+<span id="name-cddl-for-unsigned-pledge-st"></span><div id="stat_res_def">
+<figure id="figure-31">
             <div class="sourcecode" id="section-7.11.2-4.1">
 <pre>&lt;CODE BEGINS&gt;
-  status-response = {
+  pledgestatus = {
     "version": uint,
     "status":
       "factory-default" /
@@ -5418,59 +5522,58 @@ This is out of scope for this specification.<a href="#section-7.11.1-5" class="p
 
 &lt;CODE ENDS&gt;</pre>
 </div>
-<figcaption><a href="#figure-29" class="selfRef">Figure 29</a>:
-<a href="#name-cddl-for-pledge-status-resp" class="selfRef">CDDL for pledge-status response</a>
+<figcaption><a href="#figure-31" class="selfRef">Figure 31</a>:
+<a href="#name-cddl-for-unsigned-pledge-st" class="selfRef">CDDL for unsigned Pledge Status data (pledgestatus)</a>
             </figcaption></figure>
 </div>
 <p id="section-7.11.2-5">Different cases for pledge bootstrapping status may occur, which <span class="bcp14">SHOULD</span> be reflected using the status enumeration.
 This document specifies the status values in the context of the bootstrapping process and credential application.
 Other documents may enhance the above enumeration to reflect further status information.<a href="#section-7.11.2-5" class="pilcrow">¶</a></p>
-<p id="section-7.11.2-6">The pledge-status response message is signed with IDevID or LDevID, depending on bootstrapping state of the pledge.<a href="#section-7.11.2-6" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-7.11.2-7.1">
-              <p id="section-7.11.2-7.1.1">"factory-default": Pledge has not been bootstrapped.
+<li class="normal" id="section-7.11.2-6.1">
+              <p id="section-7.11.2-6.1.1">"factory-default": Pledge has not been bootstrapped.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-7.1.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-6.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-7.2">
-              <p id="section-7.11.2-7.2.1">"voucher-success": Pledge processed the voucher exchange successfully.
+            <li class="normal" id="section-7.11.2-6.2">
+              <p id="section-7.11.2-6.2.1">"voucher-success": Pledge processed the voucher exchange successfully.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-7.2.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-6.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-7.3">
-              <p id="section-7.11.2-7.3.1">"voucher-error": Pledge voucher processing terminated with error.
+            <li class="normal" id="section-7.11.2-6.3">
+              <p id="section-7.11.2-6.3.1">"voucher-error": Pledge voucher processing terminated with error.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-7.3.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-6.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-7.4">
-              <p id="section-7.11.2-7.4.1">"enroll-success": Pledge has processed the enrollment exchange successfully.
+            <li class="normal" id="section-7.11.2-6.4">
+              <p id="section-7.11.2-6.4.1">"enroll-success": Pledge has processed the enrollment exchange successfully.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-7.4.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-6.4.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-7.5">
-              <p id="section-7.11.2-7.5.1">"enroll-error": Pledge enrollment-response processing terminated with error.
+            <li class="normal" id="section-7.11.2-6.5">
+              <p id="section-7.11.2-6.5.1">"enroll-error": Pledge enrollment-response processing terminated with error.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-7.5.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-6.5.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.11.2-8">As the pledge is assumed to utilize its bootstrapped credentials (LDevID) in communication with other peers, additional status information is provided for the connectivity to other peers, which may be helpful in analyzing potential error cases.<a href="#section-7.11.2-8" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-7">As the pledge is assumed to utilize its bootstrapped credentials (LDevID) in communication with other peers, additional status information is provided for the connectivity to other peers, which may be helpful in analyzing potential error cases.<a href="#section-7.11.2-7" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-7.11.2-9.1">
-              <p id="section-7.11.2-9.1.1">"connect-success": Pledge could successfully establish a connection to another peer.
+<li class="normal" id="section-7.11.2-8.1">
+              <p id="section-7.11.2-8.1.1">"connect-success": Pledge could successfully establish a connection to another peer.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-9.1.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-8.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-9.2">
-              <p id="section-7.11.2-9.2.1">"connect-error": Pledge connection establishment terminated with error.
+            <li class="normal" id="section-7.11.2-8.2">
+              <p id="section-7.11.2-8.2.1">"connect-error": Pledge connection establishment terminated with error.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-9.2.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-8.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.11.2-10">The pledge-status responses are cumulative in the sense that connect-success implies enroll-success, which in turn implies voucher-success.<a href="#section-7.11.2-10" class="pilcrow">¶</a></p>
-<p id="section-7.11.2-11"><a href="#stat_res" class="auto internal xref">Figure 30</a> provides an example for the bootstrapping-status information.<a href="#section-7.11.2-11" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-9">The pledge-status responses are cumulative in the sense that connect-success implies enroll-success, which in turn implies voucher-success.<a href="#section-7.11.2-9" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-10"><a href="#stat_res" class="auto internal xref">Figure 32</a> provides an example for the bootstrapping-status information.<a href="#section-7.11.2-10" class="pilcrow">¶</a></p>
 <span id="name-example-of-pledge-status-re"></span><div id="stat_res">
-<figure id="figure-30">
-            <div class="alignLeft art-text artwork" id="section-7.11.2-12.1">
+<figure id="figure-32">
+            <div class="alignLeft art-text artwork" id="section-7.11.2-11.1">
 <pre>
 # The pledge "status-response" in General JWS Serialization syntax
 {
@@ -5505,31 +5608,31 @@ The pledge signs the response message using its LDevID(Pledge).<a href="#section
 }
 </pre>
 </div>
-<figcaption><a href="#figure-30" class="selfRef">Figure 30</a>:
+<figcaption><a href="#figure-32" class="selfRef">Figure 32</a>:
 <a href="#name-example-of-pledge-status-re" class="selfRef">Example of pledge-status response</a>
             </figcaption></figure>
 </div>
 <ul class="normal">
-<li class="normal" id="section-7.11.2-13.1">
-              <p id="section-7.11.2-13.1.1">In case "factory-default" the pledge does not possess the domain certificate resp. the domain trust-anchor.
-It will not be able to verify the signature of the Registrar-Agent in the bootstrapping-status request.<a href="#section-7.11.2-13.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.11.2-12.1">
+              <p id="section-7.11.2-12.1.1">In case "factory-default" the pledge does not possess the domain certificate resp. the domain trust-anchor.
+It will not be able to verify the signature of the Registrar-Agent in the bootstrapping-status request.<a href="#section-7.11.2-12.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-13.2">
-              <p id="section-7.11.2-13.2.1">In cases "vouchered" and "enrolled" the pledge already possesses the domain certificate (has domain trust-anchor) and can therefore validate the signature of the Registrar-Agent.
-If validation of the JWS signature fails, the pledge <span class="bcp14">SHOULD</span> respond with the HTTP 403 Forbidden status code.<a href="#section-7.11.2-13.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-12.2">
+              <p id="section-7.11.2-12.2.1">In cases "vouchered" and "enrolled" the pledge already possesses the domain certificate (has domain trust-anchor) and can therefore validate the signature of the Registrar-Agent.
+If validation of the JWS signature fails, the pledge <span class="bcp14">SHOULD</span> respond with the HTTP 403 Forbidden status code.<a href="#section-7.11.2-12.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-13.3">
-              <p id="section-7.11.2-13.3.1">The HTTP 406 Not Acceptable status code <span class="bcp14">SHOULD</span> be used, if the Accept header in the request indicates an unknown or unsupported format.<a href="#section-7.11.2-13.3.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-12.3">
+              <p id="section-7.11.2-12.3.1">The HTTP 406 Not Acceptable status code <span class="bcp14">SHOULD</span> be used, if the Accept header in the request indicates an unknown or unsupported format.<a href="#section-7.11.2-12.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-13.4">
-              <p id="section-7.11.2-13.4.1">The HTTP 415 Unsupported Media Type status code <span class="bcp14">SHOULD</span> be used, if the Content-Type of the request is an unknown or unsupported format.<a href="#section-7.11.2-13.4.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-12.4">
+              <p id="section-7.11.2-12.4.1">The HTTP 415 Unsupported Media Type status code <span class="bcp14">SHOULD</span> be used, if the Content-Type of the request is an unknown or unsupported format.<a href="#section-7.11.2-12.4.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-7.11.2-13.5">
-              <p id="section-7.11.2-13.5.1">The HTTP 400 Bad Request status code <span class="bcp14">SHOULD</span> be used, if the Accept/Content-Type headers are correct but nevertheless the status-request cannot be correctly parsed.<a href="#section-7.11.2-13.5.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-12.5">
+              <p id="section-7.11.2-12.5.1">The HTTP 400 Bad Request status code <span class="bcp14">SHOULD</span> be used, if the Accept/Content-Type headers are correct but nevertheless the status-request cannot be correctly parsed.<a href="#section-7.11.2-12.5.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-7.11.2-14">The pledge <span class="bcp14">SHOULD</span> by default only respond to requests from nodes it can authenticate (such as registrar
-agent), once the pledge is enrolled with CA certificates and a matching domain certificate.<a href="#section-7.11.2-14" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-13">The pledge <span class="bcp14">SHOULD</span> by default only respond to requests from nodes it can authenticate (such as registrar
+agent), once the pledge is enrolled with CA certificates and a matching domain certificate.<a href="#section-7.11.2-13" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -5788,9 +5891,9 @@ Support in PoC implementations and comments resulting from the implementation wa
         <dd>
 <span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>&gt;</span>. </dd>
 <dd class="break"></dd>
-<dt id="RFC2986">[RFC2986]</dt>
+<dt id="RFC3339">[RFC3339]</dt>
         <dd>
-<span class="refAuthor">Nystrom, M.</span> and <span class="refAuthor">B. Kaliski</span>, <span class="refTitle">"PKCS #10: Certification Request Syntax Specification Version 1.7"</span>, <span class="seriesInfo">RFC 2986</span>, <span class="seriesInfo">DOI 10.17487/RFC2986</span>, <time datetime="2000-11" class="refDate">November 2000</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc2986">https://www.rfc-editor.org/rfc/rfc2986</a>&gt;</span>. </dd>
+<span class="refAuthor">Klyne, G.</span> and <span class="refAuthor">C. Newman</span>, <span class="refTitle">"Date and Time on the Internet: Timestamps"</span>, <span class="seriesInfo">RFC 3339</span>, <span class="seriesInfo">DOI 10.17487/RFC3339</span>, <time datetime="2002-07" class="refDate">July 2002</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc3339">https://www.rfc-editor.org/rfc/rfc3339</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC6762">[RFC6762]</dt>
         <dd>
@@ -5859,7 +5962,7 @@ Support in PoC implementations and comments resulting from the implementation wa
 <dd class="break"></dd>
 <dt id="I-D.ietf-anima-brski-ae">[I-D.ietf-anima-brski-ae]</dt>
         <dd>
-<span class="refAuthor">von Oheimb, D.</span>, <span class="refAuthor">Fries, S.</span>, and <span class="refAuthor">H. Brockhaus</span>, <span class="refTitle">"BRSKI-AE: Alternative Enrollment Protocols in BRSKI"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-anima-brski-ae-09</span>, <time datetime="2023-12-19" class="refDate">19 December 2023</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-anima-brski-ae-09">https://datatracker.ietf.org/doc/html/draft-ietf-anima-brski-ae-09</a>&gt;</span>. </dd>
+<span class="refAuthor">von Oheimb, D.</span>, <span class="refAuthor">Fries, S.</span>, and <span class="refAuthor">H. Brockhaus</span>, <span class="refTitle">"BRSKI-AE: Alternative Enrollment Protocols in BRSKI"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-anima-brski-ae-10</span>, <time datetime="2024-03-01" class="refDate">1 March 2024</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-anima-brski-ae-10">https://datatracker.ietf.org/doc/html/draft-ietf-anima-brski-ae-10</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="I-D.irtf-t2trg-taxonomy-manufacturer-anchors">[I-D.irtf-t2trg-taxonomy-manufacturer-anchors]</dt>
         <dd>
@@ -5880,6 +5983,10 @@ Support in PoC implementations and comments resulting from the implementation wa
 <dt id="onpath">[onpath]</dt>
         <dd>
 <span class="refTitle">"can an on-path attacker drop traffic?"</span>, <span>n.d.</span>, <span>&lt;<a href="https://mailarchive.ietf.org/arch/msg/saag/m1r9uo4xYznOcf85Eyk0Rhut598/">https://mailarchive.ietf.org/arch/msg/saag/m1r9uo4xYznOcf85Eyk0Rhut598/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC2986">[RFC2986]</dt>
+        <dd>
+<span class="refAuthor">Nystrom, M.</span> and <span class="refAuthor">B. Kaliski</span>, <span class="refTitle">"PKCS #10: Certification Request Syntax Specification Version 1.7"</span>, <span class="seriesInfo">RFC 2986</span>, <span class="seriesInfo">DOI 10.17487/RFC2986</span>, <time datetime="2000-11" class="refDate">November 2000</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc2986">https://www.rfc-editor.org/rfc/rfc2986</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC3629">[RFC3629]</dt>
         <dd>
@@ -5955,7 +6062,7 @@ Support in PoC implementations and comments resulting from the implementation wa
 <p id="appendix-A.1-1">The following is an example request sent from a Pledge to the Registrar-Agent, in "General JWS JSON Serialization".
 The message size of this PVR is: 4649 bytes<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
 <span id="name-example-pledge-voucher-reque"></span><div id="ExamplePledgeVoucherRequestfigure">
-<figure id="figure-31">
+<figure id="figure-33">
           <div class="alignLeft art-text artwork" id="appendix-A.1-2.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -6037,7 +6144,7 @@ yuXZ2aw93zZId45R7XxAK-12YKIx6qLjiPjMw"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-31" class="selfRef">Figure 31</a>:
+<figcaption><a href="#figure-33" class="selfRef">Figure 33</a>:
 <a href="#name-example-pledge-voucher-reque" class="selfRef">Example Pledge-Voucher-Request - PVR</a>
           </figcaption></figure>
 </div>
@@ -6054,7 +6161,7 @@ been received by the Registrar, and then has been processed by the Registrar ("c
 Note that the previous PVR can be seen in the payload as "prior-signed-voucher-request".
 The message size of this RVR is: 13257 bytes<a href="#appendix-A.2-2" class="pilcrow">¶</a></p>
 <span id="name-example-registrar-voucher-r"></span><div id="ExampleRegistrarVoucherRequestfigure">
-<figure id="figure-32">
+<figure id="figure-34">
           <div class="alignLeft art-text artwork" id="appendix-A.2-3.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -6262,7 +6369,7 @@ yyFd3kP6YCn35YYJ7yK35d3styo_yoiPfKA"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-32" class="selfRef">Figure 32</a>:
+<figcaption><a href="#figure-34" class="selfRef">Figure 34</a>:
 <a href="#name-example-registrar-voucher-r" class="selfRef">Example Registrar-Voucher-Request - RVR</a>
           </figcaption></figure>
 </div>
@@ -6275,7 +6382,7 @@ yyFd3kP6YCn35YYJ7yK35d3styo_yoiPfKA"
         </h3>
 <p id="appendix-A.3-1">The following is an example voucher-response from MASA to Pledge via Registrar and Registrar-Agent, in "General JWS JSON Serialization". The message size of this Voucher is: 1916 bytes<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
 <span id="name-example-voucher-response-fr"></span><div id="ExampleVoucherResponsefigure">
-<figure id="figure-33">
+<figure id="figure-35">
           <div class="alignLeft art-text artwork" id="appendix-A.3-2.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -6315,7 +6422,7 @@ TvHMUw0wx9wdyuNVjNoAgLysNIgEvlcltBw"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-33" class="selfRef">Figure 33</a>:
+<figcaption><a href="#figure-35" class="selfRef">Figure 35</a>:
 <a href="#name-example-voucher-response-fr" class="selfRef">Example Voucher-Response from MASA</a>
           </figcaption></figure>
 </div>
@@ -6329,7 +6436,7 @@ TvHMUw0wx9wdyuNVjNoAgLysNIgEvlcltBw"
 <p id="appendix-A.4-1">The following is an example voucher-response from MASA to Pledge via Registrar and Registrar-Agent, in "General JWS JSON Serialization".
 The message size of this Voucher is: 3006 bytes<a href="#appendix-A.4-1" class="pilcrow">¶</a></p>
 <span id="name-example-voucher-response-fro"></span><div id="ExampleVoucherResponseWithRegSignfigure">
-<figure id="figure-34">
+<figure id="figure-36">
           <div class="alignLeft art-text artwork" id="appendix-A.4-2.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -6387,7 +6494,7 @@ qhRRyjnxp80IV_Fy1RAOXIIzs3Q8CnMgBgg"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-34" class="selfRef">Figure 34</a>:
+<figcaption><a href="#figure-36" class="selfRef">Figure 36</a>:
 <a href="#name-example-voucher-response-fro" class="selfRef">Example Voucher-Response from MASA, with additional Registrar signature</a>
           </figcaption></figure>
 </div>
@@ -6571,7 +6678,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-9.14.1">issue #99: motivated verification of second signature on voucher in <a href="#voucher" class="auto internal xref">Section 7.6</a><a href="#appendix-C-9.14.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.15">
-          <p id="appendix-C-9.15.1">issue #100: included negative example in <a href="#vstat" class="auto internal xref">Figure 20</a><a href="#appendix-C-9.15.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.15.1">issue #100: included negative example in <a href="#vstat" class="auto internal xref">Figure 21</a><a href="#appendix-C-9.15.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.16">
           <p id="appendix-C-9.16.1">issue #101: included handling if <a href="#voucher" class="auto internal xref">Section 7.6</a> voucher telemetry information has not been received by the Registrar-Agent<a href="#appendix-C-9.16.1" class="pilcrow">¶</a></p>
@@ -6580,7 +6687,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-9.17.1">issue #102: relaxed requirements for CA certs provisioning in <a href="#cacerts" class="auto internal xref">Section 7.7</a><a href="#appendix-C-9.17.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.18">
-          <p id="appendix-C-9.18.1">issue #105: included negative example in <a href="#estat" class="auto internal xref">Figure 24</a><a href="#appendix-C-9.18.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.18.1">issue #105: included negative example in <a href="#estat" class="auto internal xref">Figure 25</a><a href="#appendix-C-9.18.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.19">
           <p id="appendix-C-9.19.1">issue #107: included example for certificate revocation in <a href="#estatus" class="auto internal xref">Section 7.10</a><a href="#appendix-C-9.19.1" class="pilcrow">¶</a></p>
@@ -6592,7 +6699,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-9.21.1">issue #111: included pledge-status response processing for authenticated requests in <a href="#query" class="auto internal xref">Section 7.11</a><a href="#appendix-C-9.21.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.22">
-          <p id="appendix-C-9.22.1">issue #112: added "Example key word in pledge-status response in <a href="#stat_res" class="auto internal xref">Figure 30</a><a href="#appendix-C-9.22.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.22.1">issue #112: added "Example key word in pledge-status response in <a href="#stat_res" class="auto internal xref">Figure 32</a><a href="#appendix-C-9.22.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.23">
           <p id="appendix-C-9.23.1">issue #113: enhanced description of status reply for "factory-default" in  <a href="#query" class="auto internal xref">Section 7.11</a><a href="#appendix-C-9.23.1" class="pilcrow">¶</a></p>

--- a/draft-ietf-anima-brski-prm.html
+++ b/draft-ietf-anima-brski-prm.html
@@ -16,10 +16,10 @@ For this, BRSKI with Pledge in Responder Mode (BRSKI-PRM) introduces a new compo
 To establish the trust relation between pledge and registrar, BRSKI-PRM relies on object security rather than transport security.
 The approach defined here is agnostic to the enrollment protocol that connects the domain registrar to the domain CA. 
     " name="description">
-<meta content="xml2rfc 3.19.4" name="generator">
+<meta content="xml2rfc 3.20.0" name="generator">
 <meta content="draft-ietf-anima-brski-prm-12" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.19.4
+  xml2rfc 3.20.0
     Python 3.10.12
     ConfigArgParse 1.7
     google-i18n-address 3.1.0
@@ -33,9 +33,9 @@ The approach defined here is agnostic to the enrollment protocol that connects t
     setuptools 59.6.0
     six 1.16.0
     wcwidth 0.2.13
-    weasyprint 60.2
+    weasyprint 61.0
 -->
-<link href="/usr/src/app/tmp/0a0f6133-dfbd-4018-95bf-f5619587bec0/20240215.xml" rel="alternate" type="application/rfc+xml">
+<link href="/usr/src/app/tmp/a20127f7-d256-46a5-807a-2baa813f45e9/20240229.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -460,6 +460,10 @@ nav.toc li {
 }
 
 .refInstance {
+  margin-bottom: 1.25em;
+}
+
+.refSubseries {
   margin-bottom: 1.25em;
 }
 
@@ -1215,7 +1219,7 @@ li > p:last-of-type:only-child {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Fries, et al.</td>
-<td class="center">Expires 18 August 2024</td>
+<td class="center">Expires 1 September 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1228,12 +1232,12 @@ li > p:last-of-type:only-child {
 <dd class="internet-draft">draft-ietf-anima-brski-prm-12</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-02-15" class="published">15 February 2024</time>
+<time datetime="2024-02-29" class="published">29 February 2024</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-08-18">18 August 2024</time></dd>
+<dd class="expires"><time datetime="2024-09-01">1 September 2024</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1293,7 +1297,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 18 August 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 1 September 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1428,7 +1432,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3">
-                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="auto internal xref">7.3</a>.  <a href="#name-request-voucher-from-the-re" class="internal xref">Request Voucher from the Registrar</a></p>
+                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="auto internal xref">7.3</a>.  <a href="#name-supply-voucher-request-to-r" class="internal xref">Supply Voucher Request to Registrar (including backend interaction)</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.1">
                     <p id="section-toc.1-1.7.2.3.2.1.1"><a href="#section-7.3.1" class="auto internal xref">7.3.1</a>.  <a href="#name-request-artifact-pvr" class="internal xref">Request Artifact: PVR</a></p>
@@ -1448,7 +1452,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.4">
-                <p id="section-toc.1-1.7.2.4.1"><a href="#section-7.4" class="auto internal xref">7.4</a>.  <a href="#name-supply-per-to-registrar" class="internal xref">Supply PER to Registrar</a></p>
+                <p id="section-toc.1-1.7.2.4.1"><a href="#section-7.4" class="auto internal xref">7.4</a>.  <a href="#name-supply-per-to-registrar-inc" class="internal xref">Supply PER to Registrar (including backend interaction)</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.4.2.1">
                     <p id="section-toc.1-1.7.2.4.2.1.1"><a href="#section-7.4.1" class="auto internal xref">7.4.1</a>.  <a href="#name-request-artifact-pledge-enro" class="internal xref">Request Artifact: Pledge Enroll-Request (PER)</a></p>
@@ -1479,7 +1483,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                     <p id="section-toc.1-1.7.2.6.2.1.1"><a href="#section-7.6.1" class="auto internal xref">7.6.1</a>.  <a href="#name-request-artifact-voucher" class="internal xref">Request Artifact: Voucher</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.6.2.2">
-                    <p id="section-toc.1-1.7.2.6.2.2.1"><a href="#section-7.6.2" class="auto internal xref">7.6.2</a>.  <a href="#name-response-artifact-vstatus" class="internal xref">Response Artifact: vStatus</a></p>
+                    <p id="section-toc.1-1.7.2.6.2.2.1"><a href="#section-7.6.2" class="auto internal xref">7.6.2</a>.  <a href="#name-response-artifact-voucher-s" class="internal xref">Response Artifact: Voucher Status (vStatus)</a></p>
 </li>
                 </ul>
 </li>
@@ -1501,7 +1505,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                     <p id="section-toc.1-1.7.2.8.2.1.1"><a href="#section-7.8.1" class="auto internal xref">7.8.1</a>.  <a href="#name-request-artifact-enroll-res" class="internal xref">Request Artifact: Enroll-Response</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.8.2.2">
-                    <p id="section-toc.1-1.7.2.8.2.2.1"><a href="#section-7.8.2" class="auto internal xref">7.8.2</a>.  <a href="#name-response-artifact-estatus" class="internal xref">Response Artifact: eStatus</a></p>
+                    <p id="section-toc.1-1.7.2.8.2.2.1"><a href="#section-7.8.2" class="auto internal xref">7.8.2</a>.  <a href="#name-response-artifact-enroll-st" class="internal xref">Response Artifact: Enroll Status (eStatus)</a></p>
 </li>
                 </ul>
 </li>
@@ -1509,7 +1513,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 <p id="section-toc.1-1.7.2.9.1"><a href="#section-7.9" class="auto internal xref">7.9</a>.  <a href="#name-voucher-status-telemetry" class="internal xref">Voucher Status Telemetry</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.9.2.1">
-                    <p id="section-toc.1-1.7.2.9.2.1.1"><a href="#section-7.9.1" class="auto internal xref">7.9.1</a>.  <a href="#name-request-artifact-vstatus" class="internal xref">Request Artifact: vStatus</a></p>
+                    <p id="section-toc.1-1.7.2.9.2.1.1"><a href="#section-7.9.1" class="auto internal xref">7.9.1</a>.  <a href="#name-request-artifact-voucher-st" class="internal xref">Request Artifact: Voucher Status (vStatus)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.9.2.2">
                     <p id="section-toc.1-1.7.2.9.2.2.1"><a href="#section-7.9.2" class="auto internal xref">7.9.2</a>.  <a href="#name-response-2" class="internal xref">Response</a></p>
@@ -1520,7 +1524,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 <p id="section-toc.1-1.7.2.10.1"><a href="#section-7.10" class="auto internal xref">7.10</a>. <a href="#name-enroll-status-telemetry" class="internal xref">Enroll Status Telemetry</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.10.2.1">
-                    <p id="section-toc.1-1.7.2.10.2.1.1"><a href="#section-7.10.1" class="auto internal xref">7.10.1</a>.  <a href="#name-request-artifact-estatus" class="internal xref">Request Artifact: eStatus</a></p>
+                    <p id="section-toc.1-1.7.2.10.2.1.1"><a href="#section-7.10.1" class="auto internal xref">7.10.1</a>.  <a href="#name-request-artifact-enroll-sta" class="internal xref">Request Artifact: Enroll Status (eStatus)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.10.2.2">
                     <p id="section-toc.1-1.7.2.10.2.2.1"><a href="#section-7.10.2" class="auto internal xref">7.10.2</a>.  <a href="#name-response-3" class="internal xref">Response</a></p>
@@ -1531,10 +1535,10 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 <p id="section-toc.1-1.7.2.11.1"><a href="#section-7.11" class="auto internal xref">7.11</a>. <a href="#name-query-pledge-status" class="internal xref">Query Pledge Status</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.11.2.1">
-                    <p id="section-toc.1-1.7.2.11.2.1.1"><a href="#section-7.11.1" class="auto internal xref">7.11.1</a>.  <a href="#name-request-artifact-pstatus-re" class="internal xref">Request Artifact: pStatus-Req</a></p>
+                    <p id="section-toc.1-1.7.2.11.2.1.1"><a href="#section-7.11.1" class="auto internal xref">7.11.1</a>.  <a href="#name-request-artifact-pledge-sta" class="internal xref">Request Artifact: Pledge Status Request (pStatus-Req)</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.11.2.2">
-                    <p id="section-toc.1-1.7.2.11.2.2.1"><a href="#section-7.11.2" class="auto internal xref">7.11.2</a>.  <a href="#name-response-artifact-pstatus-r" class="internal xref">Response Artifact: pStatus-Resp</a></p>
+                    <p id="section-toc.1-1.7.2.11.2.2.1"><a href="#section-7.11.2" class="auto internal xref">7.11.2</a>.  <a href="#name-response-artifact-pledge-st" class="internal xref">Response Artifact: Pledge Status Response (pStatus-Resp)</a></p>
 </li>
                 </ul>
 </li>
@@ -2907,13 +2911,13 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
                 <text x="432" y="468">~</text>
                 <text x="536" y="468">~</text>
                 <text x="40" y="484">(3)</text>
-                <text x="88" y="484">Request</text>
-                <text x="136" y="484">PVR</text>
-                <text x="164" y="484">to</text>
-                <text x="216" y="484">Registrar</text>
-                <text x="280" y="484">incl.</text>
-                <text x="336" y="484">backend</text>
-                <text x="416" y="484">interaction</text>
+                <text x="84" y="484">Supply</text>
+                <text x="128" y="484">PVR</text>
+                <text x="156" y="484">to</text>
+                <text x="208" y="484">Registrar</text>
+                <text x="292" y="484">(including</text>
+                <text x="368" y="484">backend</text>
+                <text x="452" y="484">interaction)</text>
                 <text x="32" y="500">~</text>
                 <text x="168" y="500">~</text>
                 <text x="312" y="500">~</text>
@@ -2947,9 +2951,9 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
                 <text x="128" y="772">PER</text>
                 <text x="156" y="772">to</text>
                 <text x="208" y="772">Registrar</text>
-                <text x="272" y="772">incl.</text>
-                <text x="328" y="772">backend</text>
-                <text x="408" y="772">interaction</text>
+                <text x="292" y="772">(including</text>
+                <text x="368" y="772">backend</text>
+                <text x="452" y="772">interaction)</text>
                 <text x="32" y="788">~</text>
                 <text x="168" y="788">~</text>
                 <text x="312" y="788">~</text>
@@ -3154,6 +3158,93 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
 <p id="section-7.1-1">This exchange assumes that the Registrar-Agent has already discovered the pledge.
 This may be done as described in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 6.2.2</a> and <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> based on DNS-SD or similar.<a href="#section-7.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.1-2">TLS <span class="bcp14">MAY</span> be optionally used to provide privacy for this exchange between the Registrar-Agent and the pledge, see <a href="#pledgehttps" class="auto internal xref">Appendix B</a>.<a href="#section-7.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.1-3"><a href="#exchangesfig_uc2_1" class="auto internal xref">Figure 5</a> shows the Pledge Voucher-Request aquisition and the following subsections describe the corresponding artifacts.<a href="#section-7.1-3" class="pilcrow">¶</a></p>
+<span id="name-pvr-aquisition-exchanges"></span><div id="exchangesfig_uc2_1">
+<figure id="figure-5">
+          <div id="section-7.1-4.1">
+            <div class="alignLeft art-svg artwork" id="section-7.1-4.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="560" viewBox="0 0 560 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 32,160 L 32,224" fill="none" stroke="black"></path>
+                <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
+                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
+                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 432,160 L 432,224" fill="none" stroke="black"></path>
+                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 536,160 L 536,224" fill="none" stroke="black"></path>
+                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 144,176 L 160,176" fill="none" stroke="black"></path>
+                <path d="M 40,192 L 72,192" fill="none" stroke="black"></path>
+                <path d="M 128,192 L 160,192" fill="none" stroke="black"></path>
+                <path d="M 40,208 L 72,208" fill="none" stroke="black"></path>
+                <path d="M 120,208 L 160,208" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="168,208 156,202.4 156,213.6" fill="black" transform="rotate(0,160,208)"></polygon>
+                <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
+                <polygon class="arrowhead" points="48,192 36,186.4 36,197.6" fill="black" transform="rotate(180,40,192)"></polygon>
+                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <g class="text">
+                  <text x="44" y="52">Pledge</text>
+                  <text x="164" y="52">Registrar-</text>
+                  <text x="276" y="52">Domain</text>
+                  <text x="412" y="52">Domain</text>
+                  <text x="500" y="52">MASA</text>
+                  <text x="144" y="68">Agent</text>
+                  <text x="288" y="68">Registrar</text>
+                  <text x="396" y="68">CA</text>
+                  <text x="32" y="100">|</text>
+                  <text x="168" y="100">|</text>
+                  <text x="312" y="100">|</text>
+                  <text x="432" y="100">|</text>
+                  <text x="492" y="100">Internet</text>
+                  <text x="536" y="100">|</text>
+                  <text x="32" y="116">~</text>
+                  <text x="168" y="116">~</text>
+                  <text x="312" y="116">~</text>
+                  <text x="432" y="116">~</text>
+                  <text x="536" y="116">~</text>
+                  <text x="40" y="132">(1)</text>
+                  <text x="88" y="132">Trigger</text>
+                  <text x="148" y="132">Pledge</text>
+                  <text x="240" y="132">Voucher-Request</text>
+                  <text x="32" y="148">~</text>
+                  <text x="168" y="148">~</text>
+                  <text x="312" y="148">~</text>
+                  <text x="432" y="148">~</text>
+                  <text x="536" y="148">~</text>
+                  <text x="84" y="180">opt.</text>
+                  <text x="120" y="180">TLS</text>
+                  <text x="100" y="196">tPVR</text>
+                  <text x="96" y="212">PVR</text>
+                  <text x="32" y="244">~</text>
+                  <text x="168" y="244">~</text>
+                  <text x="312" y="244">~</text>
+                  <text x="432" y="244">~</text>
+                  <text x="536" y="244">~</text>
+                </g>
+              </svg><a href="#section-7.1-4.1.1" class="pilcrow">¶</a>
+</div>
+</div>
+<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
+<a href="#name-pvr-aquisition-exchanges" class="selfRef">PVR aquisition exchanges</a>
+          </figcaption></figure>
+</div>
 <div id="request-artifact-pledge-voucher-request-trigger-tpvr">
 <section id="section-7.1.1">
           <h4 id="name-request-artifact-pledge-vou">
@@ -3172,7 +3263,7 @@ Following parameters are provided in the JSON object:<a href="#section-7.1.1-2" 
           </ul>
 <p id="section-7.1.1-4">The trigger for the pledge to create a PVR is depicted in the following figure:<a href="#section-7.1.1-4" class="pilcrow">¶</a></p>
 <span id="name-representation-of-trigger-t"></span><div id="pavrt">
-<figure id="figure-5">
+<figure id="figure-6">
             <div class="alignLeft art-text artwork" id="section-7.1.1-5.1">
 <pre>
 {
@@ -3181,7 +3272,7 @@ Following parameters are provided in the JSON object:<a href="#section-7.1.1-2" 
 }
 </pre>
 </div>
-<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
+<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
 <a href="#name-representation-of-trigger-t" class="selfRef">Representation of trigger to create PVR</a>
             </figcaption></figure>
 </div>
@@ -3209,7 +3300,7 @@ The serial-number corresponds with the product-serial-number contained in the X5
 </li>
           </ul>
 <span id="name-representation-of-agent-sig"></span><div id="asd">
-<figure id="figure-6">
+<figure id="figure-7">
             <div class="alignLeft art-text artwork" id="section-7.1.1-13.1">
 <pre>
 # The agent-signed-data in General JWS Serialization syntax
@@ -3239,7 +3330,7 @@ The serial-number corresponds with the product-serial-number contained in the X5
 }
 </pre>
 </div>
-<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
+<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
 <a href="#name-representation-of-agent-sig" class="selfRef">Representation of agent-signed-data in General JWS Serialization syntax</a>
             </figcaption></figure>
 </div>
@@ -3295,13 +3386,13 @@ If the pledge does not have synchronized time, it <span class="bcp14">SHALL</spa
               <p id="section-7.1.2-9.1.1">agent-provided-proximity-registrar-cert: <span class="bcp14">MUST</span> be included and contains the base64-encoded registrar LDevID certificate (provided as PVR trigger parameter by the Registrar-Agent).<a href="#section-7.1.2-9.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.1.2-9.2">
-              <p id="section-7.1.2-9.2.1">agent-signed-data: <span class="bcp14">MUST</span> contain the base64-encoded agent-signed-data (as defined in <a href="#asd" class="auto internal xref">Figure 6</a>) and provided as a PVR trigger parameter by the Registrar-Agent.<a href="#section-7.1.2-9.2.1" class="pilcrow">¶</a></p>
+              <p id="section-7.1.2-9.2.1">agent-signed-data: <span class="bcp14">MUST</span> contain the base64-encoded agent-signed-data (as defined in <a href="#asd" class="auto internal xref">Figure 7</a>) and provided as a PVR trigger parameter by the Registrar-Agent.<a href="#section-7.1.2-9.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 <p id="section-7.1.2-10">The enhancements of the YANG module for the ietf-voucher-request with these new leaves are defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>.<a href="#section-7.1.2-10" class="pilcrow">¶</a></p>
 <p id="section-7.1.2-11">The PVR is signed using the pledge's IDevID credential contained as x5c parameter of the JOSE header.<a href="#section-7.1.2-11" class="pilcrow">¶</a></p>
 <span id="name-representation-of-pvr"></span><div id="pvr_example">
-<figure id="figure-7">
+<figure id="figure-8">
             <div class="alignLeft art-text artwork" id="section-7.1.2-12.1">
 <pre>
 # The PVR in General JWS Serialization syntax
@@ -3338,7 +3429,7 @@ If the pledge does not have synchronized time, it <span class="bcp14">SHALL</spa
 }
 </pre>
 </div>
-<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
+<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
 <a href="#name-representation-of-pvr" class="selfRef">Representation of PVR</a>
             </figcaption></figure>
 </div>
@@ -3354,6 +3445,93 @@ The PVR is included by the registrar in its RVR as described in <a href="#pvr" c
         <h3 id="name-trigger-pledge-enroll-reque">
 <a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-trigger-pledge-enroll-reque" class="section-name selfRef">Trigger Pledge Enroll-Request</a>
         </h3>
+<p id="section-7.2-1"><a href="#exchangesfig_uc2_2" class="auto internal xref">Figure 9</a> shows the the aquisition of the Pledge Enroll-Request aquisition and the following subsections describe the corresponding artifacts.<a href="#section-7.2-1" class="pilcrow">¶</a></p>
+<span id="name-per-aquisition-exchanges"></span><div id="exchangesfig_uc2_2">
+<figure id="figure-9">
+          <div id="section-7.2-2.1">
+            <div class="alignLeft art-svg artwork" id="section-7.2-2.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="560" viewBox="0 0 560 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 32,160 L 32,224" fill="none" stroke="black"></path>
+                <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
+                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
+                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 432,160 L 432,224" fill="none" stroke="black"></path>
+                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 536,160 L 536,224" fill="none" stroke="black"></path>
+                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 144,176 L 160,176" fill="none" stroke="black"></path>
+                <path d="M 40,192 L 72,192" fill="none" stroke="black"></path>
+                <path d="M 128,192 L 160,192" fill="none" stroke="black"></path>
+                <path d="M 40,208 L 72,208" fill="none" stroke="black"></path>
+                <path d="M 120,208 L 160,208" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="168,208 156,202.4 156,213.6" fill="black" transform="rotate(0,160,208)"></polygon>
+                <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
+                <polygon class="arrowhead" points="48,192 36,186.4 36,197.6" fill="black" transform="rotate(180,40,192)"></polygon>
+                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <g class="text">
+                  <text x="44" y="52">Pledge</text>
+                  <text x="164" y="52">Registrar-</text>
+                  <text x="276" y="52">Domain</text>
+                  <text x="412" y="52">Domain</text>
+                  <text x="500" y="52">MASA</text>
+                  <text x="144" y="68">Agent</text>
+                  <text x="288" y="68">Registrar</text>
+                  <text x="396" y="68">CA</text>
+                  <text x="32" y="100">|</text>
+                  <text x="168" y="100">|</text>
+                  <text x="312" y="100">|</text>
+                  <text x="432" y="100">|</text>
+                  <text x="492" y="100">Internet</text>
+                  <text x="536" y="100">|</text>
+                  <text x="24" y="116">~</text>
+                  <text x="160" y="116">~</text>
+                  <text x="304" y="116">~</text>
+                  <text x="424" y="116">~</text>
+                  <text x="528" y="116">~</text>
+                  <text x="40" y="132">(2)</text>
+                  <text x="88" y="132">Trigger</text>
+                  <text x="148" y="132">Pledge</text>
+                  <text x="236" y="132">Enroll-Request</text>
+                  <text x="32" y="148">~</text>
+                  <text x="168" y="148">~</text>
+                  <text x="312" y="148">~</text>
+                  <text x="432" y="148">~</text>
+                  <text x="536" y="148">~</text>
+                  <text x="84" y="180">opt.</text>
+                  <text x="120" y="180">TLS</text>
+                  <text x="100" y="196">tPER</text>
+                  <text x="96" y="212">PER</text>
+                  <text x="32" y="244">~</text>
+                  <text x="168" y="244">~</text>
+                  <text x="312" y="244">~</text>
+                  <text x="432" y="244">~</text>
+                  <text x="536" y="244">~</text>
+                </g>
+              </svg><a href="#section-7.2-2.1.1" class="pilcrow">¶</a>
+</div>
+</div>
+<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
+<a href="#name-per-aquisition-exchanges" class="selfRef">PER aquisition exchanges</a>
+          </figcaption></figure>
+</div>
 <div id="request-artifact-pledge-enroll-request-trigger-tper">
 <section id="section-7.2.1">
           <h4 id="name-request-artifact-pledge-enr">
@@ -3365,9 +3543,9 @@ Note, as the initial enrollment aims to request a generic certificate, no certif
 <p id="section-7.2.1-2">Triggering the pledge to create the Enroll-Request is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tper"<a href="#section-7.2.1-2" class="pilcrow">¶</a></p>
 <p id="section-7.2.1-3">The Registrar-Agent PER trigger Content-Type header is: <code>application/json</code> with an empty body by default.
 Note that using HTTP POST allows for an empty body, but also to provide additional data, like CSR attributes or information about the enroll type "enroll-generic-cert" or "re-enroll-generic-cert".
-The "enroll-generic-cert" case is shown in <a href="#raer" class="auto internal xref">Figure 8</a>.<a href="#section-7.2.1-3" class="pilcrow">¶</a></p>
+The "enroll-generic-cert" case is shown in <a href="#raer" class="auto internal xref">Figure 10</a>.<a href="#section-7.2.1-3" class="pilcrow">¶</a></p>
 <span id="name-example-of-trigger-to-creat"></span><div id="raer">
-<figure id="figure-8">
+<figure id="figure-10">
             <div class="alignLeft art-text artwork" id="section-7.2.1-4.1">
 <pre>
 {
@@ -3375,7 +3553,7 @@ The "enroll-generic-cert" case is shown in <a href="#raer" class="auto internal 
 }
 </pre>
 </div>
-<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
 <a href="#name-example-of-trigger-to-creat" class="selfRef">Example of trigger to create a PER</a>
             </figcaption></figure>
 </div>
@@ -3439,7 +3617,7 @@ The body of the Pledge Enroll-Request <span class="bcp14">SHOULD</span> contain 
 <p id="section-7.2.2-13">While BRSKI-PRM targets the initial enrollment, re-enrollment <span class="bcp14">SHOULD</span> be supported as described in a similar way as for enrollment in this document, if no other re-enrollment mechanism is supported.
 Note that in this case the current LDevID credential is used instead of the IDevID credential to create the signature of the PKCS#10 request.<a href="#section-7.2.2-13" class="pilcrow">¶</a></p>
 <span id="name-representation-of-per"></span><div id="per_example">
-<figure id="figure-9">
+<figure id="figure-11">
             <div class="alignLeft art-text artwork" id="section-7.2.2-14.1">
 <pre>
 # The PER in General JWS Serialization syntax
@@ -3472,7 +3650,7 @@ Note that in this case the current LDevID credential is used instead of the IDev
 }
 </pre>
 </div>
-<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
+<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
 <a href="#name-representation-of-per" class="selfRef">Representation of PER</a>
             </figcaption></figure>
 </div>
@@ -3489,8 +3667,8 @@ This allows bulk bootstrapping of several pledges using the same connection betw
 </div>
 <div id="pvr">
 <section id="section-7.3">
-        <h3 id="name-request-voucher-from-the-re">
-<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-request-voucher-from-the-re" class="section-name selfRef">Request Voucher from the Registrar</a>
+        <h3 id="name-supply-voucher-request-to-r">
+<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-supply-voucher-request-to-r" class="section-name selfRef">Supply Voucher Request to Registrar (including backend interaction)</a>
         </h3>
 <p id="section-7.3-1">Similar to BRSKI "requestvoucher" endpoint in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.2" class="relref">Section 5.2</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3-1" class="pilcrow">¶</a></p>
 <p id="section-7.3-2">The Registrar-Agent has acquired one or more PVR and PER object pairs<a href="#section-7.3-2" class="pilcrow">¶</a></p>
@@ -3506,6 +3684,124 @@ If the connection from Registrar-Agent to registrar is established, the authoriz
 This ensures that the pledge has been triggered by an authorized Registrar-Agent.<a href="#section-7.3-4" class="pilcrow">¶</a></p>
 <p id="section-7.3-5">With BRSKI-PRM, the pledge generates PVR and PER as JSON-in-JWS objects and the Registrar-Agent forwards them to the registrar.
 In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the pledge generates PVR as CMS-signed JSON and PER as PKCS#10 or PKCS#7 according to <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> and inherited by <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3-5" class="pilcrow">¶</a></p>
+<p id="section-7.3-6"><a href="#exchangesfig_uc2_3" class="auto internal xref">Figure 12</a> shows the exchanges for the Voucher Request processing and the following subsections describe the corresponding artifacts.<a href="#section-7.3-6" class="pilcrow">¶</a></p>
+<span id="name-voucher-request-processing"></span><div id="exchangesfig_uc2_3">
+<figure id="figure-12">
+          <div id="section-7.3-7.1">
+            <div class="alignLeft art-svg artwork" id="section-7.3-7.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="416" width="560" viewBox="0 0 560 416" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 32,160 L 32,384" fill="none" stroke="black"></path>
+                <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,384" fill="none" stroke="black"></path>
+                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,176" fill="none" stroke="black"></path>
+                <path d="M 312,272 L 312,384" fill="none" stroke="black"></path>
+                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 432,160 L 432,272" fill="none" stroke="black"></path>
+                <path d="M 432,368 L 432,384" fill="none" stroke="black"></path>
+                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 536,160 L 536,304" fill="none" stroke="black"></path>
+                <path d="M 536,352 L 536,384" fill="none" stroke="black"></path>
+                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 176,176 L 208,176" fill="none" stroke="black"></path>
+                <path d="M 264,176 L 304,176" fill="none" stroke="black"></path>
+                <path d="M 176,224 L 208,224" fill="none" stroke="black"></path>
+                <path d="M 256,224 L 304,224" fill="none" stroke="black"></path>
+                <path d="M 320,288 L 400,288" fill="none" stroke="black"></path>
+                <path d="M 456,288 L 528,288" fill="none" stroke="black"></path>
+                <path d="M 320,304 L 408,304" fill="none" stroke="black"></path>
+                <path d="M 456,304 L 528,304" fill="none" stroke="black"></path>
+                <path d="M 320,352 L 392,352" fill="none" stroke="black"></path>
+                <path d="M 472,352 L 528,352" fill="none" stroke="black"></path>
+                <path d="M 176,368 L 200,368" fill="none" stroke="black"></path>
+                <path d="M 280,368 L 304,368" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="536,304 524,298.4 524,309.6" fill="black" transform="rotate(0,528,304)"></polygon>
+                <polygon class="arrowhead" points="536,288 524,282.4 524,293.6" fill="black" transform="rotate(0,528,288)"></polygon>
+                <polygon class="arrowhead" points="328,352 316,346.4 316,357.6" fill="black" transform="rotate(180,320,352)"></polygon>
+                <polygon class="arrowhead" points="328,288 316,282.4 316,293.6" fill="black" transform="rotate(180,320,288)"></polygon>
+                <polygon class="arrowhead" points="312,224 300,218.4 300,229.6" fill="black" transform="rotate(0,304,224)"></polygon>
+                <polygon class="arrowhead" points="312,176 300,170.4 300,181.6" fill="black" transform="rotate(0,304,176)"></polygon>
+                <polygon class="arrowhead" points="184,368 172,362.4 172,373.6" fill="black" transform="rotate(180,176,368)"></polygon>
+                <polygon class="arrowhead" points="184,176 172,170.4 172,181.6" fill="black" transform="rotate(180,176,176)"></polygon>
+                <g class="text">
+                  <text x="44" y="52">Pledge</text>
+                  <text x="164" y="52">Registrar-</text>
+                  <text x="276" y="52">Domain</text>
+                  <text x="412" y="52">Domain</text>
+                  <text x="500" y="52">MASA</text>
+                  <text x="144" y="68">Agent</text>
+                  <text x="288" y="68">Registrar</text>
+                  <text x="396" y="68">CA</text>
+                  <text x="32" y="100">|</text>
+                  <text x="168" y="100">|</text>
+                  <text x="312" y="100">|</text>
+                  <text x="432" y="100">|</text>
+                  <text x="492" y="100">Internet</text>
+                  <text x="536" y="100">|</text>
+                  <text x="32" y="116">~</text>
+                  <text x="168" y="116">~</text>
+                  <text x="312" y="116">~</text>
+                  <text x="432" y="116">~</text>
+                  <text x="536" y="116">~</text>
+                  <text x="40" y="132">(3)</text>
+                  <text x="84" y="132">Supply</text>
+                  <text x="128" y="132">PVR</text>
+                  <text x="156" y="132">to</text>
+                  <text x="208" y="132">Registrar</text>
+                  <text x="292" y="132">(including</text>
+                  <text x="368" y="132">backend</text>
+                  <text x="452" y="132">interaction)</text>
+                  <text x="32" y="148">~</text>
+                  <text x="168" y="148">~</text>
+                  <text x="312" y="148">~</text>
+                  <text x="432" y="148">~</text>
+                  <text x="536" y="148">~</text>
+                  <text x="236" y="180">mTLS</text>
+                  <text x="308" y="196">[Registrar-Agent</text>
+                  <text x="308" y="212">authenticated&amp;authorized?]</text>
+                  <text x="232" y="228">PVR</text>
+                  <text x="312" y="228">|</text>
+                  <text x="272" y="244">[accept</text>
+                  <text x="340" y="244">device?]</text>
+                  <text x="276" y="260">[contact</text>
+                  <text x="344" y="260">vendor]</text>
+                  <text x="428" y="292">mTLS</text>
+                  <text x="432" y="308">RVR</text>
+                  <text x="436" y="324">[extract</text>
+                  <text x="512" y="324">DomainID]</text>
+                  <text x="432" y="340">[update</text>
+                  <text x="488" y="340">audit</text>
+                  <text x="532" y="340">log]</text>
+                  <text x="432" y="356">Voucher</text>
+                  <text x="240" y="372">Voucher</text>
+                  <text x="32" y="404">~</text>
+                  <text x="168" y="404">~</text>
+                  <text x="312" y="404">~</text>
+                  <text x="432" y="404">~</text>
+                  <text x="536" y="404">~</text>
+                </g>
+              </svg><a href="#section-7.3-7.1.1" class="pilcrow">¶</a>
+</div>
+</div>
+<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
+<a href="#name-voucher-request-processing" class="selfRef">Voucher Request processing</a>
+          </figcaption></figure>
+</div>
 <div id="request-artifact-pvr">
 <section id="section-7.3.1">
           <h4 id="name-request-artifact-pvr">
@@ -3570,7 +3866,7 @@ If multiple certificates are included in the x5c, the first <span class="bcp14">
 <p id="section-7.3.2-9">The MASA uses this information for verification that the Registrar-Agent is in proximity to the registrar to state the corresponding assertion "agent-proximity".<a href="#section-7.3.2-9" class="pilcrow">¶</a></p>
 <p id="section-7.3.2-10">The object is signed using the registrar LDevID credentials, which corresponds to the certificate referenced in the JOSE header.<a href="#section-7.3.2-10" class="pilcrow">¶</a></p>
 <span id="name-representation-of-rvr"></span><div id="rvr">
-<figure id="figure-10">
+<figure id="figure-13">
             <div class="alignLeft art-text artwork" id="section-7.3.2-11.1">
 <pre>
 # The RVR in General JWS Serialization syntax
@@ -3611,7 +3907,7 @@ If multiple certificates are included in the x5c, the first <span class="bcp14">
 }
 </pre>
 </div>
-<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
+<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
 <a href="#name-representation-of-rvr" class="selfRef">Representation of RVR</a>
             </figcaption></figure>
 </div>
@@ -3663,9 +3959,9 @@ When successful, the Voucher will then be supplied via the registrar to the Regi
 <p id="section-7.3.3-1">The MASA creates a voucher with Media-Type of <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
 If the MASA detects that the Accept header of the PVR does not match <code>application/voucher-jws+json</code> it <span class="bcp14">SHOULD</span> respond with the HTTP status code "406 Not Acceptable" as the pledge will not be able to parse the response.
 The voucher is according to <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> but uses the new assertion value specified <a href="#agt_prx" class="auto internal xref">Section 5.4</a>.<a href="#section-7.3.3-1" class="pilcrow">¶</a></p>
-<p id="section-7.3.3-2"><a href="#MASA-vr" class="auto internal xref">Figure 11</a> shows an example of the contents of a voucher.<a href="#section-7.3.3-2" class="pilcrow">¶</a></p>
+<p id="section-7.3.3-2"><a href="#MASA-vr" class="auto internal xref">Figure 14</a> shows an example of the contents of a voucher.<a href="#section-7.3.3-2" class="pilcrow">¶</a></p>
 <span id="name-representation-of-masa-issu"></span><div id="MASA-vr">
-<figure id="figure-11">
+<figure id="figure-14">
             <div class="alignLeft art-text artwork" id="section-7.3.3-3.1">
 <pre>
 # The MASA issued voucher in General JWS Serialization syntax
@@ -3701,7 +3997,7 @@ The voucher is according to <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="c
 }
 </pre>
 </div>
-<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
+<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
 <a href="#name-representation-of-masa-issu" class="selfRef">Representation of MASA issued voucher</a>
             </figcaption></figure>
 </div>
@@ -3723,14 +4019,14 @@ The pinned domain certificate is already contained in the voucher payload ("pinn
 <p id="section-7.3.4-4">In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the Registrar proved possession of the it's credential when the TLS session was setup.
 While the pledge could not, at the time, validate the certificate truly belonged the registrar, it did validate that the certificate it was provided was able to authenticate the TLS connection.<a href="#section-7.3.4-4" class="pilcrow">¶</a></p>
 <p id="section-7.3.4-5">In the BRSKI-PRM mode, with the Registrar-Agent mediating all communication, the Pledge has not as yet been able to witness that the intended Registrar really does possess the relevant private key.
-This second signature provides for the same level of assurance to the pledge, and that it matches the public key that the pledge received in the trigger for the PVR (see <a href="#pavrt" class="auto internal xref">Figure 5</a>).<a href="#section-7.3.4-5" class="pilcrow">¶</a></p>
+This second signature provides for the same level of assurance to the pledge, and that it matches the public key that the pledge received in the trigger for the PVR (see <a href="#pavrt" class="auto internal xref">Figure 6</a>).<a href="#section-7.3.4-5" class="pilcrow">¶</a></p>
 <p id="section-7.3.4-6">The registrar <span class="bcp14">MUST</span> use the same registrar EE credentials used for authentication in the TLS handshake to authenticate towards the Registrar-Agent.
 This has some operational implications when the registrar may be part of a scalable framework as described in <span>[<a href="#I-D.richardson-anima-registrar-considerations" class="cite xref">I-D.richardson-anima-registrar-considerations</a>], <a href="https://datatracker.ietf.org/doc/html/draft-richardson-anima-registrar-considerations-08#section-1.3.1" class="relref">Section 1.3.1</a></span>.<a href="#section-7.3.4-6" class="pilcrow">¶</a></p>
 <p id="section-7.3.4-7">The second signature <span class="bcp14">MUST</span> either be done with the private key associated with the registrar EE certificate provided to the Registrar-Agent, or the use of a certificate chain is necessary.
 This ensures that the same registrar EE certificate can be used to verify the signature as transmitted in the voucher-request as also transferred in the PVR in the "agent-provided-proximity-registrar-cert".<a href="#section-7.3.4-7" class="pilcrow">¶</a></p>
-<p id="section-7.3.4-8"><a href="#MASA-REG-vr" class="auto internal xref">Figure 12</a> below provides an example of the voucher with two signatures.<a href="#section-7.3.4-8" class="pilcrow">¶</a></p>
+<p id="section-7.3.4-8"><a href="#MASA-REG-vr" class="auto internal xref">Figure 15</a> below provides an example of the voucher with two signatures.<a href="#section-7.3.4-8" class="pilcrow">¶</a></p>
 <span id="name-representation-of-masa-issue"></span><div id="MASA-REG-vr">
-<figure id="figure-12">
+<figure id="figure-15">
             <div class="alignLeft art-text artwork" id="section-7.3.4-9.1">
 <pre>
 # The MASA issued voucher with additional registrar signature in
@@ -3781,7 +4077,7 @@ This ensures that the same registrar EE certificate can be used to verify the si
 }
 </pre>
 </div>
-<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
+<figcaption><a href="#figure-15" class="selfRef">Figure 15</a>:
 <a href="#name-representation-of-masa-issue" class="selfRef">Representation of MASA issued voucher with additional registrar signature</a>
             </figcaption></figure>
 </div>
@@ -3830,19 +4126,121 @@ Note, the registrar may have stored the EE (RegAgt) certificate if used during T
 </div>
 <div id="per">
 <section id="section-7.4">
-        <h3 id="name-supply-per-to-registrar">
-<a href="#section-7.4" class="section-number selfRef">7.4. </a><a href="#name-supply-per-to-registrar" class="section-name selfRef">Supply PER to Registrar</a>
+        <h3 id="name-supply-per-to-registrar-inc">
+<a href="#section-7.4" class="section-number selfRef">7.4. </a><a href="#name-supply-per-to-registrar-inc" class="section-name selfRef">Supply PER to Registrar (including backend interaction)</a>
         </h3>
 <p id="section-7.4-1">After receiving the voucher, the Registrar-Agent sends the PER to the registrar in the same HTTP-over-TLS connection. Which is similar to the PER processing described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.2" class="relref">Section 5.2</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 In case the PER cannot be send in the same HTTP-over-TLS connection the Registrar-Agent may send the PER in a new HTTP-over-TLS connection. The registrar is able to correlate the PVR and the PER based on the signatures and the contained product-serial-number information.
 Note, this also addresses situations in which a nonceless voucher is used and may be pre-provisioned to the pledge.<a href="#section-7.4-1" class="pilcrow">¶</a></p>
+<p id="section-7.4-2"><a href="#exchangesfig_uc2_4" class="auto internal xref">Figure 16</a> depicts exchanges for the PER request handling and the following subsections describe the corresponding artifacts.<a href="#section-7.4-2" class="pilcrow">¶</a></p>
+<span id="name-pledge-enroll-request-proce"></span><div id="exchangesfig_uc2_4">
+<figure id="figure-16">
+          <div id="section-7.4-3.1">
+            <div class="alignLeft art-svg artwork" id="section-7.4-3.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="304" width="560" viewBox="0 0 560 304" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 32,160 L 32,272" fill="none" stroke="black"></path>
+                <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,272" fill="none" stroke="black"></path>
+                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,272" fill="none" stroke="black"></path>
+                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 432,160 L 432,272" fill="none" stroke="black"></path>
+                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 536,160 L 536,272" fill="none" stroke="black"></path>
+                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 176,176 L 208,176" fill="none" stroke="black"></path>
+                <path d="M 264,176 L 304,176" fill="none" stroke="black"></path>
+                <path d="M 176,192 L 208,192" fill="none" stroke="black"></path>
+                <path d="M 256,192 L 304,192" fill="none" stroke="black"></path>
+                <path d="M 320,208 L 344,208" fill="none" stroke="black"></path>
+                <path d="M 400,208 L 424,208" fill="none" stroke="black"></path>
+                <path d="M 320,224 L 344,224" fill="none" stroke="black"></path>
+                <path d="M 392,224 L 424,224" fill="none" stroke="black"></path>
+                <path d="M 176,256 L 192,256" fill="none" stroke="black"></path>
+                <path d="M 288,256 L 304,256" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="432,224 420,218.4 420,229.6" fill="black" transform="rotate(0,424,224)"></polygon>
+                <polygon class="arrowhead" points="432,208 420,202.4 420,213.6" fill="black" transform="rotate(0,424,208)"></polygon>
+                <polygon class="arrowhead" points="328,208 316,202.4 316,213.6" fill="black" transform="rotate(180,320,208)"></polygon>
+                <polygon class="arrowhead" points="312,192 300,186.4 300,197.6" fill="black" transform="rotate(0,304,192)"></polygon>
+                <polygon class="arrowhead" points="312,176 300,170.4 300,181.6" fill="black" transform="rotate(0,304,176)"></polygon>
+                <polygon class="arrowhead" points="184,256 172,250.4 172,261.6" fill="black" transform="rotate(180,176,256)"></polygon>
+                <polygon class="arrowhead" points="184,176 172,170.4 172,181.6" fill="black" transform="rotate(180,176,176)"></polygon>
+                <g class="text">
+                  <text x="44" y="52">Pledge</text>
+                  <text x="164" y="52">Registrar-</text>
+                  <text x="276" y="52">Domain</text>
+                  <text x="412" y="52">Domain</text>
+                  <text x="500" y="52">MASA</text>
+                  <text x="144" y="68">Agent</text>
+                  <text x="288" y="68">Registrar</text>
+                  <text x="396" y="68">CA</text>
+                  <text x="32" y="100">|</text>
+                  <text x="168" y="100">|</text>
+                  <text x="312" y="100">|</text>
+                  <text x="432" y="100">|</text>
+                  <text x="492" y="100">Internet</text>
+                  <text x="536" y="100">|</text>
+                  <text x="32" y="116">~</text>
+                  <text x="168" y="116">~</text>
+                  <text x="312" y="116">~</text>
+                  <text x="432" y="116">~</text>
+                  <text x="536" y="116">~</text>
+                  <text x="40" y="132">(4)</text>
+                  <text x="84" y="132">Supply</text>
+                  <text x="128" y="132">PER</text>
+                  <text x="156" y="132">to</text>
+                  <text x="208" y="132">Registrar</text>
+                  <text x="292" y="132">(including</text>
+                  <text x="368" y="132">backend</text>
+                  <text x="452" y="132">interaction)</text>
+                  <text x="32" y="148">~</text>
+                  <text x="168" y="148">~</text>
+                  <text x="312" y="148">~</text>
+                  <text x="432" y="148">~</text>
+                  <text x="536" y="148">~</text>
+                  <text x="236" y="180">mTLS</text>
+                  <text x="232" y="196">PER</text>
+                  <text x="372" y="212">mTLS</text>
+                  <text x="368" y="228">RER</text>
+                  <text x="348" y="244">&lt;-Enroll</text>
+                  <text x="408" y="244">Resp-</text>
+                  <text x="220" y="260">Enroll</text>
+                  <text x="268" y="260">Resp</text>
+                  <text x="32" y="292">~</text>
+                  <text x="168" y="292">~</text>
+                  <text x="312" y="292">~</text>
+                  <text x="432" y="292">~</text>
+                  <text x="536" y="292">~</text>
+                </g>
+              </svg><a href="#section-7.4-3.1.1" class="pilcrow">¶</a>
+</div>
+</div>
+<figcaption><a href="#figure-16" class="selfRef">Figure 16</a>:
+<a href="#name-pledge-enroll-request-proce" class="selfRef">Pledge Enroll-Request processing</a>
+          </figcaption></figure>
+</div>
 <div id="request-artifact-pledge-enroll-request-per">
 <section id="section-7.4.1">
           <h4 id="name-request-artifact-pledge-enro">
 <a href="#section-7.4.1" class="section-number selfRef">7.4.1. </a><a href="#name-request-artifact-pledge-enro" class="section-name selfRef">Request Artifact: Pledge Enroll-Request (PER)</a>
           </h4>
 <p id="section-7.4.1-1">As specified in <a href="#tper" class="auto internal xref">Section 7.2</a> deviating from BRSKI the PER is not a raw PKCS#10.
-As the Registrar-Agent is involved in the exchange, the PKCS#10 is wrapped in a JWS object by the pledge and signed with pledge's IDevID to ensure proof-of-identity as outlined in <a href="#per_example" class="auto internal xref">Figure 9</a>.<a href="#section-7.4.1-1" class="pilcrow">¶</a></p>
+As the Registrar-Agent is involved in the exchange, the PKCS#10 is wrapped in a JWS object by the pledge and signed with pledge's IDevID to ensure proof-of-identity as outlined in <a href="#per_example" class="auto internal xref">Figure 11</a>.<a href="#section-7.4.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.4.1-2">EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> standard endpoints (/simpleenroll, /simplereenroll, /serverkeygen, /cacerts) on the registrar cannot be used for BRSKI-PRM.
 This is caused by the utilization of signature wrapped-objects in BRSKI-PRM.
 As EST requires to sent a raw PKCS#10 request to e.g., "/.well-known/est/simpleenroll" endpoint, this document makes an enhancement by utilizing EST but with the exception to transport a signature wrapped PKCS#10 request.
@@ -3894,6 +4292,87 @@ This is done in EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</sp
 BRSKI-PRM requires a signature wrapped CA certificate object, to avoid that the pledge can be provided with arbitrary CA certificates in an authorized way.
 The registrar signed CA certificate object will allow the pledge to verify the authorization to install the received CA certificate(s).
 As the CA certificate(s) are provided to the pledge after the voucher, the pledge has the required information (the domain certificate) to verify the wrapped CA certificate object.<a href="#section-7.5-1" class="pilcrow">¶</a></p>
+<p id="section-7.5-2"><a href="#exchangesfig_uc2_5" class="auto internal xref">Figure 17</a> shows the request and provisioning of CA certificates in the infrastructure. 
+The following subsections describe the corresponding artifacts.<a href="#section-7.5-2" class="pilcrow">¶</a></p>
+<span id="name-ca-certificate-retrival"></span><div id="exchangesfig_uc2_5">
+<figure id="figure-17">
+          <div id="section-7.5-3.1">
+            <div class="alignLeft art-svg artwork" id="section-7.5-3.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="240" width="560" viewBox="0 0 560 240" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 32,160 L 32,208" fill="none" stroke="black"></path>
+                <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,208" fill="none" stroke="black"></path>
+                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,208" fill="none" stroke="black"></path>
+                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 432,160 L 432,208" fill="none" stroke="black"></path>
+                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 536,160 L 536,208" fill="none" stroke="black"></path>
+                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 288,176 L 304,176" fill="none" stroke="black"></path>
+                <path d="M 176,192 L 192,192" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="312,176 300,170.4 300,181.6" fill="black" transform="rotate(0,304,176)"></polygon>
+                <polygon class="arrowhead" points="184,192 172,186.4 172,197.6" fill="black" transform="rotate(180,176,192)"></polygon>
+                <g class="text">
+                  <text x="44" y="52">Pledge</text>
+                  <text x="164" y="52">Registrar-</text>
+                  <text x="276" y="52">Domain</text>
+                  <text x="412" y="52">Domain</text>
+                  <text x="500" y="52">MASA</text>
+                  <text x="144" y="68">Agent</text>
+                  <text x="288" y="68">Registrar</text>
+                  <text x="396" y="68">CA</text>
+                  <text x="32" y="100">|</text>
+                  <text x="168" y="100">|</text>
+                  <text x="312" y="100">|</text>
+                  <text x="432" y="100">|</text>
+                  <text x="492" y="100">Internet</text>
+                  <text x="536" y="100">|</text>
+                  <text x="32" y="116">~</text>
+                  <text x="168" y="116">~</text>
+                  <text x="312" y="116">~</text>
+                  <text x="432" y="116">~</text>
+                  <text x="536" y="116">~</text>
+                  <text x="40" y="132">(5)</text>
+                  <text x="88" y="132">Request</text>
+                  <text x="132" y="132">CA</text>
+                  <text x="196" y="132">Certificates</text>
+                  <text x="32" y="148">~</text>
+                  <text x="168" y="148">~</text>
+                  <text x="312" y="148">~</text>
+                  <text x="432" y="148">~</text>
+                  <text x="536" y="148">~</text>
+                  <text x="180" y="180">--</text>
+                  <text x="236" y="180">cACert-Req</text>
+                  <text x="256" y="196">cACert-Resp--</text>
+                  <text x="32" y="228">~</text>
+                  <text x="168" y="228">~</text>
+                  <text x="312" y="228">~</text>
+                  <text x="432" y="228">~</text>
+                  <text x="536" y="228">~</text>
+                </g>
+              </svg><a href="#section-7.5-3.1.1" class="pilcrow">¶</a>
+</div>
+</div>
+<figcaption><a href="#figure-17" class="selfRef">Figure 17</a>:
+<a href="#name-ca-certificate-retrival" class="selfRef">CA certificate retrival</a>
+          </figcaption></figure>
+</div>
 <div id="request-artifact-cacert-req">
 <section id="section-7.5.1">
           <h4 id="name-request-artifact-cacert-req">
@@ -3913,7 +4392,7 @@ As the CA certificate(s) are provided to the pledge after the voucher, the pledg
 The additional processing is to sign the CA certificate(s) information using the registrar LDevID credentials.
 This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certificates are provided as base64-encoded "x5bag" (see definition in <span>[<a href="#RFC9360" class="cite xref">RFC9360</a>]</span>) in the JWS payload.<a href="#section-7.5.2-2" class="pilcrow">¶</a></p>
 <span id="name-representation-of-ca-certif"></span><div id="PCAC">
-<figure id="figure-13">
+<figure id="figure-18">
             <div class="alignLeft art-text artwork" id="section-7.5.2-3.1">
 <pre>
 # The CA certificates data with registrar signature in General JWS Serialization syntax
@@ -3947,7 +4426,7 @@ This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certific
 }
 </pre>
 </div>
-<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
+<figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
 <a href="#name-representation-of-ca-certif" class="selfRef">Representation of CA certificate(s) data with registrar signature</a>
             </figcaption></figure>
 </div>
@@ -3982,14 +4461,103 @@ The IDevID CA certificate is necessary, when the connection between the Registra
 </li>
         </ul>
 <p id="section-7.6-6">The Registrar-Agent <span class="bcp14">MAY</span> optionally use TLS to protect the communication as outlined in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.<a href="#section-7.6-6" class="pilcrow">¶</a></p>
-<p id="section-7.6-7">The Registrar-Agent provides the information via distinct pledge endpoints as following.<a href="#section-7.6-7" class="pilcrow">¶</a></p>
+<p id="section-7.6-7">The Registrar-Agent provides the information via distinct pledge endpoints as following.
+<a href="#exchangesfig_uc2_6" class="auto internal xref">Figure 19</a> shows the provisioning of the voucher to the pledge. 
+The following subsections describe the corresponding artifacts.<a href="#section-7.6-7" class="pilcrow">¶</a></p>
+<span id="name-supply-voucher-to-pledge-2"></span><div id="exchangesfig_uc2_6">
+<figure id="figure-19">
+          <div id="section-7.6-8.1">
+            <div class="alignLeft art-svg artwork" id="section-7.6-8.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="560" viewBox="0 0 560 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 32,160 L 32,224" fill="none" stroke="black"></path>
+                <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
+                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
+                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 432,160 L 432,224" fill="none" stroke="black"></path>
+                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 536,160 L 536,224" fill="none" stroke="black"></path>
+                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 136,176 L 160,176" fill="none" stroke="black"></path>
+                <path d="M 40,192 L 64,192" fill="none" stroke="black"></path>
+                <path d="M 144,192 L 160,192" fill="none" stroke="black"></path>
+                <path d="M 40,208 L 64,208" fill="none" stroke="black"></path>
+                <path d="M 144,208 L 160,208" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="168,208 156,202.4 156,213.6" fill="black" transform="rotate(0,160,208)"></polygon>
+                <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
+                <polygon class="arrowhead" points="48,192 36,186.4 36,197.6" fill="black" transform="rotate(180,40,192)"></polygon>
+                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <g class="text">
+                  <text x="44" y="52">Pledge</text>
+                  <text x="164" y="52">Registrar-</text>
+                  <text x="276" y="52">Domain</text>
+                  <text x="412" y="52">Domain</text>
+                  <text x="500" y="52">MASA</text>
+                  <text x="144" y="68">Agent</text>
+                  <text x="288" y="68">Registrar</text>
+                  <text x="396" y="68">CA</text>
+                  <text x="32" y="100">|</text>
+                  <text x="168" y="100">|</text>
+                  <text x="312" y="100">|</text>
+                  <text x="432" y="100">|</text>
+                  <text x="492" y="100">Internet</text>
+                  <text x="536" y="100">|</text>
+                  <text x="32" y="116">~</text>
+                  <text x="168" y="116">~</text>
+                  <text x="312" y="116">~</text>
+                  <text x="432" y="116">~</text>
+                  <text x="536" y="116">~</text>
+                  <text x="40" y="132">(6)</text>
+                  <text x="84" y="132">Supply</text>
+                  <text x="144" y="132">Voucher</text>
+                  <text x="188" y="132">to</text>
+                  <text x="228" y="132">Pledge</text>
+                  <text x="32" y="148">~</text>
+                  <text x="168" y="148">~</text>
+                  <text x="312" y="148">~</text>
+                  <text x="432" y="148">~</text>
+                  <text x="536" y="148">~</text>
+                  <text x="76" y="180">opt.</text>
+                  <text x="112" y="180">TLS</text>
+                  <text x="104" y="196">Voucher</text>
+                  <text x="104" y="212">vStatus</text>
+                  <text x="32" y="244">~</text>
+                  <text x="168" y="244">~</text>
+                  <text x="312" y="244">~</text>
+                  <text x="432" y="244">~</text>
+                  <text x="536" y="244">~</text>
+                </g>
+              </svg><a href="#section-7.6-8.1.1" class="pilcrow">¶</a>
+</div>
+</div>
+<figcaption><a href="#figure-19" class="selfRef">Figure 19</a>:
+<a href="#name-supply-voucher-to-pledge-2" class="selfRef">Supply voucher to pledge</a>
+          </figcaption></figure>
+</div>
 <div id="request-artifact-voucher">
 <section id="section-7.6.1">
           <h4 id="name-request-artifact-voucher">
 <a href="#section-7.6.1" class="section-number selfRef">7.6.1. </a><a href="#name-request-artifact-voucher" class="section-name selfRef">Request Artifact: Voucher</a>
           </h4>
 <p id="section-7.6.1-1">The Registrar-Agent <span class="bcp14">SHALL</span> send the voucher-response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/svr".<a href="#section-7.6.1-1" class="pilcrow">¶</a></p>
-<p id="section-7.6.1-2">The Registrar-Agent voucher-response Content-Type header is <code>application/voucher-jws+json</code> and contains the voucher as provided by the MASA. An example is given in <a href="#MASA-vr" class="auto internal xref">Figure 11</a> for a MASA  signed voucher and in <a href="#MASA-REG-vr" class="auto internal xref">Figure 12</a> for the voucher with the additional signature of the registrar.<a href="#section-7.6.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.6.1-2">The Registrar-Agent voucher-response Content-Type header is <code>application/voucher-jws+json</code> and contains the voucher as provided by the MASA. An example is given in <a href="#MASA-vr" class="auto internal xref">Figure 14</a> for a MASA  signed voucher and in <a href="#MASA-REG-vr" class="auto internal xref">Figure 15</a> for the voucher with the additional signature of the registrar.<a href="#section-7.6.1-2" class="pilcrow">¶</a></p>
 <p id="section-7.6.1-3">A nonceless voucher may be accepted as in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> and may be allowed by a manufacture's pledge implementation.<a href="#section-7.6.1-3" class="pilcrow">¶</a></p>
 <p id="section-7.6.1-4">To perform the validation of several signatures on the voucher object, the pledge <span class="bcp14">SHALL</span> perform the signature verification in the following order:<a href="#section-7.6.1-4" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-7.6.1-5">
@@ -4011,17 +4579,17 @@ If all steps stated above have been performed successfully, the pledge <span cla
 <p id="section-7.6.1-7">If an error occurs during the verification and validation of the voucher, this <span class="bcp14">SHALL</span> be reported in the reason field of the pledge voucher status.<a href="#section-7.6.1-7" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="response-artifact-vstatus">
+<div id="response-artifact-voucher-status-vstatus">
 <section id="section-7.6.2">
-          <h4 id="name-response-artifact-vstatus">
-<a href="#section-7.6.2" class="section-number selfRef">7.6.2. </a><a href="#name-response-artifact-vstatus" class="section-name selfRef">Response Artifact: vStatus</a>
+          <h4 id="name-response-artifact-voucher-s">
+<a href="#section-7.6.2" class="section-number selfRef">7.6.2. </a><a href="#name-response-artifact-voucher-s" class="section-name selfRef">Response Artifact: Voucher Status (vStatus)</a>
           </h4>
 <p id="section-7.6.2-1">After voucher verification and validation the pledge <span class="bcp14">MUST</span> reply with a status telemetry message as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.7" class="relref">Section 5.7</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 The pledge generates the voucher-status and provides it as signed JSON-in-JWS object in response to the Registrar-Agent.<a href="#section-7.6.2-1" class="pilcrow">¶</a></p>
-<p id="section-7.6.2-2">The response has the Content-Type <code>application/jose+json</code> and is signed using the IDevID of the pledge as shown in <a href="#vstat" class="auto internal xref">Figure 14</a>.
+<p id="section-7.6.2-2">The response has the Content-Type <code>application/jose+json</code> and is signed using the IDevID of the pledge as shown in <a href="#vstat" class="auto internal xref">Figure 20</a>.
 As the reason field is optional (see <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>), it <span class="bcp14">MAY</span> be omitted in case of success.<a href="#section-7.6.2-2" class="pilcrow">¶</a></p>
 <span id="name-representation-of-pledge-vo"></span><div id="vstat">
-<figure id="figure-14">
+<figure id="figure-20">
             <div class="alignLeft art-text artwork" id="section-7.6.2-3.1">
 <pre>
 # The "pledge-voucher-status" telemetry in general JWS
@@ -4070,7 +4638,7 @@ As the reason field is optional (see <span>[<a href="#RFC8995" class="cite xref"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
+<figcaption><a href="#figure-20" class="selfRef">Figure 20</a>:
 <a href="#name-representation-of-pledge-vo" class="selfRef">Representation of pledge voucher status telemetry</a>
             </figcaption></figure>
 </div>
@@ -4084,6 +4652,96 @@ As the reason field is optional (see <span>[<a href="#RFC8995" class="cite xref"
         <h3 id="name-supply-ca-certificates-to-p">
 <a href="#section-7.7" class="section-number selfRef">7.7. </a><a href="#name-supply-ca-certificates-to-p" class="section-name selfRef">Supply CA certificates to Pledge</a>
         </h3>
+<p id="section-7.7-1"><a href="#exchangesfig_uc2_7" class="auto internal xref">Figure 21</a> shows the provisioning of the CA certificates aquired by the pledge-agent to the pledge. 
+The following subsections describe the corresponding artifacts.<a href="#section-7.7-1" class="pilcrow">¶</a></p>
+<span id="name-supply-ca-certificates-to-pl"></span><div id="exchangesfig_uc2_7">
+<figure id="figure-21">
+          <div id="section-7.7-2.1">
+            <div class="alignLeft art-svg artwork" id="section-7.7-2.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="256" width="560" viewBox="0 0 560 256" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 32,160 L 32,224" fill="none" stroke="black"></path>
+                <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,224" fill="none" stroke="black"></path>
+                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
+                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 432,160 L 432,224" fill="none" stroke="black"></path>
+                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 536,160 L 536,224" fill="none" stroke="black"></path>
+                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 136,176 L 160,176" fill="none" stroke="black"></path>
+                <path d="M 40,192 L 64,192" fill="none" stroke="black"></path>
+                <path d="M 144,192 L 160,192" fill="none" stroke="black"></path>
+                <path d="M 40,208 L 56,208" fill="none" stroke="black"></path>
+                <path d="M 136,208 L 160,208" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="168,208 156,202.4 156,213.6" fill="black" transform="rotate(0,160,208)"></polygon>
+                <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
+                <polygon class="arrowhead" points="48,192 36,186.4 36,197.6" fill="black" transform="rotate(180,40,192)"></polygon>
+                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <g class="text">
+                  <text x="44" y="52">Pledge</text>
+                  <text x="164" y="52">Registrar-</text>
+                  <text x="276" y="52">Domain</text>
+                  <text x="412" y="52">Domain</text>
+                  <text x="500" y="52">MASA</text>
+                  <text x="144" y="68">Agent</text>
+                  <text x="288" y="68">Registrar</text>
+                  <text x="396" y="68">CA</text>
+                  <text x="32" y="100">|</text>
+                  <text x="168" y="100">|</text>
+                  <text x="312" y="100">|</text>
+                  <text x="432" y="100">|</text>
+                  <text x="492" y="100">Internet</text>
+                  <text x="536" y="100">|</text>
+                  <text x="32" y="116">~</text>
+                  <text x="168" y="116">~</text>
+                  <text x="312" y="116">~</text>
+                  <text x="432" y="116">~</text>
+                  <text x="536" y="116">~</text>
+                  <text x="40" y="132">(7)</text>
+                  <text x="84" y="132">Supply</text>
+                  <text x="124" y="132">CA</text>
+                  <text x="188" y="132">certificates</text>
+                  <text x="252" y="132">to</text>
+                  <text x="292" y="132">Pledge</text>
+                  <text x="32" y="148">~</text>
+                  <text x="168" y="148">~</text>
+                  <text x="312" y="148">~</text>
+                  <text x="432" y="148">~</text>
+                  <text x="536" y="148">~</text>
+                  <text x="76" y="180">opt.</text>
+                  <text x="112" y="180">TLS</text>
+                  <text x="104" y="196">cACerts</text>
+                  <text x="96" y="212">cACerts</text>
+                  <text x="32" y="244">~</text>
+                  <text x="168" y="244">~</text>
+                  <text x="312" y="244">~</text>
+                  <text x="432" y="244">~</text>
+                  <text x="536" y="244">~</text>
+                </g>
+              </svg><a href="#section-7.7-2.1.1" class="pilcrow">¶</a>
+</div>
+</div>
+<figcaption><a href="#figure-21" class="selfRef">Figure 21</a>:
+<a href="#name-supply-ca-certificates-to-pl" class="selfRef">Supply CA certificates to pledge</a>
+          </figcaption></figure>
+</div>
 <div id="request-artifact">
 <section id="section-7.7.1">
           <h4 id="name-request-artifact">
@@ -4091,7 +4749,7 @@ As the reason field is optional (see <span>[<a href="#RFC8995" class="cite xref"
           </h4>
 <p id="section-7.7.1-1">The Registrar-Agent <span class="bcp14">SHALL</span> provide the set of CA certificates requested from the registrar to the pledge by HTTP POST to the endpoint: "/.well-known/brski/scac".<a href="#section-7.7.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.7.1-2">As the CA certificate provisioning is crucial from a security perspective, this provisioning <span class="bcp14">SHOULD</span> only be done, if the voucher-response has been successfully processed by pledge as reflected in the voucher status telemetry.<a href="#section-7.7.1-2" class="pilcrow">¶</a></p>
-<p id="section-7.7.1-3">The CA certificates message has the Content-Type <code>application/jose+json</code> and is signed using the credential of the registrar as shown in <a href="#PCAC" class="auto internal xref">Figure 13</a>.<a href="#section-7.7.1-3" class="pilcrow">¶</a></p>
+<p id="section-7.7.1-3">The CA certificates message has the Content-Type <code>application/jose+json</code> and is signed using the credential of the registrar as shown in <a href="#PCAC" class="auto internal xref">Figure 18</a>.<a href="#section-7.7.1-3" class="pilcrow">¶</a></p>
 <p id="section-7.7.1-4">The CA certificates are provided as base64-encoded "x5bag".
 The pledge <span class="bcp14">SHALL</span> install the received CA certificates as trust anchor after successful verification of the registrar's signature.<a href="#section-7.7.1-4" class="pilcrow">¶</a></p>
 </section>
@@ -4128,6 +4786,89 @@ The pledge <span class="bcp14">SHALL</span> install the received CA certificates
         <h3 id="name-supply-enroll-response-to-p">
 <a href="#section-7.8" class="section-number selfRef">7.8. </a><a href="#name-supply-enroll-response-to-p" class="section-name selfRef">Supply Enroll-Response to Pledge</a>
         </h3>
+<p id="section-7.8-1"><a href="#exchangesfig_uc2_8" class="auto internal xref">Figure 22</a> shows the supply of the Enroll-Response to the pledge.
+The following subsections describe the corresponding artifacts.<a href="#section-7.8-1" class="pilcrow">¶</a></p>
+<span id="name-supply-enroll-response-to-pl"></span><div id="exchangesfig_uc2_8">
+<figure id="figure-22">
+          <div id="section-7.8-2.1">
+            <div class="alignLeft art-svg artwork" id="section-7.8-2.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="240" width="560" viewBox="0 0 560 240" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 32,160 L 32,208" fill="none" stroke="black"></path>
+                <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,208" fill="none" stroke="black"></path>
+                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,208" fill="none" stroke="black"></path>
+                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 432,160 L 432,208" fill="none" stroke="black"></path>
+                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 536,160 L 536,208" fill="none" stroke="black"></path>
+                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
+                <path d="M 40,192 L 56,192" fill="none" stroke="black"></path>
+                <path d="M 136,192 L 160,192" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="168,192 156,186.4 156,197.6" fill="black" transform="rotate(0,160,192)"></polygon>
+                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
+                <g class="text">
+                  <text x="44" y="52">Pledge</text>
+                  <text x="164" y="52">Registrar-</text>
+                  <text x="276" y="52">Domain</text>
+                  <text x="412" y="52">Domain</text>
+                  <text x="500" y="52">MASA</text>
+                  <text x="144" y="68">Agent</text>
+                  <text x="288" y="68">Registrar</text>
+                  <text x="396" y="68">CA</text>
+                  <text x="32" y="100">|</text>
+                  <text x="168" y="100">|</text>
+                  <text x="312" y="100">|</text>
+                  <text x="432" y="100">|</text>
+                  <text x="492" y="100">Internet</text>
+                  <text x="536" y="100">|</text>
+                  <text x="32" y="116">~</text>
+                  <text x="168" y="116">~</text>
+                  <text x="312" y="116">~</text>
+                  <text x="432" y="116">~</text>
+                  <text x="536" y="116">~</text>
+                  <text x="40" y="132">(8)</text>
+                  <text x="84" y="132">Supply</text>
+                  <text x="176" y="132">Enroll-Response</text>
+                  <text x="252" y="132">to</text>
+                  <text x="292" y="132">Pledge</text>
+                  <text x="32" y="148">~</text>
+                  <text x="168" y="148">~</text>
+                  <text x="312" y="148">~</text>
+                  <text x="432" y="148">~</text>
+                  <text x="536" y="148">~</text>
+                  <text x="84" y="180">Enroll</text>
+                  <text x="140" y="180">Resp--</text>
+                  <text x="96" y="196">eStatus</text>
+                  <text x="32" y="228">~</text>
+                  <text x="168" y="228">~</text>
+                  <text x="312" y="228">~</text>
+                  <text x="432" y="228">~</text>
+                  <text x="536" y="228">~</text>
+                </g>
+              </svg><a href="#section-7.8-2.1.1" class="pilcrow">¶</a>
+</div>
+</div>
+<figcaption><a href="#figure-22" class="selfRef">Figure 22</a>:
+<a href="#name-supply-enroll-response-to-pl" class="selfRef">Supply Enroll-Response to pledge</a>
+          </figcaption></figure>
+</div>
 <div id="request-artifact-enroll-response">
 <section id="section-7.8.1">
           <h4 id="name-request-artifact-enroll-res">
@@ -4141,14 +4882,14 @@ The pledge <span class="bcp14">SHALL</span> generate the enroll status and provi
 If the verification of the LDevID certificate succeeds, the status property <span class="bcp14">SHALL</span> be set to "status": true, otherwise to "status": false<a href="#section-7.8.1-3" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="response-artifact-estatus">
+<div id="response-artifact-enroll-status-estatus">
 <section id="section-7.8.2">
-          <h4 id="name-response-artifact-estatus">
-<a href="#section-7.8.2" class="section-number selfRef">7.8.2. </a><a href="#name-response-artifact-estatus" class="section-name selfRef">Response Artifact: eStatus</a>
+          <h4 id="name-response-artifact-enroll-st">
+<a href="#section-7.8.2" class="section-number selfRef">7.8.2. </a><a href="#name-response-artifact-enroll-st" class="section-name selfRef">Response Artifact: Enroll Status (eStatus)</a>
           </h4>
 <p id="section-7.8.2-1">After enrollment processing the pledge <span class="bcp14">MUST</span> reply with a enrollment status telemetry message as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 The enroll-status is also a signed object in BRSKI-PRM and results in form of JSON-in-JWS here.
-If the pledge verified the received LDevID certificate successfully it <span class="bcp14">SHALL</span> sign the enroll-status using its new LDevID credentials as shown in <a href="#estat" class="auto internal xref">Figure 16</a>.
+If the pledge verified the received LDevID certificate successfully it <span class="bcp14">SHALL</span> sign the enroll-status using its new LDevID credentials as shown in <a href="#estat" class="auto internal xref">Figure 24</a>.
 In failure case, the pledge <span class="bcp14">SHALL</span> use its IDevID credentials.
 <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> specifies the enrollment status telemetry message with two optional fields for "reason" and "reason-context". 
 In BRSKI-PRM the optional fields are mandated to have a clear distinction between other status messages and <span class="bcp14">MUST</span> be provided therefore.
@@ -4156,7 +4897,7 @@ This distinction is intended for better error handling on registrar side, as a s
 <p id="section-7.8.2-2">The following CDDL <span>[<a href="#RFC8610" class="cite xref">RFC8610</a>]</span> explains enroll-status response structure. 
 It is similar as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with the optional fields set to mandatory as described above.<a href="#section-7.8.2-2" class="pilcrow">¶</a></p>
 <span id="name-cddl-for-pledge-enrollment-"></span><div id="e_stat_res_def">
-<figure id="figure-15">
+<figure id="figure-23">
             <div class="sourcecode" id="section-7.8.2-3.1">
 <pre>&lt;CODE BEGINS&gt;
 enrollstatus-post = {
@@ -4168,13 +4909,13 @@ enrollstatus-post = {
 
 &lt;CODE ENDS&gt;</pre>
 </div>
-<figcaption><a href="#figure-15" class="selfRef">Figure 15</a>:
+<figcaption><a href="#figure-23" class="selfRef">Figure 23</a>:
 <a href="#name-cddl-for-pledge-enrollment-" class="selfRef">CDDL for pledge-enrollment-status response</a>
             </figcaption></figure>
 </div>
 <p id="section-7.8.2-4">The response has the Content-Type <code>application/jose+json</code>.<a href="#section-7.8.2-4" class="pilcrow">¶</a></p>
 <span id="name-representation-of-pledge-en"></span><div id="estat">
-<figure id="figure-16">
+<figure id="figure-24">
             <div class="alignLeft art-text artwork" id="section-7.8.2-5.1">
 <pre>
 # The "pledge-enroll-status" telemetry in General JWS Serialization
@@ -4222,7 +4963,7 @@ enrollstatus-post = {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-16" class="selfRef">Figure 16</a>:
+<figcaption><a href="#figure-24" class="selfRef">Figure 24</a>:
 <a href="#name-representation-of-pledge-en" class="selfRef">Representation of pledge enroll status telemetry</a>
             </figcaption></figure>
 </div>
@@ -4244,97 +4985,110 @@ It <span class="bcp14">SHALL</span> provide the status information to the regist
             <p id="section-7.9-3.1.1">Registrar-Agent: obtained voucher status (vStatus) and enroll status (eStatus) from pledge.<a href="#section-7.9-3.1.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<span id="name-bootstrapping-status-handli"></span><div id="exchangesfig_uc2_4">
-<figure id="figure-17">
-          <div id="section-7.9-4.1">
-            <div class="alignLeft art-svg artwork" id="section-7.9-4.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="304" width="496" viewBox="0 0 496 304" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
-                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 40,144 L 40,288" fill="none" stroke="black"></path>
-                <path d="M 104,32 L 104,80" fill="none" stroke="black"></path>
-                <path d="M 176,32 L 176,80" fill="none" stroke="black"></path>
-                <path d="M 224,88 L 224,224" fill="none" stroke="black"></path>
-                <path d="M 224,256 L 224,288" fill="none" stroke="black"></path>
-                <path d="M 272,32 L 272,80" fill="none" stroke="black"></path>
-                <path d="M 304,32 L 304,80" fill="none" stroke="black"></path>
-                <path d="M 344,88 L 344,192" fill="none" stroke="black"></path>
-                <path d="M 344,256 L 344,288" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 408,32 L 408,80" fill="none" stroke="black"></path>
-                <path d="M 448,88 L 448,224" fill="none" stroke="black"></path>
-                <path d="M 448,256 L 448,288" fill="none" stroke="black"></path>
-                <path d="M 488,32 L 488,80" fill="none" stroke="black"></path>
-                <path d="M 8,32 L 104,32" fill="none" stroke="black"></path>
-                <path d="M 176,32 L 272,32" fill="none" stroke="black"></path>
-                <path d="M 304,32 L 376,32" fill="none" stroke="black"></path>
-                <path d="M 408,32 L 488,32" fill="none" stroke="black"></path>
-                <path d="M 8,80 L 104,80" fill="none" stroke="black"></path>
-                <path d="M 176,80 L 272,80" fill="none" stroke="black"></path>
-                <path d="M 304,80 L 376,80" fill="none" stroke="black"></path>
-                <path d="M 408,80 L 488,80" fill="none" stroke="black"></path>
-                <path d="M 48,160 L 104,160" fill="none" stroke="black"></path>
-                <path d="M 160,160 L 216,160" fill="none" stroke="black"></path>
-                <path d="M 48,192 L 88,192" fill="none" stroke="black"></path>
-                <path d="M 168,192 L 216,192" fill="none" stroke="black"></path>
-                <path d="M 232,208 L 248,208" fill="none" stroke="black"></path>
-                <path d="M 424,208 L 440,208" fill="none" stroke="black"></path>
-                <path d="M 232,224 L 264,224" fill="none" stroke="black"></path>
-                <path d="M 416,224 L 440,224" fill="none" stroke="black"></path>
-                <path d="M 48,272 L 88,272" fill="none" stroke="black"></path>
-                <path d="M 168,272 L 216,272" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="448,208 436,202.4 436,213.6" fill="black" transform="rotate(0,440,208)"></polygon>
-                <polygon class="arrowhead" points="240,224 228,218.4 228,229.6" fill="black" transform="rotate(180,232,224)"></polygon>
-                <polygon class="arrowhead" points="224,272 212,266.4 212,277.6" fill="black" transform="rotate(0,216,272)"></polygon>
-                <polygon class="arrowhead" points="224,192 212,186.4 212,197.6" fill="black" transform="rotate(0,216,192)"></polygon>
-                <polygon class="arrowhead" points="224,160 212,154.4 212,165.6" fill="black" transform="rotate(0,216,160)"></polygon>
-                <polygon class="arrowhead" points="56,160 44,154.4 44,165.6" fill="black" transform="rotate(180,48,160)"></polygon>
-                <g class="text">
-                  <text x="60" y="52">Registrar-</text>
-                  <text x="212" y="52">Domain</text>
-                  <text x="340" y="52">Domain</text>
-                  <text x="436" y="52">MASA</text>
-                  <text x="40" y="68">Agent</text>
-                  <text x="224" y="68">Registrar</text>
-                  <text x="324" y="68">CA</text>
-                  <text x="40" y="100">|</text>
-                  <text x="404" y="100">Internet</text>
-                  <text x="36" y="116">[voucher</text>
-                  <text x="80" y="116">+</text>
-                  <text x="116" y="116">enroll</text>
-                  <text x="152" y="116">]</text>
-                  <text x="32" y="132">[status</text>
-                  <text x="84" y="132">info</text>
-                  <text x="148" y="132">available]</text>
-                  <text x="132" y="164">mTLS</text>
-                  <text x="128" y="196">vStatus</text>
-                  <text x="300" y="212">req-device</text>
-                  <text x="368" y="212">audit</text>
-                  <text x="408" y="212">log</text>
-                  <text x="300" y="228">device</text>
-                  <text x="352" y="228">audit</text>
-                  <text x="392" y="228">log</text>
-                  <text x="184" y="244">[verify</text>
-                  <text x="240" y="244">audit</text>
-                  <text x="280" y="244">log</text>
-                  <text x="304" y="244">]</text>
-                  <text x="128" y="276">eStatus</text>
-                </g>
-              </svg><a href="#section-7.9-4.1.1" class="pilcrow">¶</a>
+<div id="section-7.9-4">
+          <div class="alignLeft art-svg artwork" id="section-7.9-4.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="288" width="560" viewBox="0 0 560 288" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+              <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+              <path d="M 32,160 L 32,256" fill="none" stroke="black"></path>
+              <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+              <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+              <path d="M 168,160 L 168,256" fill="none" stroke="black"></path>
+              <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+              <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+              <path d="M 312,160 L 312,224" fill="none" stroke="black"></path>
+              <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+              <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+              <path d="M 432,160 L 432,192" fill="none" stroke="black"></path>
+              <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+              <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+              <path d="M 536,160 L 536,224" fill="none" stroke="black"></path>
+              <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+              <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
+              <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+              <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+              <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+              <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+              <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+              <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+              <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+              <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+              <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+              <path d="M 176,176 L 208,176" fill="none" stroke="black"></path>
+              <path d="M 264,176 L 304,176" fill="none" stroke="black"></path>
+              <path d="M 176,192 L 200,192" fill="none" stroke="black"></path>
+              <path d="M 280,192 L 304,192" fill="none" stroke="black"></path>
+              <path d="M 320,208 L 336,208" fill="none" stroke="black"></path>
+              <path d="M 512,208 L 528,208" fill="none" stroke="black"></path>
+              <path d="M 320,224 L 352,224" fill="none" stroke="black"></path>
+              <path d="M 504,224 L 528,224" fill="none" stroke="black"></path>
+              <polygon class="arrowhead" points="536,208 524,202.4 524,213.6" fill="black" transform="rotate(0,528,208)"></polygon>
+              <polygon class="arrowhead" points="328,224 316,218.4 316,229.6" fill="black" transform="rotate(180,320,224)"></polygon>
+              <polygon class="arrowhead" points="312,192 300,186.4 300,197.6" fill="black" transform="rotate(0,304,192)"></polygon>
+              <polygon class="arrowhead" points="312,176 300,170.4 300,181.6" fill="black" transform="rotate(0,304,176)"></polygon>
+              <polygon class="arrowhead" points="184,176 172,170.4 172,181.6" fill="black" transform="rotate(180,176,176)"></polygon>
+              <g class="text">
+                <text x="44" y="52">Pledge</text>
+                <text x="164" y="52">Registrar-</text>
+                <text x="276" y="52">Domain</text>
+                <text x="412" y="52">Domain</text>
+                <text x="500" y="52">MASA</text>
+                <text x="144" y="68">Agent</text>
+                <text x="288" y="68">Registrar</text>
+                <text x="396" y="68">CA</text>
+                <text x="32" y="100">|</text>
+                <text x="168" y="100">|</text>
+                <text x="312" y="100">|</text>
+                <text x="432" y="100">|</text>
+                <text x="492" y="100">Internet</text>
+                <text x="536" y="100">|</text>
+                <text x="32" y="116">~</text>
+                <text x="168" y="116">~</text>
+                <text x="312" y="116">~</text>
+                <text x="432" y="116">~</text>
+                <text x="536" y="116">~</text>
+                <text x="40" y="132">(9)</text>
+                <text x="88" y="132">Voucher</text>
+                <text x="148" y="132">Status</text>
+                <text x="216" y="132">Telemetry</text>
+                <text x="32" y="148">~</text>
+                <text x="168" y="148">~</text>
+                <text x="312" y="148">~</text>
+                <text x="432" y="148">~</text>
+                <text x="536" y="148">~</text>
+                <text x="236" y="180">mTLS</text>
+                <text x="240" y="196">vStatus</text>
+                <text x="360" y="212">req</text>
+                <text x="404" y="212">device</text>
+                <text x="456" y="212">audit</text>
+                <text x="496" y="212">log</text>
+                <text x="388" y="228">device</text>
+                <text x="440" y="228">audit</text>
+                <text x="480" y="228">log</text>
+                <text x="288" y="244">[verify</text>
+                <text x="344" y="244">audit</text>
+                <text x="388" y="244">log]</text>
+                <text x="312" y="260">|</text>
+                <text x="432" y="260">|</text>
+                <text x="536" y="260">|</text>
+                <text x="32" y="276">~</text>
+                <text x="168" y="276">~</text>
+                <text x="312" y="276">~</text>
+                <text x="432" y="276">~</text>
+                <text x="536" y="276">~</text>
+              </g>
+            </svg><a href="#section-7.9-4.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-17" class="selfRef">Figure 17</a>:
-<a href="#name-bootstrapping-status-handli" class="selfRef">Bootstrapping status handling</a>
-          </figcaption></figure>
-</div>
-<p id="section-7.9-5">The Registrar-Agent <span class="bcp14">MUST</span> provide the collected pledge voucher status to the registrar.
-This status indicates if the pledge could process the voucher successfully or not.<a href="#section-7.9-5" class="pilcrow">¶</a></p>
-<p id="section-7.9-6">In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-7.9-6" class="pilcrow">¶</a></p>
-<div id="request-artifact-vstatus">
+<p id="section-7.9-5">{: #exchangesfig_uc2_9 title='Voucher Status tekemetry handling' artwork-align="left"}~~~~ aasvg<a href="#section-7.9-5" class="pilcrow">¶</a></p>
+<p id="section-7.9-6">The Registrar-Agent <span class="bcp14">MUST</span> provide the collected pledge voucher status to the registrar.
+This status indicates if the pledge could process the voucher successfully or not.<a href="#section-7.9-6" class="pilcrow">¶</a></p>
+<p id="section-7.9-7">In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-7.9-7" class="pilcrow">¶</a></p>
+<div id="request-artifact-voucher-status-vstatus">
 <section id="section-7.9.1">
-          <h4 id="name-request-artifact-vstatus">
-<a href="#section-7.9.1" class="section-number selfRef">7.9.1. </a><a href="#name-request-artifact-vstatus" class="section-name selfRef">Request Artifact: vStatus</a>
+          <h4 id="name-request-artifact-voucher-st">
+<a href="#section-7.9.1" class="section-number selfRef">7.9.1. </a><a href="#name-request-artifact-voucher-st" class="section-name selfRef">Request Artifact: Voucher Status (vStatus)</a>
           </h4>
-<p id="section-7.9.1-1">The Registrar-Agent sends the pledge voucher status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/voucher_status". The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#vstat" class="auto internal xref">Figure 14</a>.<a href="#section-7.9.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.9.1-1">The Registrar-Agent sends the pledge voucher status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/voucher_status". The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#vstat" class="auto internal xref">Figure 20</a>.<a href="#section-7.9.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.9.1-2">The registrar <span class="bcp14">SHOULD</span> log the transaction provided for a pledge via Registrar-Agent and include the identity of the Registrar-Agent in these logs. For log analysis the following may be considered:<a href="#section-7.9.1-2" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.9.1-3.1">
@@ -4370,13 +5124,89 @@ Within the server logs the server <span class="bcp14">SHOULD</span> capture this
         </h3>
 <p id="section-7.10-1">The Registrar-Agent <span class="bcp14">MUST</span> provide the pledge's enroll status to the registrar.
 The status indicates the pledge could process the Enroll-Response (certificate) and holds the corresponding private key.<a href="#section-7.10-1" class="pilcrow">¶</a></p>
-<div id="request-artifact-estatus">
+<span id="name-enroll-status-provisioning-"></span><div id="exchangesfig_uc2_10">
+<figure id="figure-25">
+          <div id="section-7.10-2.1">
+            <div class="alignLeft art-svg artwork" id="section-7.10-2.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="224" width="560" viewBox="0 0 560 224" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 32,160 L 32,192" fill="none" stroke="black"></path>
+                <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,192" fill="none" stroke="black"></path>
+                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,192" fill="none" stroke="black"></path>
+                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 432,160 L 432,192" fill="none" stroke="black"></path>
+                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 536,160 L 536,192" fill="none" stroke="black"></path>
+                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
+                <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 176,176 L 200,176" fill="none" stroke="black"></path>
+                <path d="M 280,176 L 304,176" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="312,176 300,170.4 300,181.6" fill="black" transform="rotate(0,304,176)"></polygon>
+                <g class="text">
+                  <text x="44" y="52">Pledge</text>
+                  <text x="164" y="52">Registrar-</text>
+                  <text x="276" y="52">Domain</text>
+                  <text x="412" y="52">Domain</text>
+                  <text x="500" y="52">MASA</text>
+                  <text x="144" y="68">Agent</text>
+                  <text x="288" y="68">Registrar</text>
+                  <text x="396" y="68">CA</text>
+                  <text x="32" y="100">|</text>
+                  <text x="168" y="100">|</text>
+                  <text x="312" y="100">|</text>
+                  <text x="432" y="100">|</text>
+                  <text x="492" y="100">Internet</text>
+                  <text x="536" y="100">|</text>
+                  <text x="32" y="116">~</text>
+                  <text x="168" y="116">~</text>
+                  <text x="312" y="116">~</text>
+                  <text x="432" y="116">~</text>
+                  <text x="536" y="116">~</text>
+                  <text x="44" y="132">(10)</text>
+                  <text x="92" y="132">Enroll</text>
+                  <text x="148" y="132">Status</text>
+                  <text x="216" y="132">Telemetry</text>
+                  <text x="32" y="148">~</text>
+                  <text x="168" y="148">~</text>
+                  <text x="312" y="148">~</text>
+                  <text x="432" y="148">~</text>
+                  <text x="536" y="148">~</text>
+                  <text x="240" y="180">eStatus</text>
+                  <text x="32" y="212">~</text>
+                  <text x="168" y="212">~</text>
+                  <text x="312" y="212">~</text>
+                  <text x="432" y="212">~</text>
+                  <text x="536" y="212">~</text>
+                </g>
+              </svg><a href="#section-7.10-2.1.1" class="pilcrow">¶</a>
+</div>
+</div>
+<figcaption><a href="#figure-25" class="selfRef">Figure 25</a>:
+<a href="#name-enroll-status-provisioning-" class="selfRef">Enroll-Status provisioning to domain registrar</a>
+          </figcaption></figure>
+</div>
+<div id="request-artifact-enroll-status-estatus">
 <section id="section-7.10.1">
-          <h4 id="name-request-artifact-estatus">
-<a href="#section-7.10.1" class="section-number selfRef">7.10.1. </a><a href="#name-request-artifact-estatus" class="section-name selfRef">Request Artifact: eStatus</a>
+          <h4 id="name-request-artifact-enroll-sta">
+<a href="#section-7.10.1" class="section-number selfRef">7.10.1. </a><a href="#name-request-artifact-enroll-sta" class="section-name selfRef">Request Artifact: Enroll Status (eStatus)</a>
           </h4>
 <p id="section-7.10.1-1">The Registrar-Agent sends the pledge enroll status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/enrollstatus".
-The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#estat" class="auto internal xref">Figure 16</a>.<a href="#section-7.10.1-1" class="pilcrow">¶</a></p>
+The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#estat" class="auto internal xref">Figure 24</a>.<a href="#section-7.10.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.10.1-2">The registrar <span class="bcp14">MUST</span> verify the signature of the pledge enroll status.
 Also, the registrar <span class="bcp14">SHALL</span> validate that the pledge is an accepted device of the domain based on the contained product-serial-number in the LDevID certificate referenced in the header of the enroll status.
 The registrar <span class="bcp14">SHOULD</span> log this event.
@@ -4407,56 +5237,97 @@ Within the server log the registrar <span class="bcp14">SHOULD</span> capture th
 <p id="section-7.11-1">The following assumes that a Registrar-Agent may need to query the status of a pledge.
 This information may be useful to solve errors, when the pledge was not able to connect to the target domain during the bootstrapping.
 The pledge <span class="bcp14">MAY</span> provide a dedicated endpoint to accept status-requests.<a href="#section-7.11-1" class="pilcrow">¶</a></p>
-<span id="name-pledge-status-handling-betw"></span><div id="exchangesfig_uc2_5">
-<figure id="figure-18">
+<span id="name-pledge-status-handling-betw"></span><div id="exchangesfig_uc2_11">
+<figure id="figure-26">
           <div id="section-7.11-2.1">
             <div class="alignLeft art-svg artwork" id="section-7.11-2.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="176" width="360" viewBox="0 0 360 176" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="240" width="560" viewBox="0 0 560 240" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
-                <path d="M 40,88 L 40,160" fill="none" stroke="black"></path>
+                <path d="M 32,160 L 32,208" fill="none" stroke="black"></path>
                 <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 256,32 L 256,80" fill="none" stroke="black"></path>
-                <path d="M 304,88 L 304,160" fill="none" stroke="black"></path>
-                <path d="M 352,32 L 352,80" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+                <path d="M 168,160 L 168,208" fill="none" stroke="black"></path>
+                <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+                <path d="M 312,160 L 312,208" fill="none" stroke="black"></path>
+                <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 432,160 L 432,208" fill="none" stroke="black"></path>
+                <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+                <path d="M 536,160 L 536,208" fill="none" stroke="black"></path>
+                <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 256,32 L 352,32" fill="none" stroke="black"></path>
+                <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
+                <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
+                <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
                 <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
-                <path d="M 256,80 L 352,80" fill="none" stroke="black"></path>
-                <path d="M 48,112 L 112,112" fill="none" stroke="black"></path>
-                <path d="M 224,112 L 296,112" fill="none" stroke="black"></path>
-                <path d="M 56,144 L 112,144" fill="none" stroke="black"></path>
-                <path d="M 232,144 L 296,144" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="304,144 292,138.4 292,149.6" fill="black" transform="rotate(0,296,144)"></polygon>
-                <polygon class="arrowhead" points="56,112 44,106.4 44,117.6" fill="black" transform="rotate(180,48,112)"></polygon>
+                <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+                <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+                <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+                <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+                <path d="M 40,176 L 56,176" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
-                  <text x="308" y="52">Registrar-</text>
-                  <text x="288" y="68">Agent</text>
-                  <text x="168" y="116">pStatus-Req</text>
-                  <text x="172" y="148">pStatus-Resp</text>
+                  <text x="164" y="52">Registrar-</text>
+                  <text x="276" y="52">Domain</text>
+                  <text x="412" y="52">Domain</text>
+                  <text x="500" y="52">MASA</text>
+                  <text x="144" y="68">Agent</text>
+                  <text x="288" y="68">Registrar</text>
+                  <text x="396" y="68">CA</text>
+                  <text x="32" y="100">|</text>
+                  <text x="168" y="100">|</text>
+                  <text x="312" y="100">|</text>
+                  <text x="432" y="100">|</text>
+                  <text x="492" y="100">Internet</text>
+                  <text x="536" y="100">|</text>
+                  <text x="32" y="116">~</text>
+                  <text x="168" y="116">~</text>
+                  <text x="312" y="116">~</text>
+                  <text x="432" y="116">~</text>
+                  <text x="536" y="116">~</text>
+                  <text x="44" y="132">(11)</text>
+                  <text x="88" y="132">Query</text>
+                  <text x="140" y="132">Pledge</text>
+                  <text x="196" y="132">Status</text>
+                  <text x="32" y="148">~</text>
+                  <text x="168" y="148">~</text>
+                  <text x="312" y="148">~</text>
+                  <text x="432" y="148">~</text>
+                  <text x="536" y="148">~</text>
+                  <text x="112" y="180">pStatus-Req--</text>
+                  <text x="100" y="196">--pStatus-Resp-&gt;</text>
+                  <text x="32" y="228">~</text>
+                  <text x="168" y="228">~</text>
+                  <text x="312" y="228">~</text>
+                  <text x="432" y="228">~</text>
+                  <text x="536" y="228">~</text>
                 </g>
               </svg><a href="#section-7.11-2.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
+<figcaption><a href="#figure-26" class="selfRef">Figure 26</a>:
 <a href="#name-pledge-status-handling-betw" class="selfRef">Pledge-status handling between Registrar-Agent and pledge</a>
           </figcaption></figure>
 </div>
-<div id="request-artifact-pstatus-req">
+<div id="request-artifact-pledge-status-request-pstatus-req">
 <section id="section-7.11.1">
-          <h4 id="name-request-artifact-pstatus-re">
-<a href="#section-7.11.1" class="section-number selfRef">7.11.1. </a><a href="#name-request-artifact-pstatus-re" class="section-name selfRef">Request Artifact: pStatus-Req</a>
+          <h4 id="name-request-artifact-pledge-sta">
+<a href="#section-7.11.1" class="section-number selfRef">7.11.1. </a><a href="#name-request-artifact-pledge-sta" class="section-name selfRef">Request Artifact: Pledge Status Request (pStatus-Req)</a>
           </h4>
 <p id="section-7.11.1-1">The Registrar-Agent requests the pledge-status via HTTP POST on the defined pledge endpoint: "/.well-known/brski/qps"<a href="#section-7.11.1-1" class="pilcrow">¶</a></p>
 <p id="section-7.11.1-2">The Registrar-Agent Content-Type header for the pledge-status request is: <code>application/jose+json</code>.
-It contains information on the requested status-type, the time and date the request is created, and the product serial-number of the pledge contacted as shown in <a href="#stat_req_def" class="auto internal xref">Figure 19</a>.
+It contains information on the requested status-type, the time and date the request is created, and the product serial-number of the pledge contacted as shown in <a href="#stat_req_def" class="auto internal xref">Figure 27</a>.
 The pledge-status request is signed by Registrar-Agent using the private key corresponding to the EE (RegAgt) certificate.<a href="#section-7.11.1-2" class="pilcrow">¶</a></p>
 <p id="section-7.11.1-3">The following Concise Data Definition Language (CDDL) <span>[<a href="#RFC8610" class="cite xref">RFC8610</a>]</span> explains the structure of the format for the pledge-status request. It is defined following the status telemetry definitions in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 Consequently, format and semantics of pledge-status requests below are for version 1.
 The version field is included to permit significant changes to the pledge-status request and response in the future.
 A pledge or a Registrar-Agent that receives a pledge-status request with a version larger than it knows about <span class="bcp14">SHOULD</span> log the contents and alert a human.<a href="#section-7.11.1-3" class="pilcrow">¶</a></p>
 <span id="name-cddl-for-pledge-status-requ"></span><div id="stat_req_def">
-<figure id="figure-19">
+<figure id="figure-27">
             <div class="sourcecode" id="section-7.11.1-4.1">
 <pre>&lt;CODE BEGINS&gt;
   status-request = {
@@ -4468,7 +5339,7 @@ A pledge or a Registrar-Agent that receives a pledge-status request with a versi
 
 &lt;CODE ENDS&gt;</pre>
 </div>
-<figcaption><a href="#figure-19" class="selfRef">Figure 19</a>:
+<figcaption><a href="#figure-27" class="selfRef">Figure 27</a>:
 <a href="#name-cddl-for-pledge-status-requ" class="selfRef">CDDL for pledge-status request</a>
             </figcaption></figure>
 </div>
@@ -4476,9 +5347,9 @@ A pledge or a Registrar-Agent that receives a pledge-status request with a versi
 This indicates the pledge to provide current status information regarding the bootstrapping status (voucher processing and enrollment of the pledge into the new domain).
 As the pledge-status request is defined generic, it may be used by other specifications to request further status information, e.g., for onboarding to get further information about enrollment of application specific LDevIDs or other parameters.
 This is out of scope for this specification.<a href="#section-7.11.1-5" class="pilcrow">¶</a></p>
-<p id="section-7.11.1-6"><a href="#stat_req" class="auto internal xref">Figure 20</a> below shows an example for querying pledge-status using status-type bootstrap.<a href="#section-7.11.1-6" class="pilcrow">¶</a></p>
+<p id="section-7.11.1-6"><a href="#stat_req" class="auto internal xref">Figure 28</a> below shows an example for querying pledge-status using status-type bootstrap.<a href="#section-7.11.1-6" class="pilcrow">¶</a></p>
 <span id="name-example-of-registrar-agent-"></span><div id="stat_req">
-<figure id="figure-20">
+<figure id="figure-28">
             <div class="alignLeft art-text artwork" id="section-7.11.1-7.1">
 <pre>
 # The Registrar-Agent request of "pledge-status" in general JWS
@@ -4513,22 +5384,22 @@ This is out of scope for this specification.<a href="#section-7.11.1-5" class="p
 }
 </pre>
 </div>
-<figcaption><a href="#figure-20" class="selfRef">Figure 20</a>:
+<figcaption><a href="#figure-28" class="selfRef">Figure 28</a>:
 <a href="#name-example-of-registrar-agent-" class="selfRef">Example of Registrar-Agent request of pledge-status using status-type bootstrap</a>
             </figcaption></figure>
 </div>
 </section>
 </div>
-<div id="response-artifact-pstatus-resp">
+<div id="response-artifact-pledge-status-response-pstatus-resp">
 <section id="section-7.11.2">
-          <h4 id="name-response-artifact-pstatus-r">
-<a href="#section-7.11.2" class="section-number selfRef">7.11.2. </a><a href="#name-response-artifact-pstatus-r" class="section-name selfRef">Response Artifact: pStatus-Resp</a>
+          <h4 id="name-response-artifact-pledge-st">
+<a href="#section-7.11.2" class="section-number selfRef">7.11.2. </a><a href="#name-response-artifact-pledge-st" class="section-name selfRef">Response Artifact: Pledge Status Response (pStatus-Resp)</a>
           </h4>
 <p id="section-7.11.2-1">If the pledge receives the pledge-status request with status-type "bootstrap" it <span class="bcp14">SHALL</span> react with a status response message based on previously collected telemetry information (see <a href="#vstatus" class="auto internal xref">Section 7.9</a> and <a href="#estatus" class="auto internal xref">Section 7.10</a>) in a single status-response artifact.<a href="#section-7.11.2-1" class="pilcrow">¶</a></p>
 <p id="section-7.11.2-2">The pledge-status response Content-Type header is <code>application/jose+json</code>.<a href="#section-7.11.2-2" class="pilcrow">¶</a></p>
 <p id="section-7.11.2-3">The following CDDL explains the structure of the format for the status response, which is:<a href="#section-7.11.2-3" class="pilcrow">¶</a></p>
 <span id="name-cddl-for-pledge-status-resp"></span><div id="stat_res_def">
-<figure id="figure-21">
+<figure id="figure-29">
             <div class="sourcecode" id="section-7.11.2-4.1">
 <pre>&lt;CODE BEGINS&gt;
   status-response = {
@@ -4547,7 +5418,7 @@ This is out of scope for this specification.<a href="#section-7.11.1-5" class="p
 
 &lt;CODE ENDS&gt;</pre>
 </div>
-<figcaption><a href="#figure-21" class="selfRef">Figure 21</a>:
+<figcaption><a href="#figure-29" class="selfRef">Figure 29</a>:
 <a href="#name-cddl-for-pledge-status-resp" class="selfRef">CDDL for pledge-status response</a>
             </figcaption></figure>
 </div>
@@ -4596,9 +5467,9 @@ The pledge signs the response message using its LDevID(Pledge).<a href="#section
 </li>
           </ul>
 <p id="section-7.11.2-10">The pledge-status responses are cumulative in the sense that connect-success implies enroll-success, which in turn implies voucher-success.<a href="#section-7.11.2-10" class="pilcrow">¶</a></p>
-<p id="section-7.11.2-11"><a href="#stat_res" class="auto internal xref">Figure 22</a> provides an example for the bootstrapping-status information.<a href="#section-7.11.2-11" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-11"><a href="#stat_res" class="auto internal xref">Figure 30</a> provides an example for the bootstrapping-status information.<a href="#section-7.11.2-11" class="pilcrow">¶</a></p>
 <span id="name-example-of-pledge-status-re"></span><div id="stat_res">
-<figure id="figure-22">
+<figure id="figure-30">
             <div class="alignLeft art-text artwork" id="section-7.11.2-12.1">
 <pre>
 # The pledge "status-response" in General JWS Serialization syntax
@@ -4634,7 +5505,7 @@ The pledge signs the response message using its LDevID(Pledge).<a href="#section
 }
 </pre>
 </div>
-<figcaption><a href="#figure-22" class="selfRef">Figure 22</a>:
+<figcaption><a href="#figure-30" class="selfRef">Figure 30</a>:
 <a href="#name-example-of-pledge-status-re" class="selfRef">Example of pledge-status response</a>
             </figcaption></figure>
 </div>
@@ -5084,7 +5955,7 @@ Support in PoC implementations and comments resulting from the implementation wa
 <p id="appendix-A.1-1">The following is an example request sent from a Pledge to the Registrar-Agent, in "General JWS JSON Serialization".
 The message size of this PVR is: 4649 bytes<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
 <span id="name-example-pledge-voucher-reque"></span><div id="ExamplePledgeVoucherRequestfigure">
-<figure id="figure-23">
+<figure id="figure-31">
           <div class="alignLeft art-text artwork" id="appendix-A.1-2.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -5166,7 +6037,7 @@ yuXZ2aw93zZId45R7XxAK-12YKIx6qLjiPjMw"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-23" class="selfRef">Figure 23</a>:
+<figcaption><a href="#figure-31" class="selfRef">Figure 31</a>:
 <a href="#name-example-pledge-voucher-reque" class="selfRef">Example Pledge-Voucher-Request - PVR</a>
           </figcaption></figure>
 </div>
@@ -5183,7 +6054,7 @@ been received by the Registrar, and then has been processed by the Registrar ("c
 Note that the previous PVR can be seen in the payload as "prior-signed-voucher-request".
 The message size of this RVR is: 13257 bytes<a href="#appendix-A.2-2" class="pilcrow">¶</a></p>
 <span id="name-example-registrar-voucher-r"></span><div id="ExampleRegistrarVoucherRequestfigure">
-<figure id="figure-24">
+<figure id="figure-32">
           <div class="alignLeft art-text artwork" id="appendix-A.2-3.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -5391,7 +6262,7 @@ yyFd3kP6YCn35YYJ7yK35d3styo_yoiPfKA"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-24" class="selfRef">Figure 24</a>:
+<figcaption><a href="#figure-32" class="selfRef">Figure 32</a>:
 <a href="#name-example-registrar-voucher-r" class="selfRef">Example Registrar-Voucher-Request - RVR</a>
           </figcaption></figure>
 </div>
@@ -5404,7 +6275,7 @@ yyFd3kP6YCn35YYJ7yK35d3styo_yoiPfKA"
         </h3>
 <p id="appendix-A.3-1">The following is an example voucher-response from MASA to Pledge via Registrar and Registrar-Agent, in "General JWS JSON Serialization". The message size of this Voucher is: 1916 bytes<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
 <span id="name-example-voucher-response-fr"></span><div id="ExampleVoucherResponsefigure">
-<figure id="figure-25">
+<figure id="figure-33">
           <div class="alignLeft art-text artwork" id="appendix-A.3-2.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -5444,7 +6315,7 @@ TvHMUw0wx9wdyuNVjNoAgLysNIgEvlcltBw"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-25" class="selfRef">Figure 25</a>:
+<figcaption><a href="#figure-33" class="selfRef">Figure 33</a>:
 <a href="#name-example-voucher-response-fr" class="selfRef">Example Voucher-Response from MASA</a>
           </figcaption></figure>
 </div>
@@ -5458,7 +6329,7 @@ TvHMUw0wx9wdyuNVjNoAgLysNIgEvlcltBw"
 <p id="appendix-A.4-1">The following is an example voucher-response from MASA to Pledge via Registrar and Registrar-Agent, in "General JWS JSON Serialization".
 The message size of this Voucher is: 3006 bytes<a href="#appendix-A.4-1" class="pilcrow">¶</a></p>
 <span id="name-example-voucher-response-fro"></span><div id="ExampleVoucherResponseWithRegSignfigure">
-<figure id="figure-26">
+<figure id="figure-34">
           <div class="alignLeft art-text artwork" id="appendix-A.4-2.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -5516,7 +6387,7 @@ qhRRyjnxp80IV_Fy1RAOXIIzs3Q8CnMgBgg"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-26" class="selfRef">Figure 26</a>:
+<figcaption><a href="#figure-34" class="selfRef">Figure 34</a>:
 <a href="#name-example-voucher-response-fro" class="selfRef">Example Voucher-Response from MASA, with additional Registrar signature</a>
           </figcaption></figure>
 </div>
@@ -5700,7 +6571,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-9.14.1">issue #99: motivated verification of second signature on voucher in <a href="#voucher" class="auto internal xref">Section 7.6</a><a href="#appendix-C-9.14.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.15">
-          <p id="appendix-C-9.15.1">issue #100: included negative example in <a href="#vstat" class="auto internal xref">Figure 14</a><a href="#appendix-C-9.15.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.15.1">issue #100: included negative example in <a href="#vstat" class="auto internal xref">Figure 20</a><a href="#appendix-C-9.15.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.16">
           <p id="appendix-C-9.16.1">issue #101: included handling if <a href="#voucher" class="auto internal xref">Section 7.6</a> voucher telemetry information has not been received by the Registrar-Agent<a href="#appendix-C-9.16.1" class="pilcrow">¶</a></p>
@@ -5709,7 +6580,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-9.17.1">issue #102: relaxed requirements for CA certs provisioning in <a href="#cacerts" class="auto internal xref">Section 7.7</a><a href="#appendix-C-9.17.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.18">
-          <p id="appendix-C-9.18.1">issue #105: included negative example in <a href="#estat" class="auto internal xref">Figure 16</a><a href="#appendix-C-9.18.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.18.1">issue #105: included negative example in <a href="#estat" class="auto internal xref">Figure 24</a><a href="#appendix-C-9.18.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.19">
           <p id="appendix-C-9.19.1">issue #107: included example for certificate revocation in <a href="#estatus" class="auto internal xref">Section 7.10</a><a href="#appendix-C-9.19.1" class="pilcrow">¶</a></p>
@@ -5721,7 +6592,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-9.21.1">issue #111: included pledge-status response processing for authenticated requests in <a href="#query" class="auto internal xref">Section 7.11</a><a href="#appendix-C-9.21.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.22">
-          <p id="appendix-C-9.22.1">issue #112: added "Example key word in pledge-status response in <a href="#stat_res" class="auto internal xref">Figure 22</a><a href="#appendix-C-9.22.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.22.1">issue #112: added "Example key word in pledge-status response in <a href="#stat_res" class="auto internal xref">Figure 30</a><a href="#appendix-C-9.22.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.23">
           <p id="appendix-C-9.23.1">issue #113: enhanced description of status reply for "factory-default" in  <a href="#query" class="auto internal xref">Section 7.11</a><a href="#appendix-C-9.23.1" class="pilcrow">¶</a></p>

--- a/draft-ietf-anima-brski-prm.html
+++ b/draft-ietf-anima-brski-prm.html
@@ -16,25 +16,26 @@ For this, BRSKI with Pledge in Responder Mode (BRSKI-PRM) introduces a new compo
 To establish the trust relation between pledge and registrar, BRSKI-PRM relies on object security rather than transport security.
 The approach defined here is agnostic to the enrollment protocol that connects the domain registrar to the domain CA. 
     " name="description">
-<meta content="xml2rfc 3.19.0" name="generator">
+<meta content="xml2rfc 3.19.4" name="generator">
 <meta content="draft-ietf-anima-brski-prm-12" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.19.0
-    Python 3.9.2
+  xml2rfc 3.19.4
+    Python 3.10.12
     ConfigArgParse 1.7
     google-i18n-address 3.1.0
     intervaltree 3.1.0
-    Jinja2 3.1.2
-    lxml 5.0.0
-    platformdirs 4.1.0
+    Jinja2 3.1.3
+    lxml 4.9.4
+    platformdirs 4.2.0
     pycountry 23.12.11
     PyYAML 6.0.1
     requests 2.31.0
-    setuptools 52.0.0
+    setuptools 59.6.0
     six 1.16.0
-    wcwidth 0.2.12
+    wcwidth 0.2.13
+    weasyprint 60.2
 -->
-<link href="draft-ietf-anima-brski-prm.xml" rel="alternate" type="application/rfc+xml">
+<link href="/usr/src/app/tmp/dbad6348-cc47-4d97-b1fe-c52118398dc1/brski-prm-12-mkovatsc.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1210,11 +1211,11 @@ li > p:last-of-type:only-child {
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">BRSKI-PRM</td>
-<td class="right">January 2024</td>
+<td class="right">February 2024</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Fries, et al.</td>
-<td class="center">Expires 7 July 2024</td>
+<td class="center">Expires 17 August 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1227,12 +1228,12 @@ li > p:last-of-type:only-child {
 <dd class="internet-draft">draft-ietf-anima-brski-prm-12</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-01-04" class="published">4 January 2024</time>
+<time datetime="2024-02-14" class="published">14 February 2024</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-07-07">7 July 2024</time></dd>
+<dd class="expires"><time datetime="2024-08-17">17 August 2024</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1292,7 +1293,7 @@ The approach defined here is agnostic to the enrollment protocol that connects t
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 7 July 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 17 August 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1359,199 +1360,270 @@ The approach defined here is agnostic to the enrollment protocol that connects t
                 <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="auto internal xref">5.1</a>.  <a href="#name-overview" class="internal xref">Overview</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.2">
-                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="auto internal xref">5.2</a>.  <a href="#name-nomadic-connectivity" class="internal xref">Nomadic connectivity</a></p>
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="auto internal xref">5.2</a>.  <a href="#name-nomadic-connectivity" class="internal xref">Nomadic Connectivity</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
-                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="auto internal xref">5.3</a>.  <a href="#name-registrar-agent-co-located-" class="internal xref">Registrar-Agent co-located with registrar</a></p>
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="auto internal xref">5.3</a>.  <a href="#name-co-located-registrar-agent-" class="internal xref">Co-located Registrar-Agent and Domain Registrar</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4">
                 <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="auto internal xref">5.4</a>.  <a href="#name-agent-proximity-assertion" class="internal xref">Agent-Proximity Assertion</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.5">
-                <p id="section-toc.1-1.5.2.5.1"><a href="#section-5.5" class="auto internal xref">5.5</a>.  <a href="#name-behavior-of-pledge-in-pledg" class="internal xref">Behavior of Pledge in Pledge-Responder-Mode</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.6">
-                <p id="section-toc.1-1.5.2.6.1"><a href="#section-5.6" class="auto internal xref">5.6</a>.  <a href="#name-behavior-of-registrar-agent" class="internal xref">Behavior of Registrar-Agent</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.6.2.1">
-                    <p id="section-toc.1-1.5.2.6.2.1.1"><a href="#section-5.6.1" class="auto internal xref">5.6.1</a>.  <a href="#name-discovery-of-registrar-by-r" class="internal xref">Discovery of Registrar by Registrar-Agent</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.6.2.2">
-                    <p id="section-toc.1-1.5.2.6.2.2.1"><a href="#section-5.6.2" class="auto internal xref">5.6.2</a>.  <a href="#name-discovery-of-pledge-by-regi" class="internal xref">Discovery of Pledge by Registrar-Agent</a></p>
-</li>
-                </ul>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.7">
-                <p id="section-toc.1-1.5.2.7.1"><a href="#section-5.7" class="auto internal xref">5.7</a>.  <a href="#name-behavior-of-pledge-with-com" class="internal xref">Behavior of Pledge with Combined Functionality</a></p>
-</li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-bootstrapping-data-objects-" class="internal xref">Bootstrapping Data Objects and Corresponding Exchanges</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-system-components" class="internal xref">System Components</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
-                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="auto internal xref">6.1</a>.  <a href="#name-request-objects-acquisition" class="internal xref">Request Objects Acquisition by Registrar-Agent from Pledge</a></p>
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="auto internal xref">6.1</a>.  <a href="#name-domain-registrar" class="internal xref">Domain Registrar</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1.2.1">
-                    <p id="section-toc.1-1.6.2.1.2.1.1"><a href="#section-6.1.1" class="auto internal xref">6.1.1</a>.  <a href="#name-pledge-voucher-request-pvr-" class="internal xref">Pledge-Voucher-Request (PVR) - Trigger</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1.2.2">
-                    <p id="section-toc.1-1.6.2.1.2.2.1"><a href="#section-6.1.2" class="auto internal xref">6.1.2</a>.  <a href="#name-pledge-voucher-request-pvr-r" class="internal xref">Pledge-Voucher-Request (PVR) - Response</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1.2.3">
-                    <p id="section-toc.1-1.6.2.1.2.3.1"><a href="#section-6.1.3" class="auto internal xref">6.1.3</a>.  <a href="#name-pledge-enrollment-request-p" class="internal xref">Pledge-Enrollment-Request (PER) - Trigger</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1.2.4">
-                    <p id="section-toc.1-1.6.2.1.2.4.1"><a href="#section-6.1.4" class="auto internal xref">6.1.4</a>.  <a href="#name-pledge-enrollment-request-pe" class="internal xref">Pledge-Enrollment-Request (PER) - Response</a></p>
+                    <p id="section-toc.1-1.6.2.1.2.1.1"><a href="#section-6.1.1" class="auto internal xref">6.1.1</a>.  <a href="#name-domain-registrar-with-combi" class="internal xref">Domain Registrar with Combined Functionality</a></p>
 </li>
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
-                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="auto internal xref">6.2</a>.  <a href="#name-request-object-handling-ini" class="internal xref">Request Object Handling initiated by the Registrar-Agent on Registrar, MASA and Domain CA</a></p>
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="auto internal xref">6.2</a>.  <a href="#name-registrar-agent" class="internal xref">Registrar-Agent</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.1">
-                    <p id="section-toc.1-1.6.2.2.2.1.1"><a href="#section-6.2.1" class="auto internal xref">6.2.1</a>.  <a href="#name-connection-establishment-re" class="internal xref">Connection Establishment (Registrar-Agent to Registrar)</a></p>
+                    <p id="section-toc.1-1.6.2.2.2.1.1"><a href="#section-6.2.1" class="auto internal xref">6.2.1</a>.  <a href="#name-discovery-of-the-registrar" class="internal xref">Discovery of the Registrar</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.2">
-                    <p id="section-toc.1-1.6.2.2.2.2.1"><a href="#section-6.2.2" class="auto internal xref">6.2.2</a>.  <a href="#name-pledge-voucher-request-pvr-p" class="internal xref">Pledge-Voucher-Request (PVR) Processing by Registrar</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.3">
-                    <p id="section-toc.1-1.6.2.2.2.3.1"><a href="#section-6.2.3" class="auto internal xref">6.2.3</a>.  <a href="#name-registrar-voucher-request-r" class="internal xref">Registrar-Voucher-Request (RVR) Processing (Registrar to MASA)</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.4">
-                    <p id="section-toc.1-1.6.2.2.2.4.1"><a href="#section-6.2.4" class="auto internal xref">6.2.4</a>.  <a href="#name-voucher-issuance-by-masa" class="internal xref">Voucher Issuance by MASA</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.5">
-                    <p id="section-toc.1-1.6.2.2.2.5.1"><a href="#section-6.2.5" class="auto internal xref">6.2.5</a>.  <a href="#name-masa-issued-voucher-process" class="internal xref">MASA issued Voucher Processing by Registrar</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.6">
-                    <p id="section-toc.1-1.6.2.2.2.6.1"><a href="#section-6.2.6" class="auto internal xref">6.2.6</a>.  <a href="#name-pledge-enrollment-request-per" class="internal xref">Pledge-Enrollment-Request (PER) Processing (Registrar-Agent to Registrar)</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.7">
-                    <p id="section-toc.1-1.6.2.2.2.7.1"><a href="#section-6.2.7" class="auto internal xref">6.2.7</a>.  <a href="#name-request-wrapped-ca-certific" class="internal xref">Request Wrapped-CA-certificate(s) (Registrar-Agent to Registrar)</a></p>
+                    <p id="section-toc.1-1.6.2.2.2.2.1"><a href="#section-6.2.2" class="auto internal xref">6.2.2</a>.  <a href="#name-discovery-of-the-pledge" class="internal xref">Discovery of the Pledge</a></p>
 </li>
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3">
-                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="auto internal xref">6.3</a>.  <a href="#name-response-objects-supplied-b" class="internal xref">Response Objects supplied by the Registrar-Agent to the Pledge</a></p>
+                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="auto internal xref">6.3</a>.  <a href="#name-pledge-in-responder-mode" class="internal xref">Pledge in Responder Mode</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3.2.1">
-                    <p id="section-toc.1-1.6.2.3.2.1.1"><a href="#section-6.3.1" class="auto internal xref">6.3.1</a>.  <a href="#name-pledge-voucher-response-pro" class="internal xref">Pledge: Voucher-Response Processing</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3.2.2">
-                    <p id="section-toc.1-1.6.2.3.2.2.1"><a href="#section-6.3.2" class="auto internal xref">6.3.2</a>.  <a href="#name-pledge-voucher-status-telem" class="internal xref">Pledge: Voucher Status Telemetry</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3.2.3">
-                    <p id="section-toc.1-1.6.2.3.2.3.1"><a href="#section-6.3.3" class="auto internal xref">6.3.3</a>.  <a href="#name-pledge-wrapped-ca-certifica" class="internal xref">Pledge: Wrapped-CA-Certificate(s) Processing</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3.2.4">
-                    <p id="section-toc.1-1.6.2.3.2.4.1"><a href="#section-6.3.4" class="auto internal xref">6.3.4</a>.  <a href="#name-pledge-enrollment-response-" class="internal xref">Pledge: Enrollment-Response Processing</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3.2.5">
-                    <p id="section-toc.1-1.6.2.3.2.5.1"><a href="#section-6.3.5" class="auto internal xref">6.3.5</a>.  <a href="#name-pledge-enrollment-status-te" class="internal xref">Pledge: Enrollment-Status Telemetry</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3.2.6">
-                    <p id="section-toc.1-1.6.2.3.2.6.1"><a href="#section-6.3.6" class="auto internal xref">6.3.6</a>.  <a href="#name-telemetry-voucher-status-an" class="internal xref">Telemetry Voucher Status and Enroll Status Handling (Registrar-Agent to Domain Registrar)</a></p>
-</li>
-                </ul>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.4">
-                <p id="section-toc.1-1.6.2.4.1"><a href="#section-6.4" class="auto internal xref">6.4</a>.  <a href="#name-request-pledge-status-by-re" class="internal xref">Request Pledge-Status by Registrar-Agent from Pledge</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.4.2.1">
-                    <p id="section-toc.1-1.6.2.4.2.1.1"><a href="#section-6.4.1" class="auto internal xref">6.4.1</a>.  <a href="#name-pledge-status-request-regis" class="internal xref">Pledge-Status - Request (Registrar-Agent to Pledge)</a></p>
-</li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.4.2.2">
-                    <p id="section-toc.1-1.6.2.4.2.2.1"><a href="#section-6.4.2" class="auto internal xref">6.4.2</a>.  <a href="#name-pledge-status-response-pled" class="internal xref">Pledge-Status - Response (Pledge - Registrar-Agent)</a></p>
+                    <p id="section-toc.1-1.6.2.3.2.1.1"><a href="#section-6.3.1" class="auto internal xref">6.3.1</a>.  <a href="#name-pledge-with-combined-functi" class="internal xref">Pledge with Combined Functionality</a></p>
 </li>
                 </ul>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-artifacts" class="internal xref">Artifacts</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-exchanges-and-artifacts" class="internal xref">Exchanges and Artifacts</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1">
-                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="auto internal xref">7.1</a>.  <a href="#name-voucher-request-artifact" class="internal xref">Voucher-Request Artifact</a></p>
+                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="auto internal xref">7.1</a>.  <a href="#name-trigger-pledge-voucher-requ" class="internal xref">Trigger Pledge Voucher-Request</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1.2.1">
+                    <p id="section-toc.1-1.7.2.1.2.1.1"><a href="#section-7.1.1" class="auto internal xref">7.1.1</a>.  <a href="#name-request-artifact-pledge-vou" class="internal xref">Request Artifact: Pledge Voucher-Request Trigger (tPVR)</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1.2.2">
+                    <p id="section-toc.1-1.7.2.1.2.2.1"><a href="#section-7.1.2" class="auto internal xref">7.1.2</a>.  <a href="#name-response-artifact-pledge-vo" class="internal xref">Response Artifact: Pledge Voucher-Request (PVR)</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2">
+                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="auto internal xref">7.2</a>.  <a href="#name-trigger-pledge-enroll-reque" class="internal xref">Trigger Pledge Enroll-Request</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2.2.1">
+                    <p id="section-toc.1-1.7.2.2.2.1.1"><a href="#section-7.2.1" class="auto internal xref">7.2.1</a>.  <a href="#name-request-artifact-pledge-enr" class="internal xref">Request Artifact: Pledge Enroll-Request Trigger (tPER)</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2.2.2">
+                    <p id="section-toc.1-1.7.2.2.2.2.1"><a href="#section-7.2.2" class="auto internal xref">7.2.2</a>.  <a href="#name-response-artifact-pledge-en" class="internal xref">Response Artifact: Pledge Enroll-Request (PER)</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3">
+                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="auto internal xref">7.3</a>.  <a href="#name-request-voucher-from-the-re" class="internal xref">Request Voucher from the Registrar</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.1">
+                    <p id="section-toc.1-1.7.2.3.2.1.1"><a href="#section-7.3.1" class="auto internal xref">7.3.1</a>.  <a href="#name-request-artifact-pvr" class="internal xref">Request Artifact: PVR</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.2">
+                    <p id="section-toc.1-1.7.2.3.2.2.1"><a href="#section-7.3.2" class="auto internal xref">7.3.2</a>.  <a href="#name-registrar-voucher-request-r" class="internal xref">Registrar Voucher-Request (RVR) Processing (Registrar to MASA)</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.3">
+                    <p id="section-toc.1-1.7.2.3.2.3.1"><a href="#section-7.3.3" class="auto internal xref">7.3.3</a>.  <a href="#name-voucher-issuance-by-masa" class="internal xref">Voucher Issuance by MASA</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.4">
+                    <p id="section-toc.1-1.7.2.3.2.4.1"><a href="#section-7.3.4" class="auto internal xref">7.3.4</a>.  <a href="#name-masa-issued-voucher-process" class="internal xref">MASA issued Voucher Processing by Registrar</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.5">
+                    <p id="section-toc.1-1.7.2.3.2.5.1"><a href="#section-7.3.5" class="auto internal xref">7.3.5</a>.  <a href="#name-response-artifact-voucher" class="internal xref">Response Artifact: Voucher</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.4">
+                <p id="section-toc.1-1.7.2.4.1"><a href="#section-7.4" class="auto internal xref">7.4</a>.  <a href="#name-supply-per-to-registrar" class="internal xref">Supply PER to Registrar</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.4.2.1">
+                    <p id="section-toc.1-1.7.2.4.2.1.1"><a href="#section-7.4.1" class="auto internal xref">7.4.1</a>.  <a href="#name-request-artifact-pledge-enro" class="internal xref">Request Artifact: Pledge Enroll-Request (PER)</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.4.2.2">
+                    <p id="section-toc.1-1.7.2.4.2.2.1"><a href="#section-7.4.2" class="auto internal xref">7.4.2</a>.  <a href="#name-enrollment-by-domain-ca" class="internal xref">Enrollment by Domain CA</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.4.2.3">
+                    <p id="section-toc.1-1.7.2.4.2.3.1"><a href="#section-7.4.3" class="auto internal xref">7.4.3</a>.  <a href="#name-response-artifact-enroll-re" class="internal xref">Response Artifact: Enroll-Response</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.5">
+                <p id="section-toc.1-1.7.2.5.1"><a href="#section-7.5" class="auto internal xref">7.5</a>.  <a href="#name-request-ca-certificates" class="internal xref">Request CA Certificates</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.5.2.1">
+                    <p id="section-toc.1-1.7.2.5.2.1.1"><a href="#section-7.5.1" class="auto internal xref">7.5.1</a>.  <a href="#name-request-artifact-cacert-req" class="internal xref">Request Artifact: cACert-Req</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.5.2.2">
+                    <p id="section-toc.1-1.7.2.5.2.2.1"><a href="#section-7.5.2" class="auto internal xref">7.5.2</a>.  <a href="#name-response-artifact-cacert-re" class="internal xref">Response Artifact: cACert-Resp</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.6">
+                <p id="section-toc.1-1.7.2.6.1"><a href="#section-7.6" class="auto internal xref">7.6</a>.  <a href="#name-supply-voucher-to-pledge" class="internal xref">Supply Voucher to Pledge</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.6.2.1">
+                    <p id="section-toc.1-1.7.2.6.2.1.1"><a href="#section-7.6.1" class="auto internal xref">7.6.1</a>.  <a href="#name-request-artifact-voucher" class="internal xref">Request Artifact: Voucher</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.6.2.2">
+                    <p id="section-toc.1-1.7.2.6.2.2.1"><a href="#section-7.6.2" class="auto internal xref">7.6.2</a>.  <a href="#name-response-artifact-vstatus" class="internal xref">Response Artifact: vStatus</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.7">
+                <p id="section-toc.1-1.7.2.7.1"><a href="#section-7.7" class="auto internal xref">7.7</a>.  <a href="#name-supply-ca-certificates-to-p" class="internal xref">Supply CA certificates to Pledge</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.7.2.1">
+                    <p id="section-toc.1-1.7.2.7.2.1.1"><a href="#section-7.7.1" class="auto internal xref">7.7.1</a>.  <a href="#name-request-artifact" class="internal xref">Request Artifact:</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.7.2.2">
+                    <p id="section-toc.1-1.7.2.7.2.2.1"><a href="#section-7.7.2" class="auto internal xref">7.7.2</a>.  <a href="#name-response" class="internal xref">Response</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.8">
+                <p id="section-toc.1-1.7.2.8.1"><a href="#section-7.8" class="auto internal xref">7.8</a>.  <a href="#name-supply-enroll-response-to-p" class="internal xref">Supply Enroll-Response to Pledge</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.8.2.1">
+                    <p id="section-toc.1-1.7.2.8.2.1.1"><a href="#section-7.8.1" class="auto internal xref">7.8.1</a>.  <a href="#name-request-artifact-enroll-res" class="internal xref">Request Artifact: Enroll-Response</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.8.2.2">
+                    <p id="section-toc.1-1.7.2.8.2.2.1"><a href="#section-7.8.2" class="auto internal xref">7.8.2</a>.  <a href="#name-response-artifact-estatus" class="internal xref">Response Artifact: eStatus</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.9">
+                <p id="section-toc.1-1.7.2.9.1"><a href="#section-7.9" class="auto internal xref">7.9</a>.  <a href="#name-voucher-status-telemetry" class="internal xref">Voucher Status Telemetry</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.9.2.1">
+                    <p id="section-toc.1-1.7.2.9.2.1.1"><a href="#section-7.9.1" class="auto internal xref">7.9.1</a>.  <a href="#name-request-artifact-vstatus" class="internal xref">Request Artifact: vStatus</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.9.2.2">
+                    <p id="section-toc.1-1.7.2.9.2.2.1"><a href="#section-7.9.2" class="auto internal xref">7.9.2</a>.  <a href="#name-response-2" class="internal xref">Response</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.10">
+                <p id="section-toc.1-1.7.2.10.1"><a href="#section-7.10" class="auto internal xref">7.10</a>. <a href="#name-enroll-status-telemetry" class="internal xref">Enroll Status Telemetry</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.10.2.1">
+                    <p id="section-toc.1-1.7.2.10.2.1.1"><a href="#section-7.10.1" class="auto internal xref">7.10.1</a>.  <a href="#name-request-artifact-vstatus-2" class="internal xref">Request Artifact: vStatus</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.10.2.2">
+                    <p id="section-toc.1-1.7.2.10.2.2.1"><a href="#section-7.10.2" class="auto internal xref">7.10.2</a>.  <a href="#name-response-3" class="internal xref">Response</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.11">
+                <p id="section-toc.1-1.7.2.11.1"><a href="#section-7.11" class="auto internal xref">7.11</a>. <a href="#name-query-pledge-status" class="internal xref">Query Pledge Status</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.11.2.1">
+                    <p id="section-toc.1-1.7.2.11.2.1.1"><a href="#section-7.11.1" class="auto internal xref">7.11.1</a>.  <a href="#name-request-artifact-status-req" class="internal xref">Request Artifact: status-request</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.11.2.2">
+                    <p id="section-toc.1-1.7.2.11.2.2.1"><a href="#section-7.11.2" class="auto internal xref">7.11.2</a>.  <a href="#name-response-artifact-status-re" class="internal xref">Response Artifact: status-response</a></p>
+</li>
+                </ul>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-todo-artifacts" class="internal xref">TODO Artifacts</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.1">
-                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="auto internal xref">8.1</a>.  <a href="#name-brski-well-known-registry" class="internal xref">BRSKI .well-known Registry</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.2">
-                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="auto internal xref">8.2</a>.  <a href="#name-dns-service-names" class="internal xref">DNS Service Names</a></p>
+                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="auto internal xref">8.1</a>.  <a href="#name-voucher-request-artifact" class="internal xref">Voucher-Request Artifact</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-privacy-considerations" class="internal xref">Privacy Considerations</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.1">
+                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="auto internal xref">9.1</a>.  <a href="#name-brski-well-known-registry" class="internal xref">BRSKI .well-known Registry</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.2">
+                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="auto internal xref">9.2</a>.  <a href="#name-dns-service-names" class="internal xref">DNS Service Names</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.1">
-                <p id="section-toc.1-1.10.2.1.1"><a href="#section-10.1" class="auto internal xref">10.1</a>.  <a href="#name-denial-of-service-dos-attac" class="internal xref">Denial of Service (DoS) Attack on Pledge</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.2">
-                <p id="section-toc.1-1.10.2.2.1"><a href="#section-10.2" class="auto internal xref">10.2</a>.  <a href="#name-misuse-of-acquired-pvr-and-" class="internal xref">Misuse of acquired PVR and PER by Registrar-Agent</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.3">
-                <p id="section-toc.1-1.10.2.3.1"><a href="#section-10.3" class="auto internal xref">10.3</a>.  <a href="#name-misuse-of-registrar-agent-c" class="internal xref">Misuse of Registrar-Agent Credentials</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.4">
-                <p id="section-toc.1-1.10.2.4.1"><a href="#section-10.4" class="auto internal xref">10.4</a>.  <a href="#name-misuse-of-dns-sd-with-mdns-" class="internal xref">Misuse of DNS-SD with mDNS to obtain list of pledges</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.5">
-                <p id="section-toc.1-1.10.2.5.1"><a href="#section-10.5" class="auto internal xref">10.5</a>.  <a href="#name-yang-module-security-consid" class="internal xref">YANG Module Security Considerations</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-privacy-considerations" class="internal xref">Privacy Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-11" class="auto internal xref">11</a>. <a href="#name-acknowledgments" class="internal xref">Acknowledgments</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-12" class="auto internal xref">12</a>. <a href="#name-references" class="internal xref">References</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="auto internal xref">11</a>. <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
 <ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.1">
-                <p id="section-toc.1-1.12.2.1.1"><a href="#section-12.1" class="auto internal xref">12.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.1">
+                <p id="section-toc.1-1.11.2.1.1"><a href="#section-11.1" class="auto internal xref">11.1</a>.  <a href="#name-denial-of-service-dos-attac" class="internal xref">Denial of Service (DoS) Attack on Pledge</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.2">
-                <p id="section-toc.1-1.12.2.2.1"><a href="#section-12.2" class="auto internal xref">12.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.2">
+                <p id="section-toc.1-1.11.2.2.1"><a href="#section-11.2" class="auto internal xref">11.2</a>.  <a href="#name-misuse-of-acquired-pvr-and-" class="internal xref">Misuse of acquired PVR and PER by Registrar-Agent</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.3">
+                <p id="section-toc.1-1.11.2.3.1"><a href="#section-11.3" class="auto internal xref">11.3</a>.  <a href="#name-misuse-of-registrar-agent-c" class="internal xref">Misuse of Registrar-Agent Credentials</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.4">
+                <p id="section-toc.1-1.11.2.4.1"><a href="#section-11.4" class="auto internal xref">11.4</a>.  <a href="#name-misuse-of-dns-sd-with-mdns-" class="internal xref">Misuse of DNS-SD with mDNS to obtain list of pledges</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.5">
+                <p id="section-toc.1-1.11.2.5.1"><a href="#section-11.5" class="auto internal xref">11.5</a>.  <a href="#name-yang-module-security-consid" class="internal xref">YANG Module Security Considerations</a></p>
 </li>
             </ul>
 </li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#section-12" class="auto internal xref">12</a>. <a href="#name-acknowledgments" class="internal xref">Acknowledgments</a></p>
+</li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-examples" class="internal xref">Examples</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#section-13" class="auto internal xref">13</a>. <a href="#name-references" class="internal xref">References</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.1">
-                <p id="section-toc.1-1.13.2.1.1"><a href="#appendix-A.1" class="auto internal xref">A.1</a>.  <a href="#name-example-pledge-voucher-requ" class="internal xref">Example Pledge-Voucher-Request - PVR (from Pledge to Registrar-Agent)</a></p>
+                <p id="section-toc.1-1.13.2.1.1"><a href="#section-13.1" class="auto internal xref">13.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.2">
-                <p id="section-toc.1-1.13.2.2.1"><a href="#appendix-A.2" class="auto internal xref">A.2</a>.  <a href="#name-example-parboiled-registrar" class="internal xref">Example Parboiled Registrar-Voucher-Request - RVR (from Registrar to MASA)</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.3">
-                <p id="section-toc.1-1.13.2.3.1"><a href="#appendix-A.3" class="auto internal xref">A.3</a>.  <a href="#name-example-voucher-response-fr" class="internal xref">Example Voucher-Response (from MASA to Pledge, via Registrar and Registrar-Agent)</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.4">
-                <p id="section-toc.1-1.13.2.4.1"><a href="#appendix-A.4" class="auto internal xref">A.4</a>.  <a href="#name-example-voucher-response-ma" class="internal xref">Example Voucher-Response, MASA issued Voucher with additional Registrar signature (from MASA to Pledge, via Registrar and Registrar-Agent)</a></p>
+                <p id="section-toc.1-1.13.2.2.1"><a href="#section-13.2" class="auto internal xref">13.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#appendix-B" class="auto internal xref">Appendix B</a>.  <a href="#name-http-over-tls-operations-be" class="internal xref">HTTP-over-TLS operations between Registrar-Agent and Pledge</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-examples" class="internal xref">Examples</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.1">
+                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-A.1" class="auto internal xref">A.1</a>.  <a href="#name-example-pledge-voucher-requ" class="internal xref">Example Pledge Voucher-Request (PVR) - from Pledge to Registrar-Agent</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.2">
+                <p id="section-toc.1-1.14.2.2.1"><a href="#appendix-A.2" class="auto internal xref">A.2</a>.  <a href="#name-example-parboiled-registrar" class="internal xref">Example Parboiled Registrar Voucher-Request (RVR) - from Registrar to MASA</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.3">
+                <p id="section-toc.1-1.14.2.3.1"><a href="#appendix-A.3" class="auto internal xref">A.3</a>.  <a href="#name-example-voucher-from-masa-t" class="internal xref">Example Voucher - from MASA to Pledge, via Registrar and Registrar-Agent</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.4">
+                <p id="section-toc.1-1.14.2.4.1"><a href="#appendix-A.4" class="auto internal xref">A.4</a>.  <a href="#name-example-voucher-masa-issued" class="internal xref">Example Voucher, MASA issued Voucher with additional Registrar signature (from MASA to Pledge, via Registrar and Registrar-Agent)</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15">
-            <p id="section-toc.1-1.15.1"><a href="#appendix-C" class="auto internal xref">Appendix C</a>.  <a href="#name-history-of-changes-rfc-edit" class="internal xref">History of Changes [RFC Editor: please delete]</a></p>
+            <p id="section-toc.1-1.15.1"><a href="#appendix-B" class="auto internal xref">Appendix B</a>.  <a href="#name-http-over-tls-operations-be" class="internal xref">HTTP-over-TLS operations between Registrar-Agent and Pledge</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16">
-            <p id="section-toc.1-1.16.1"><a href="#appendix-D" class="auto internal xref"></a><a href="#name-contributors" class="internal xref">Contributors</a></p>
+            <p id="section-toc.1-1.16.1"><a href="#appendix-C" class="auto internal xref">Appendix C</a>.  <a href="#name-history-of-changes-rfc-edit" class="internal xref">History of Changes [RFC Editor: please delete]</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.17">
-            <p id="section-toc.1-1.17.1"><a href="#appendix-E" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.17.1"><a href="#appendix-D" class="auto internal xref"></a><a href="#name-contributors" class="internal xref">Contributors</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.18">
+            <p id="section-toc.1-1.18.1"><a href="#appendix-E" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1562,23 +1634,22 @@ The approach defined here is agnostic to the enrollment protocol that connects t
       <h2 id="name-introduction">
 <a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
       </h2>
-<p id="section-1-1">BRSKI as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> specifies a solution for secure zero-touch (automated) bootstrapping of devices (pledges) in a (customer site) domain.
+<p id="section-1-1">BRSKI as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> specifies a solution for secure zero-touch (automated) bootstrapping of devices (pledges) in a customer domain, which may be associated to a specific installation location.
 This includes the discovery of the BRSKI registrar in the customer domain and the exchange of security information necessary to establish trust between a pledge and the domain.<a href="#section-1-1" class="pilcrow">¶</a></p>
 <p id="section-1-2">Security information about the customer domain, specifically the customer domain certificate, are exchanged and authenticated utilizing voucher-request and voucher-response artifacts as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-Vouchers are signed objects from the Manufacturer's Authorized Signing Authority (MASA).
+Vouchers are signed objects from the Manufacturer Authorized Signing Authority (MASA).
 The MASA issues the voucher and provides it via the domain registrar to the pledge.
-<span>[<a href="#RFC8366" class="cite xref">RFC8366</a>]</span> specifies the format of the voucher artifacts.
-<span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> further enhances the format of the voucher artifacts and also the voucher-request.<a href="#section-1-2" class="pilcrow">¶</a></p>
+<span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> specifies the format of the voucher artifacts including the voucher-request.<a href="#section-1-2" class="pilcrow">¶</a></p>
 <p id="section-1-3">For the certificate enrollment of devices, BRSKI relies on EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> to request and distribute customer domain specific device certificates.
 EST in turn relies for the authentication and authorization of the certification request on the credentials used by the underlying TLS between the EST client and the EST server.<a href="#section-1-3" class="pilcrow">¶</a></p>
 <p id="section-1-4">BRSKI addresses scenarios in which the pledge initiates the bootstrapping acting as client (referred to as initiator mode by this document).
-BRSKI with pledge in responder mode (BRSKI-PRM) defined in this document allows the pledge to act as server, so that it can be triggered to generate bootstrapping requests in the customer domain.
+BRSKI with Pledge in Responder Mode (BRSKI-PRM) defined in this document allows the pledge to act as server, so that it can be triggered externally and at a specific time to generate bootstrapping requests in the customer domain.
 For this approach, this document:<a href="#section-1-4" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-1-5.1">
           <p id="section-1-5.1.1">introduces the Registrar-Agent as new component to facilitate the communication between the pledge and the domain registrar.
-The Registrar-Agent may be implemented as an integrated functionality of a commissioning tool or be co-located with the registrar itself.
-BRSKI-PRM supports the identification of the Registrar-Agent that was performing the bootstrapping allowing for accountability of the pledges installation, when the Registrar-Agent is a component used by an installer and not co-located with the registrar.<a href="#section-1-5.1.1" class="pilcrow">¶</a></p>
+The Registrar-Agent may be implemented as an integrated functionality of a commissioning tool or be co-located with the domain registrar itself.
+BRSKI-PRM supports the identification of the Registrar-Agent that was performing the bootstrapping allowing for accountability of the pledges installation, when the Registrar-Agent is a component used by an installer and not co-located with the domain registrar.<a href="#section-1-5.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-1-5.2">
           <p id="section-1-5.2.1">specifies the interaction (data exchange and data objects) between a pledge acting as server, the Registrar-Agent acting as client, and the domain registrar.<a href="#section-1-5.2.1" class="pilcrow">¶</a></p>
@@ -1594,13 +1665,13 @@ BRSKI-PRM supports the identification of the Registrar-Agent that was performing
 Endpoints are accessible via Well-Known URIs <span>[<a href="#RFC8615" class="cite xref">RFC8615</a>]</span>.
 For the interaction with the domain registrar, the Registrar-Agent will use existing BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> endpoints as well as additional endpoints defined in this document.
 To utilize the EST server endpoints on the domain registrar, the Registrar-Agent will act as client toward the registrar.<a href="#section-1-6" class="pilcrow">¶</a></p>
-<p id="section-1-7">The Registrar-Agent also acts as a client when communicating with a pledge in responder mode.
+<p id="section-1-7">The Registrar-Agent also acts as a client when communicating with a pledge that is in responder mode.
 Here, TLS with server-side, certificate-based authentication is only optionally supported.
-If TLS is optionally used between the Registrar-Agent and the pledge, the Registrar-Agent needs to identify the pledge based on its product-serial-number rather than the hostname as this is not set in an IDevID certificate.<a href="#section-1-7" class="pilcrow">¶</a></p>
+If TLS is optionally used between the Registrar-Agent and the pledge, the Registrar-Agent needs to identify the pledge based on its product-serial-number rather than the hostname, as the latter is not set in an IDevID certificate.<a href="#section-1-7" class="pilcrow">¶</a></p>
 <p id="section-1-8">BRSKI-PRM is designed to rely on object security to support also for alternative transports for which TLS may not be available, e.g., Bluetooth or NFC.
 This is achieved through an additional signature wrapping of the exchanged data objects involving the Registrar-Agent for transport.<a href="#section-1-8" class="pilcrow">¶</a></p>
-<p id="section-1-9">To utilize EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> for enrollment, the domain registrar must perform the pre-processing of this wrapping signature before actually using EST as defined in <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span>.<a href="#section-1-9" class="pilcrow">¶</a></p>
-<p id="section-1-10">There may be pledges which can support both modes, initiator and responder mode.
+<p id="section-1-9">To utilize EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> for enrollment, the domain registrar performs pre-processing of the wrapping signature before actually using EST as defined in <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span>.<a href="#section-1-9" class="pilcrow">¶</a></p>
+<p id="section-1-10">There may be pledges that can support both modes, initiator and responder mode.
 In these cases BRSKI-PRM can be combined with BRSKI as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> or BRSKI-AE <span>[<a href="#I-D.ietf-anima-brski-ae" class="cite xref">I-D.ietf-anima-brski-ae</a>]</span> to allow for more bootstrapping flexibility.<a href="#section-1-10" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -1613,12 +1684,12 @@ In these cases BRSKI-PRM can be combined with BRSKI as defined in <span>[<a href
 "<span class="bcp14">MAY</span>", and "<span class="bcp14">OPTIONAL</span>" in this document are to be interpreted as
 described in BCP 14 <span>[<a href="#RFC2119" class="cite xref">RFC2119</a>]</span> <span>[<a href="#RFC8174" class="cite xref">RFC8174</a>]</span> when, and only when, they
 appear in all capitals, as shown here.<a href="#section-2-1" class="pilcrow">¶</a></p>
-<p id="section-2-2">This document relies on the terminology defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, section 1.2.
-The following terms are defined additionally:<a href="#section-2-2" class="pilcrow">¶</a></p>
+<p id="section-2-2">This document relies on the terminology defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-1.2" class="relref">Section 1.2</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+The following terms are defined in addition:<a href="#section-2-2" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlParallel" id="section-2-3">
         <dt id="section-2-3.1">authenticated self-contained object:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.2">
-          <p id="section-2-3.2.1">Describes an object, which is cryptographically bound to the end entity (EE) certificate (IDevID certificate or LDEVID certificate).
+          <p id="section-2-3.2.1">Describes an object, which is cryptographically bound to the end entity (EE) certificate.
 The binding is assumed to be provided through a digital signature of the actual object using the corresponding private key of the certificate.<a href="#section-2-3.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
@@ -1639,35 +1710,33 @@ The binding is assumed to be provided through a digital signature of the actual 
         <dd class="break"></dd>
 <dt id="section-2-3.9">EE:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.10">
-          <p id="section-2-3.10.1">End Entity.<a href="#section-2-3.10.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.10.1">End entity.<a href="#section-2-3.10.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
-<dt id="section-2-3.11">endpoint:</dt>
+<dt id="section-2-3.11">EE certificate:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.12">
-          <p id="section-2-3.12.1">term equivalent to resource in HTTP <span>[<a href="#RFC9110" class="cite xref">RFC9110</a>]</span> and CoAP <span>[<a href="#RFC7252" class="cite xref">RFC7252</a>]</span>.
-Endpoints are accessible via .well-known URIs.<a href="#section-2-3.12.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.12.1">Either IDevID certificate or LDevID certificate of the EE.<a href="#section-2-3.12.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
-<dt id="section-2-3.13">mTLS:</dt>
+<dt id="section-2-3.13">endpoint:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.14">
-          <p id="section-2-3.14.1">mutual Transport Layer Security.<a href="#section-2-3.14.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.14.1">Term equivalent to resource in HTTP <span>[<a href="#RFC9110" class="cite xref">RFC9110</a>]</span> and CoAP <span>[<a href="#RFC7252" class="cite xref">RFC7252</a>]</span>.
+Endpoints are accessible via Well-Known URIs <span>[<a href="#RFC8615" class="cite xref">RFC8615</a>]</span>.<a href="#section-2-3.14.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
-<dt id="section-2-3.15">on-site:</dt>
+<dt id="section-2-3.15">mTLS:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.16">
-          <p id="section-2-3.16.1">Describes a component or service or functionality available in the customer domain.<a href="#section-2-3.16.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.16.1">mutual Transport Layer Security.<a href="#section-2-3.16.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
-<dt id="section-2-3.17">off-site:</dt>
+<dt id="section-2-3.17">PER:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.18">
-          <p id="section-2-3.18.1">Describes a component or service or functionality not available on-site.
-It may be at a central site or an internet resident "cloud" service.
-The on-site to off-site connection may also be temporary and, e.g., only available at times when workers are present on a construction side, for instance.<a href="#section-2-3.18.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.18.1">Pledge Enroll-Request is a signature wrapped CSR, signed by the pledge that requests enrollment to a domain.<a href="#section-2-3.18.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
-<dt id="section-2-3.19">PER:</dt>
+<dt id="section-2-3.19">POI:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.20">
-          <p id="section-2-3.20.1">Pledge-Enrollment-Request is a signature wrapped CSR, signed by the pledge that requests enrollment to a domain.<a href="#section-2-3.20.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.20.1">Proof-of-Identity, as defined in <span>[<a href="#RFC5272" class="cite xref">RFC5272</a>]</span>.<a href="#section-2-3.20.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 <dt id="section-2-3.21">POP:</dt>
@@ -1675,40 +1744,46 @@ The on-site to off-site connection may also be temporary and, e.g., only availab
           <p id="section-2-3.22.1">Proof-of-Possession (of a private key), as defined in <span>[<a href="#RFC5272" class="cite xref">RFC5272</a>]</span>.<a href="#section-2-3.22.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
-<dt id="section-2-3.23">POI:</dt>
+<dt id="section-2-3.23">PVR:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.24">
-          <p id="section-2-3.24.1">Proof-of-Identity, as defined in <span>[<a href="#RFC5272" class="cite xref">RFC5272</a>]</span>.<a href="#section-2-3.24.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.24.1">Pledge Voucher-Request is a request for a voucher sent to the domain registrar.
+The PVR is signed by the Pledge.<a href="#section-2-3.24.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
-<dt id="section-2-3.25">PVR:</dt>
+<dt id="section-2-3.25">RA:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.26">
-          <p id="section-2-3.26.1">Pledge-Voucher-Request is a request for a voucher sent to the domain registrar.
-The PVR is signed by the Pledge.<a href="#section-2-3.26.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.26.1">Registration Authority, an optional system component to which a CA delegates certificate management functions such as authorization checks.
+In BRSKI-PRM this is a functionality of the domain registrar, as in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-2-3.26.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
-<dt id="section-2-3.27">RA:</dt>
+<dt id="section-2-3.27">RER:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.28">
-          <p id="section-2-3.28.1">Registration Authority, an optional system component to which a CA delegates certificate management functions such as authorization checks.
-In BRSKI-PRM this is a functionality of the domain registrar, as in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-2-3.28.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.28.1">Registrar Enroll-Request is the CSR of a PER sent to the CA by the domain registrar (in its role as PKI RA).<a href="#section-2-3.28.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
-<dt id="section-2-3.29">RER:</dt>
+<dt id="section-2-3.29">RVR:</dt>
         <dd style="margin-left: 1.5em" id="section-2-3.30">
-          <p id="section-2-3.30.1">Registrar-Enrollment-Request is the CSR of a PER sent to the CA by the domain registrar (in its role as PKI RA).<a href="#section-2-3.30.1" class="pilcrow">¶</a></p>
-</dd>
-        <dd class="break"></dd>
-<dt id="section-2-3.31">RVR:</dt>
-        <dd style="margin-left: 1.5em" id="section-2-3.32">
-          <p id="section-2-3.32.1">Registrar-Voucher-Request is a request for a voucher signed by the domain registrar to the MASA.
-It may contain the PVR received from the pledge.<a href="#section-2-3.32.1" class="pilcrow">¶</a></p>
+          <p id="section-2-3.30.1">Registrar Voucher-Request is a request for a voucher signed by the domain registrar to the MASA.
+It may contain the PVR received from the pledge.<a href="#section-2-3.30.1" class="pilcrow">¶</a></p>
 </dd>
       <dd class="break"></dd>
 </dl>
-<p id="section-2-4">This document includes many examples that would contain many long sequences of base64 encoded objects with no content directly comprehensible to a human reader.
+<p id="section-2-4">This document uses the following encoding notations in the given JWS Voucher <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span> examples:<a href="#section-2-4" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="section-2-5">
+        <dt id="section-2-5.1">BASE64URL(OCTETS):</dt>
+        <dd style="margin-left: 1.5em" id="section-2-5.2">
+          <p id="section-2-5.2.1">Denotes the base64url encoding of OCTETS, per <span><a href="https://rfc-editor.org/rfc/rfc7515#section-2" class="relref">Section 2</a> of [<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>.<a href="#section-2-5.2.1" class="pilcrow">¶</a></p>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-2-5.3">UTF8(STRING):</dt>
+        <dd style="margin-left: 1.5em" id="section-2-5.4">
+          <p id="section-2-5.4.1">Denotes the octets of the UTF-8 <span>[<a href="#RFC3629" class="cite xref">RFC3629</a>]</span> representation of STRING, per <span><a href="https://rfc-editor.org/rfc/rfc7515#section-1" class="relref">Section 1</a> of [<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>.<a href="#section-2-5.4.1" class="pilcrow">¶</a></p>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<p id="section-2-6">This document includes many examples that would contain many long sequences of base64-encoded objects with no content directly comprehensible to a human reader.
 In order to keep those examples short, they use the token "base64encodedvalue==" as a placeholder for base64 data.
-The full base64 data is included in the appendices of this document.<a href="#section-2-4" class="pilcrow">¶</a></p>
-<p id="section-2-5">This protocol unavoidably has a mix of both base64 encoded data (as is normal for many JSON encoded protocols), and also BASE64URL encoded data, as specified by JWS.
-The latter is indicated by a string like "BASE64URL(content-name)".<a href="#section-2-5" class="pilcrow">¶</a></p>
+The full base64 data is included in the appendices of this document.<a href="#section-2-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="scope-of-solution">
@@ -1791,7 +1866,7 @@ This requires the definition of pledge endpoints to allow interaction with the R
 </li>
         <li class="normal" id="section-4-2.2">
           <p id="section-4-2.2.1">The security of communication between the Registrar-Agent and the pledge must not rely on Transport Layer Security (TLS) to enable application of BRSKI-PRM in environments, in which the communication between the Registrar-Agent and the pledge is done over other technologies like BTLE or NFC, which may not support TLS protected communication.
-In addition, the pledge does not have a certificate that can easily be verified by <span>[<a href="#RFC6125" class="cite xref">RFC6125</a>]</span> methods.<a href="#section-4-2.2.1" class="pilcrow">¶</a></p>
+In addition, the pledge does not have a certificate that can easily be verified by <span>[<a href="#RFC9525" class="cite xref">RFC9525</a>]</span> methods.<a href="#section-4-2.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-2.3">
           <p id="section-4-2.3.1">The use of authenticated self-contained objects addresses both, the TLS challenges and the technology stack challenge.<a href="#section-4-2.3.1" class="pilcrow">¶</a></p>
@@ -1802,13 +1877,13 @@ In addition the registrar must be able to verify, which Registrar-Agent was in d
 </li>
         <li class="normal" id="section-4-2.5">
           <p id="section-4-2.5.1">It would be inaccurate for the voucher-request and voucher-response to use an assertion with value "proximity" in the voucher, as the pledge was not in direct contact with the registrar for bootstrapping.
-Therefore, a new "agent-proximity" assertion value is necessary for distinguishing assertions the MASA can state.<a href="#section-4-2.5.1" class="pilcrow">¶</a></p>
+Therefore, a new Agent-Proximity Assertion value {#agt_prx} is necessary for distinguishing assertions the MASA can state.<a href="#section-4-2.5.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <p id="section-4-3">At least the following properties are required for the voucher and enrollment processing:<a href="#section-4-3" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-4-4.1">
-          <p id="section-4-4.1.1">POI: provides data-origin authentication of a data object, e.g., a voucher-request or an enrollment-request, utilizing an existing IDevID.
+          <p id="section-4-4.1.1">POI: provides data-origin authentication of a data object, e.g., a voucher-request or an Enroll-Request, utilizing an existing IDevID.
 Certificate updates may utilize the certificate that is to be updated.<a href="#section-4-4.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-4.2">
@@ -1842,17 +1917,17 @@ While BRSKI uses the binding to TLS, BRSKI-PRM aims at an additional signature o
         <h3 id="name-overview">
 <a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-overview" class="section-name selfRef">Overview</a>
         </h3>
-<p id="section-5.1-1">For BRSKI with pledge in responder mode, the base system architecture defined in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> is enhanced to facilitate new use cases in which the pledge acts as server.
+<p id="section-5.1-1">For BRSKI with Pledge in Responder Mode (BRSKI-PRM), the base system architecture defined in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> is enhanced to facilitate new use cases in which the pledge acts as server.
 The responder mode allows delegated bootstrapping using a Registrar-Agent instead of a direct connection between the pledge and the domain registrar.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
 <p id="section-5.1-2">Necessary enhancements to support authenticated self-contained objects for certificate enrollment are kept at a minimum to enable reuse of already defined architecture elements and interactions.
-The format of the bootstrapping objects produced or consumed by the pledge is based on JOSE <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span> and further specified in <a href="#exchanges_uc2" class="auto internal xref">Section 6</a> to address the requirements stated in <a href="#req-sol" class="auto internal xref">Section 4</a> above.
-In constrained environments it may be provided based on COSE <span>[<a href="#RFC9052" class="cite xref">RFC9052</a>]</span> and <span>[<a href="#RFC9053" class="cite xref">RFC9053</a>]</span>.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
+The format of the bootstrapping objects produced or consumed by the pledge is usually based on JSON Web Signature (JWS) <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span> and further specified in <a href="#exchanges_uc2" class="auto internal xref">Section 7</a> to address the requirements stated in <a href="#req-sol" class="auto internal xref">Section 4</a> above.
+In constrained environments, it may be based on COSE <span>[<a href="#RFC9052" class="cite xref">RFC9052</a>]</span>.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
 <p id="section-5.1-3">An abstract overview of the BRSKI-PRM protocol can be found on slide 8 of <span>[<a href="#BRSKI-PRM-abstract" class="cite xref">BRSKI-PRM-abstract</a>]</span>.<a href="#section-5.1-3" class="pilcrow">¶</a></p>
 <p id="section-5.1-4">To support mutual trust establishment between the domain registrar and pledges not directly connected to the customer domain, this document specifies the exchange of authenticated self-contained objects with the help of a Registrar-Agent.<a href="#section-5.1-4" class="pilcrow">¶</a></p>
 <p id="section-5.1-5">This leads to extensions of the logical components in the BRSKI architecture as shown in <a href="#uc2figure" class="auto internal xref">Figure 1</a>.<a href="#section-5.1-5" class="pilcrow">¶</a></p>
-<p id="section-5.1-6">Note that the Join Proxy is not shown in the figure, having been replaced by Registrar-Agent.
+<p id="section-5.1-6">Note that the Join Proxy is not shown in the figure.
 In certain situations the Join Proxy may still be present and could be used by the Registrar-Agent to connect to the Registrar.
-For example, a Registrar-Agent application on a smartphone often can connect to local wifi without giving up their LTE connection <span>[<a href="#androidnsd" class="cite xref">androidnsd</a>]</span>, but only can make link-local connections.<a href="#section-5.1-6" class="pilcrow">¶</a></p>
+For example, a Registrar-Agent application on a smartphone often can connect to local Wi-Fi without giving up their cellular network connection <span>[<a href="#androidnsd" class="cite xref">androidnsd</a>]</span>, but only can make link-local connections.<a href="#section-5.1-6" class="pilcrow">¶</a></p>
 <p id="section-5.1-7">The Registrar-Agent interacts with the pledge to transfer the required data objects for bootstrapping, which are then also exchanged between the Registrar-Agent and the domain registrar.
 The addition of the Registrar-Agent influences the sequences of the data exchange between the pledge and the domain registrar described in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:<a href="#section-5.1-7" class="pilcrow">¶</a></p>
@@ -1910,7 +1985,7 @@ To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:<a
                   <text x="140" y="52">Ship</text>
                   <text x="184" y="52">.....</text>
                   <text x="244" y="52">Vendor</text>
-                  <text x="304" y="52">Service</text>
+                  <text x="308" y="52">Services</text>
                   <text x="40" y="68">:</text>
                   <text x="40" y="84">:</text>
                   <text x="224" y="84">M</text>
@@ -1957,7 +2032,8 @@ To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:<a
                   <text x="392" y="308">RA)</text>
                   <text x="448" y="308">.</text>
                   <text x="128" y="324">.</text>
-                  <text x="220" y="324">LDevID</text>
+                  <text x="196" y="324">EE</text>
+                  <text x="228" y="324">cert</text>
                   <text x="448" y="324">.</text>
                   <text x="128" y="340">.</text>
                   <text x="448" y="340">.</text>
@@ -1978,8 +2054,8 @@ To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:<a
                   <text x="128" y="420">.</text>
                   <text x="448" y="420">.</text>
                   <text x="288" y="436">.........................................</text>
-                  <text x="236" y="452">"Domain"</text>
-                  <text x="316" y="452">Components</text>
+                  <text x="260" y="452">Customer</text>
+                  <text x="324" y="452">Domain</text>
                 </g>
               </svg><a href="#section-5.1-9.1.1" class="pilcrow">¶</a>
 </div>
@@ -1991,24 +2067,24 @@ To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:<a
 <p id="section-5.1-10"><a href="#uc2figure" class="auto internal xref">Figure 1</a> shows the relations between the following main components:<a href="#section-5.1-10" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-5.1-11.1">
-            <p id="section-5.1-11.1.1">Pledge: The pledge is expected to respond with the necessary data objects for bootstrapping to the Registrar-Agent.
+            <p id="section-5.1-11.1.1">Pledge: Is expected to respond with the necessary data objects for bootstrapping to the Registrar-Agent.
 The protocol used between the pledge and the Registrar-Agent is assumed to be HTTP in the context of this document.
 Any other protocols (including HTTPS) can be used as long as they support the exchange of the necessary data objects.
 This includes CoAP or protocol to be used over Bluetooth or NFC connections
-A pledge acting as a server during bootstrapping leads to some differences for BRSKI:<a href="#section-5.1-11.1.1" class="pilcrow">¶</a></p>
+A pledge acting as a server during bootstrapping leads to the following differences compared to BRSKI:<a href="#section-5.1-11.1.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-5.1-11.1.2.1">
-                <p id="section-5.1-11.1.2.1.1">Discovery of the pledge by the Registrar-Agent <span class="bcp14">MUST</span> be possible.<a href="#section-5.1-11.1.2.1.1" class="pilcrow">¶</a></p>
+                <p id="section-5.1-11.1.2.1.1">The pledge is discovered by the Registrar-Agent as defined in {#discovery_uc2_ppa}.<a href="#section-5.1-11.1.2.1.1" class="pilcrow">¶</a></p>
 </li>
               <li class="normal" id="section-5.1-11.1.2.2">
-                <p id="section-5.1-11.1.2.2.1">As the Registrar-Agent <span class="bcp14">MUST</span> be able to request data objects for bootstrapping of the pledge, the pledge <span class="bcp14">MUST</span> offer corresponding endpoints as defined in <a href="#pledge_ep" class="auto internal xref">Section 5.5</a>.<a href="#section-5.1-11.1.2.2.1" class="pilcrow">¶</a></p>
+                <p id="section-5.1-11.1.2.2.1">The pledge offers additional endpoints as defined in <a href="#pledge_ep" class="auto internal xref">Section 6.3</a>, so that the Registrar-Agent can request data required for bootstrapping the pledge.<a href="#section-5.1-11.1.2.2.1" class="pilcrow">¶</a></p>
 </li>
               <li class="normal" id="section-5.1-11.1.2.3">
-                <p id="section-5.1-11.1.2.3.1">The Registrar-Agent <span class="bcp14">MUST</span> provide additional data to the pledge in the context of the voucher-request trigger, which the pledge <span class="bcp14">MUST</span> include into the PVR as defined in <a href="#pvrt" class="auto internal xref">Section 6.1.1</a> and <a href="#pvrr" class="auto internal xref">Section 6.1.2</a>.
+                <p id="section-5.1-11.1.2.3.1">The pledge includes additional data in the PVR, which is provided by the Registrar-Agent in the voucher-request trigger as defined in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.
 This allows the registrar to identify, with which Registrar-Agent the pledge was in contact.<a href="#section-5.1-11.1.2.3.1" class="pilcrow">¶</a></p>
 </li>
               <li class="normal" id="section-5.1-11.1.2.4">
-                <p id="section-5.1-11.1.2.4.1">The order of exchanges in the BRSKI-PRM call flow is different those in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, as the PVR and PER are collected at once and provided to the registrar.
+                <p id="section-5.1-11.1.2.4.1">The order of exchanges in the BRSKI-PRM call flow is different from those in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, as the PVR and PER are collected simultaneously and provided to the registrar.
 This enables bulk bootstrapping of several devices.<a href="#section-5.1-11.1.2.4.1" class="pilcrow">¶</a></p>
 </li>
               <li class="normal" id="section-5.1-11.1.2.5">
@@ -2017,31 +2093,42 @@ This enables bulk bootstrapping of several devices.<a href="#section-5.1-11.1.2.
             </ul>
 </li>
           <li class="normal" id="section-5.1-11.2">
-            <p id="section-5.1-11.2.1">Registrar-Agent: provides a store and forward communication path to exchange data objects between the pledge and the domain registrar.
+            <p id="section-5.1-11.2.1">Registrar-Agent: Provides a store and forward communication path to exchange data objects between the pledge and the domain registrar.
 The Registrar-Agent acts as a broker in situations in which the domain registrar is not directly reachable by the pledge.
-This may be due to a different technology stack or due to missing connectivity.
-The Registrar-Agent triggers a pledge to create bootstrapping artifacts such as the voucher-request and the enrollment-request on one or multiple pledges.
-It can then perform a (bulk) bootstrapping based on the collected data.
-The Registrar-Agent is expected to possess information about the domain registrar: the registrar EE certificate, LDevID(CA) certificate, IP address, either by configuration or by using the discovery mechanism defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-There is no trust assumption between the pledge and the Registrar-Agent as only authenticated self-contained objects are used, which are transported via the Registrar-Agent and provided either by the pledge or the registrar.
-The trust assumption between the Registrar-Agent and the registrar is based on the LDevID of the Registrar-Agent, provided by the PKI responsible for the domain.
-This allows the Registrar-Agent to authenticate towards the registrar, e.g., in a TLS handshake.
-Based on this, the registrar is able to distinguish a pledge from a Registrar-Agent during the TLS session establishment and also to verify that this Registrar-Agent is authorized to perform the bootstrapping of the distinct pledge.
-The Registrar-Agent may be realized as stand-alone component supporting nomadic activities of a service technician moving between different installation sites.
-Contrary, the Registrar-Agent may also be realized as co-located functionality for a registrar, to support pledges in pledge-responder-mode.<a href="#section-5.1-11.2.1" class="pilcrow">¶</a></p>
+This may be due to a different technology stack or due to missing connectivity.<a href="#section-5.1-11.2.1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-5.1-11.2.2.1">
+                <p id="section-5.1-11.2.2.1.1">The Registrar-Agent triggers one or more pledges to create bootstrapping artifacts such as the voucher-request and the Enroll-Request.
+It can then perform a (bulk) bootstrapping based on the collected data.<a href="#section-5.1-11.2.2.1.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-5.1-11.2.2.2">
+                <p id="section-5.1-11.2.2.2.1">The Registrar-Agent is expected to possess information about the domain registrar: the registrar EE certificate, LDevID(CA) certificate, and IP address, either by configuration or by using the discovery mechanism defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-5.1-11.2.2.2.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-5.1-11.2.2.3">
+                <p id="section-5.1-11.2.2.3.1">There is no trust assumption between the pledge and the Registrar-Agent as only authenticated self-contained objects are used, which are transported via the Registrar-Agent and provided either by the pledge or the domain registrar.<a href="#section-5.1-11.2.2.3.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-5.1-11.2.2.4">
+                <p id="section-5.1-11.2.2.4.1">The trust assumption between the Registrar-Agent and the domain registrar may be based on an LDevID, which is provided by the PKI responsible for the customer domain.<a href="#section-5.1-11.2.2.4.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-5.1-11.2.2.5">
+                <p id="section-5.1-11.2.2.5.1">The Registrar-Agent may be realized as stand-alone component supporting nomadic activities of a service technician moving between different installation sites.<a href="#section-5.1-11.2.2.5.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-5.1-11.2.2.6">
+                <p id="section-5.1-11.2.2.6.1">Alternatively, the Registrar-Agent may also be realized as co-located functionality for a registrar, to support pledges in responder mode.<a href="#section-5.1-11.2.2.6.1" class="pilcrow">¶</a></p>
+</li>
+            </ul>
 </li>
           <li class="normal" id="section-5.1-11.3">
-            <p id="section-5.1-11.3.1">Join Proxy (not shown): same functionality as described in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> if needed.
-Note that a Registrar-Agent may use a join proxy to facilitate the TLS connection to the registrar, in the same way that a BRSKI pledge would use a join proxy. This is useful in cases where the Registrar-Agent does not have full IP connectivity via the domain network, or cases where it has no other means to locate the registrar on the network.<a href="#section-5.1-11.3.1" class="pilcrow">¶</a></p>
+            <p id="section-5.1-11.3.1">Join Proxy (not shown): Has the same functionality as described in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> if needed.
+Note that a Registrar-Agent may use a join proxy to facilitate the TLS connection to the registrar in the same way that a BRSKI pledge would use a join proxy. This is useful in cases where the Registrar-Agent does not have full IP connectivity via the domain network or cases where it has no other means to locate the registrar on the network.<a href="#section-5.1-11.3.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal" id="section-5.1-11.4">
-            <p id="section-5.1-11.4.1">Domain Registrar: In general, the domain registrar fulfills the same functionality regarding the bootstrapping of the pledge in a (customer site) domain by facilitating the communication of the pledge with the MASA service and the domain PKI service.
-In contrast to <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the domain registrar does not interact with a pledge directly but through the Registrar-Agent.
-A registrar with combined functionality of BRSKI and BRSKI-PRM detects if the bootstrapping is performed by the pledge directly (BRSKI case) or by the Registrar-Agent (BRSKI-PRM case) based on the utilized credential for authentication (either pledge’s IDevID or LDevID from Registrar-Agent), see also <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a>.<a href="#section-5.1-11.4.1" class="pilcrow">¶</a></p>
+            <p id="section-5.1-11.4.1">Domain Registrar: In general fulfills the same functionality regarding the bootstrapping of the pledge in a customer domain by facilitating the communication of the pledge with the MASA service and the domain key infrastructure (PKI).
+In contrast to <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, a BRSKI-PRM domain registrar does not interact with a pledge directly, but through the Registrar-Agent.<a href="#section-5.1-11.4.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal" id="section-5.1-11.5">
-            <p id="section-5.1-11.5.1">The manufacturer provided components/services (MASA and Ownership tracker) are used as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-A MASA is able to support enrollment via Registrar-Agent without changes unless it checks the vouchers proximity indication, in which case it would need to be enhanced to support BRSKI-PRM to also accept the agent-proximity.<a href="#section-5.1-11.5.1" class="pilcrow">¶</a></p>
+            <p id="section-5.1-11.5.1">Vendor Services: Encompass MASA and Ownership Tracker and are used as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+A MASA is able to support enrollment via Registrar-Agent without changes unless it checks the vouchers proximity indication, in which case it would need to be enhanced to support BRSKI-PRM to also accept the Agent-Proximity Assertion {#agt_prx}.<a href="#section-5.1-11.5.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 </section>
@@ -2049,7 +2136,7 @@ A MASA is able to support enrollment via Registrar-Agent without changes unless 
 <div id="arch_nomadic">
 <section id="section-5.2">
         <h3 id="name-nomadic-connectivity">
-<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-nomadic-connectivity" class="section-name selfRef">Nomadic connectivity</a>
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-nomadic-connectivity" class="section-name selfRef">Nomadic Connectivity</a>
         </h3>
 <p id="section-5.2-1">In one example instance of the PRM architecture as shown in <a href="#uc3figure" class="auto internal xref">Figure 2</a>, there is no connectivity between the location in which the pledge is installed and the location of the domain registrar.
 This is often the case in the aforementioned building automation use case (<a href="#building-automation" class="auto internal xref">Section 3.1.1</a>).<a href="#section-5.2-1" class="pilcrow">¶</a></p>
@@ -2090,7 +2177,7 @@ This is often the case in the aforementioned building automation use case (<a hr
                   <text x="140" y="52">Ship</text>
                   <text x="184" y="52">.....</text>
                   <text x="244" y="52">Vendor</text>
-                  <text x="304" y="52">Service</text>
+                  <text x="308" y="52">Services</text>
                   <text x="40" y="68">:</text>
                   <text x="40" y="84">:</text>
                   <text x="164" y="100">........................................</text>
@@ -2123,9 +2210,9 @@ This is often the case in the aforementioned building automation use case (<a hr
                   <text x="320" y="196">.</text>
                   <text x="164" y="212">..........................!.............</text>
                   <text x="52" y="228">Pledge</text>
-                  <text x="112" y="228">install</text>
+                  <text x="132" y="228">Installation</text>
                   <text x="216" y="228">!</text>
-                  <text x="60" y="244">location</text>
+                  <text x="60" y="244">Location</text>
                   <text x="216" y="244">!</text>
                   <text x="256" y="244">Nomadic</text>
                   <text x="216" y="260">!</text>
@@ -2170,8 +2257,8 @@ This is often the case in the aforementioned building automation use case (<a hr
                   <text x="128" y="452">.</text>
                   <text x="448" y="452">.</text>
                   <text x="288" y="468">.........................................</text>
-                  <text x="236" y="484">"Domain"</text>
-                  <text x="316" y="484">Components</text>
+                  <text x="260" y="484">Customer</text>
+                  <text x="324" y="484">Domain</text>
                 </g>
               </svg><a href="#section-5.2-2.1.1" class="pilcrow">¶</a>
 </div>
@@ -2181,32 +2268,32 @@ This is often the case in the aforementioned building automation use case (<a hr
           </figcaption></figure>
 </div>
 <p id="section-5.2-3">PRM enables support of this case through nomadic connectivity of the Registrar-Agent.
-To perform enrollment in this setup, multiple round trips of the Registrar-Agent between the pledge install location and the domain registrar are required.<a href="#section-5.2-3" class="pilcrow">¶</a></p>
+To perform enrollment in this setup, multiple round trips of the Registrar-Agent between the pledge installation location and the domain registrar are required.<a href="#section-5.2-3" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-5.2-4">
 <li id="section-5.2-4.1">
             <p id="section-5.2-4.1.1">Connectivity to domain registrar: preparation tasks for pledge bootstrapping not part of the BRSKI-PRM protocol definition, like retrieval of list of pledges to enroll.<a href="#section-5.2-4.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="section-5.2-4.2">
-            <p id="section-5.2-4.2.1">Connectivity to pledge install location: retrieve information about available pledges (IDevID), collect request objects like voucher-requests and enrollment-requests using the BRSKI-PRM approach described in <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a>.<a href="#section-5.2-4.2.1" class="pilcrow">¶</a></p>
+            <p id="section-5.2-4.2.1">Connectivity to pledge installation location: retrieve information about available pledges (IDevID), collect request objects (i.e., Pledge Voucher-Requests and Pledge Enroll-Requests using the BRSKI-PRM approach described in <a href="#tpvr" class="auto internal xref">Section 7.1</a> and <a href="#tper" class="auto internal xref">Section 7.2</a>.<a href="#section-5.2-4.2.1" class="pilcrow">¶</a></p>
 </li>
           <li id="section-5.2-4.3">
-            <p id="section-5.2-4.3.1">Connectivity to domain registrar, submit collected pledges' request information, retrieve response objects as voucher and enrollment information using the BRSKI-PRM approach described in <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a>.<a href="#section-5.2-4.3.1" class="pilcrow">¶</a></p>
+            <p id="section-5.2-4.3.1">Connectivity to domain registrar, submit collected request information of pledges, retrieve response objects (i.e., Voucher and Enroll-Response) using the BRSKI-PRM approach described in <a href="#pvr" class="auto internal xref">Section 7.3</a> and <a href="#per" class="auto internal xref">Section 7.4</a>.<a href="#section-5.2-4.3.1" class="pilcrow">¶</a></p>
 </li>
           <li id="section-5.2-4.4">
-            <p id="section-5.2-4.4.1">Connectivity to pledge install location, provide retrieved objects to the pledge to enroll pledges and collect status using the BRSKI-PRM approach described in <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a>.<a href="#section-5.2-4.4.1" class="pilcrow">¶</a></p>
+            <p id="section-5.2-4.4.1">Connectivity to pledge installation location, provide retrieved objects to the pledges to enroll pledges and collect status using the BRSKI-PRM approach described in <a href="#voucher" class="auto internal xref">Section 7.6</a>, <a href="#cacerts" class="auto internal xref">Section 7.7</a>, and <a href="#enroll_response" class="auto internal xref">Section 7.8</a>.<a href="#section-5.2-4.4.1" class="pilcrow">¶</a></p>
 </li>
           <li id="section-5.2-4.5">
-            <p id="section-5.2-4.5.1">Connectivity to domain registrar, submit voucher status and enrollment status using the BRSKI-PRM approach described in <a href="#exchanges_uc2_4" class="auto internal xref">Section 6.3.6</a>.<a href="#section-5.2-4.5.1" class="pilcrow">¶</a></p>
+            <p id="section-5.2-4.5.1">Connectivity to domain registrar, submit Voucher Status and Enrollment Status using the BRSKI-PRM approach described in <a href="#vstatus" class="auto internal xref">Section 7.9</a> and <a href="#estatus" class="auto internal xref">Section 7.10</a>.<a href="#section-5.2-4.5.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="section-5.2-5">Variations of this setup include cases where the Registrar-Agent uses for example WiFi to connect to the pledge installation network, and mobile network connectivity to connect to the domain registrar.
-Both connections may also be possible in a single location at the same time, based on installation building conditions.,<a href="#section-5.2-5" class="pilcrow">¶</a></p>
+Both connections may also be possible in a single location at the same time, based on installation building conditions.<a href="#section-5.2-5" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="registrar-agent-co-located-with-registrar">
+<div id="co-located-registrar-agent-and-domain-registrar">
 <section id="section-5.3">
-        <h3 id="name-registrar-agent-co-located-">
-<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-registrar-agent-co-located-" class="section-name selfRef">Registrar-Agent co-located with registrar</a>
+        <h3 id="name-co-located-registrar-agent-">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-co-located-registrar-agent-" class="section-name selfRef">Co-located Registrar-Agent and Domain Registrar</a>
         </h3>
 <p id="section-5.3-1">Compared to <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> BRSKI, pledges supporting BRSKI-PRM can be completely passive and only need to react when being requested to react by a Registrar-Agent.
 In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, pledges instead need to continuously request enrollment from a domain registrar, which may result in undesirable communications pattern and possible overload of a domain registrar.<a href="#section-5.3-1" class="pilcrow">¶</a></p>
@@ -2214,7 +2301,7 @@ In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, pledges inst
 <figure id="figure-3">
           <div id="section-5.3-2.1">
             <div class="alignLeft art-svg artwork" id="section-5.3-2.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="352" width="448" viewBox="0 0 448 352" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="352" width="472" viewBox="0 0 472 352" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
                 <path d="M 8,160 L 8,208" fill="none" stroke="black"></path>
                 <path d="M 80,160 L 80,208" fill="none" stroke="black"></path>
                 <path d="M 200,32 L 200,64" fill="none" stroke="black"></path>
@@ -2290,8 +2377,8 @@ In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, pledges inst
                   <text x="120" y="292">.</text>
                   <text x="440" y="292">.</text>
                   <text x="280" y="308">.........................................</text>
-                  <text x="228" y="324">"Domain"</text>
-                  <text x="308" y="324">Components</text>
+                  <text x="252" y="324">Customer</text>
+                  <text x="316" y="324">Domain</text>
                 </g>
               </svg><a href="#section-5.3-2.1.1" class="pilcrow">¶</a>
 </div>
@@ -2308,702 +2395,787 @@ In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, pledges inst
         <h3 id="name-agent-proximity-assertion">
 <a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-agent-proximity-assertion" class="section-name selfRef">Agent-Proximity Assertion</a>
         </h3>
-<p id="section-5.4-1">"Agent-proximity" is a statement in the PVR and in the voucher, that the registrar certificate was provided via the Registrar-Agent as defined in <a href="#exchanges_uc2" class="auto internal xref">Section 6</a> and not directly to the pledge.
-"Agent-proximity" is therefore a different assertion then "proximity", which is defined in section 4 of <span>[<a href="#RFC8366" class="cite xref">RFC8366</a>]</span>.
-"Agent-proximity" is defined as additional assertion type in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>.
-This can be verified by the registrar and also by the MASA during the voucher-request processing.<a href="#section-5.4-1" class="pilcrow">¶</a></p>
+<p id="section-5.4-1">"Agent-proximity" is a statement in the PVR and in the voucher, that the registrar certificate was provided via the Registrar-Agent as defined in <a href="#exchanges_uc2" class="auto internal xref">Section 7</a> and not directly to the pledge.
+Agent-proximity is therefore a different assertion than "proximity", which is defined in <span><a href="https://rfc-editor.org/rfc/rfc8366#section-4" class="relref">Section 4</a> of [<a href="#RFC8366" class="cite xref">RFC8366</a>]</span>.
+Agent-proximity is defined as additional assertion type in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>.
+This assertion can be verified by the registrar and also by the MASA during the voucher-request processing.<a href="#section-5.4-1" class="pilcrow">¶</a></p>
 <p id="section-5.4-2">In BRSKI, the pledge verifies POP of the registrar via the TLS handshake and pins that public key as the "proximity-registrar-cert" into the voucher request.
 This allows the MASA to verify the proximity of the pledge and registrar, facilitating a decision to assign the pledge to that domain owner.
 In BRSKI, the TLS connection is considered provisional until the pledge receives the voucher.<a href="#section-5.4-2" class="pilcrow">¶</a></p>
-<p id="section-5.4-3">In contrast, in BRSKI-PRM, the pledge has no direct connection to the registrar and must take the Registrar-Agent LDevID provisionally.
-The Registrar-Agent has included its LDevID, a certificate signed by the domain owner, into the PVR trigger message.
-The Registrar-Agent identity is therefore included into the Pledge Voucher Request (PVR).<a href="#section-5.4-3" class="pilcrow">¶</a></p>
-<p id="section-5.4-4">Akin to the BRSKI case, the pledge has provided proximity evidence to the MASA.
-But additionally, this allows the Registrar to be sure that the PVR collected by the Registrar-Agent was in fact collected by the Registrar-Agent to which the Registrar is connected to.<a href="#section-5.4-4" class="pilcrow">¶</a></p>
-<p id="section-5.4-5">In a similar fashion, the pledge accepts the registrar certificate provisionally until it receives the voucher as described in <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a>.
-See also Section 5 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> on "PROVISIONAL accept of server cert".<a href="#section-5.4-5" class="pilcrow">¶</a></p>
+<p id="section-5.4-3">In contrast, in BRSKI-PRM, the pledge has no direct connection to the registrar and <span class="bcp14">MUST</span> accept the registrar certificate provisionally until it receives the voucher as described in <a href="#voucher" class="auto internal xref">Section 7.6</a>.
+In a similar fashion, the pledge <span class="bcp14">MUST</span> accept the Registrar-Agent EE certificate provisionally.
+See also <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5" class="relref">Section 5</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> on "provisional state".<a href="#section-5.4-3" class="pilcrow">¶</a></p>
+<p id="section-5.4-4">For agent-proximity, the EE certificate of the Registrar-Agent <span class="bcp14">MUST</span> be an LDevID certificate signed by the domain owner.
+TODO[always in agent-signed-data] Further, the Registrar-Agent <span class="bcp14">MUST</span> include its LDevID certificate in the PVR trigger message and, in turn, the pledge <span class="bcp14">MUST</span> include it in the Pledge Voucher Request (PVR).
+TODO[no other field, right?] The corresponding fields are defined in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.<a href="#section-5.4-4" class="pilcrow">¶</a></p>
+<p id="section-5.4-5">Akin to the proximity assertion in the BRSKI case, the agent-proximity provides pledge proximity evidence to the MASA.
+But additionally, agent-proximity allows the domain registrar to be sure that the PVR collected by the Registrar-Agent was in fact collected by the Registrar-Agent, to which the registrar is connected to.<a href="#section-5.4-5" class="pilcrow">¶</a></p>
+<p id="section-5.4-6">The provisioning of the Registrar-Agent LDevID certificate is out of scope for this document, but may be done in advance using a separate BRSKI run or by other means like configuration.
+It is recommended to use short lived Registrar-Agent LDevIDs in the range of days or weeks as outlined in <a href="#sec_cons_reg-agt" class="auto internal xref">Section 11.3</a>.<a href="#section-5.4-6" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="pledge_ep">
-<section id="section-5.5">
-        <h3 id="name-behavior-of-pledge-in-pledg">
-<a href="#section-5.5" class="section-number selfRef">5.5. </a><a href="#name-behavior-of-pledge-in-pledg" class="section-name selfRef">Behavior of Pledge in Pledge-Responder-Mode</a>
+</section>
+</div>
+<div id="system-components">
+<section id="section-6">
+      <h2 id="name-system-components">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-system-components" class="section-name selfRef">System Components</a>
+      </h2>
+<div id="domain-registrar">
+<section id="section-6.1">
+        <h3 id="name-domain-registrar">
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-domain-registrar" class="section-name selfRef">Domain Registrar</a>
         </h3>
-<p id="section-5.5-1">The pledge is triggered by the Registrar-Agent to generate the PVR and PER.
-It will also be triggered for processing of the responses and the generation of status information once the Registrar-Agent has received the responses from the registrar later in the process.
-Due to the use of the Registrar-Agent, the interaction with the domain registrar is changed as shown in <a href="#exchangesfig_uc2_1" class="auto internal xref">Figure 5</a>.
-To enable interaction as responder with the Registrar-Agent, the pledge provides endpoints using the BRSKI defined endpoints based on the "/.well-known/brski" URI tree.<a href="#section-5.5-1" class="pilcrow">¶</a></p>
-<p id="section-5.5-2">When the Registrar-Agent reaches out to a pledge, for instance with an example URI path "http://pledge.example/.well-known/brski/tpvr", it will in fact send a Host: header of "pledge.example", with a relative path of "/.well-known/brski/tpbr".
-However in practice the pledge will often be known only by its IP address as returned by a discovery protocol, and that is what will be present in the Host: header.<a href="#section-5.5-2" class="pilcrow">¶</a></p>
-<p id="section-5.5-3">The pledge <span class="bcp14">MUST</span> respond to all queries regardless of what Host: header is provided by the client.
-<span>[<a href="#RFC9110" class="cite xref">RFC9110</a>], <a href="https://rfc-editor.org/rfc/rfc9110#section-7.2" class="relref">Section 7.2</a></span> makes the Host: header mandatory, so it will always be present.<a href="#section-5.5-3" class="pilcrow">¶</a></p>
-<p id="section-5.5-4">The following operations are defined for the <em>pledge</em> in this document, describing their endpoints and their corresponding URIs.
-The endpoints are defined with short names to also accommodate for the constraint case.<a href="#section-5.5-4" class="pilcrow">¶</a></p>
-<span id="name-endpoints-on-the-pledge"></span><div id="eppfigure1">
+<p id="section-6.1-1">In BRSKI-PRM, the domain registrar provides the endpoints already specified in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> (derived from EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span>) where suitable.
+In addition, it <span class="bcp14">MUST</span> provide the endpoints defined in <a href="#registrar_ep_table" class="auto internal xref">Table 1</a> within the BRSKI-defined "/.well-known/brski/" URI path.
+These endpoints accommodate for the signature-wrapped objects used by BRSKI-PRM for the Pledge Enroll-Request (PER) and the provisioning of CA certificates.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<span id="name-additional-well-known-endpo"></span><div id="registrar_ep_table">
 <table class="center" id="table-1">
           <caption>
 <a href="#table-1" class="selfRef">Table 1</a>:
-<a href="#name-endpoints-on-the-pledge" class="selfRef">Endpoints on the pledge</a>
+<a href="#name-additional-well-known-endpo" class="selfRef">Additional Well-Known Endpoints on a BRSKI-PRM Registrar</a>
           </caption>
 <thead>
             <tr>
-              <th class="text-left" rowspan="1" colspan="1">Operation</th>
               <th class="text-left" rowspan="1" colspan="1">Endpoint</th>
-              <th class="text-left" rowspan="1" colspan="1">Details</th>
+              <th class="text-left" rowspan="1" colspan="1">Operation</th>
+              <th class="text-left" rowspan="1" colspan="1">Exchange and Artifacts</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td class="text-left" rowspan="1" colspan="1">Trigger pledge-voucher-request creation - Returns PVR</td>
-              <td class="text-left" rowspan="1" colspan="1">/tpvr</td>
+              <td class="text-left" rowspan="1" colspan="1">requestenroll</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply PER to registrar</td>
               <td class="text-left" rowspan="1" colspan="1">
-                <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a>
+                <a href="#per" class="auto internal xref">Section 7.4</a>
 </td>
             </tr>
             <tr>
-              <td class="text-left" rowspan="1" colspan="1">Trigger pledge-enrollment-request - Returns PER</td>
-              <td class="text-left" rowspan="1" colspan="1">/tper</td>
+              <td class="text-left" rowspan="1" colspan="1">wrappedcacerts</td>
+              <td class="text-left" rowspan="1" colspan="1">Request CA certificates</td>
               <td class="text-left" rowspan="1" colspan="1">
-                <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a>
-</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Supply voucher to pledge - Returns pledge voucher-status</td>
-              <td class="text-left" rowspan="1" colspan="1">/svr</td>
-              <td class="text-left" rowspan="1" colspan="1">
-                <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a>
-</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Supply enrollment-response to pledge - Returns pledge enrollment-status</td>
-              <td class="text-left" rowspan="1" colspan="1">/ser</td>
-              <td class="text-left" rowspan="1" colspan="1">
-                <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a>
-</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Supply CA certs to pledge</td>
-              <td class="text-left" rowspan="1" colspan="1">/scac</td>
-              <td class="text-left" rowspan="1" colspan="1">
-                <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a>
-</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Query status of pledge - Returns pledge-status</td>
-              <td class="text-left" rowspan="1" colspan="1">/qps</td>
-              <td class="text-left" rowspan="1" colspan="1">
-                <a href="#exchanges_uc2_5" class="auto internal xref">Section 6.4</a>
+                <a href="#req_cacerts" class="auto internal xref">Section 7.5</a>
 </td>
             </tr>
           </tbody>
         </table>
+</div>
+<p id="section-6.1-3">According to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.3" class="relref">Section 5.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the domain registrar performs the pledge authorization for bootstrapping within his domain based on the Pledge Voucher-Request.
+This behavior is retained in BRSKI-PRM.<a href="#section-6.1-3" class="pilcrow">¶</a></p>
+<p id="section-6.1-4">The domain registrar <span class="bcp14">MUST</span> possess and trust the IDevID (root or issuing) CA certificate 
+of the pledge vendor/manufacturer.<a href="#section-6.1-4" class="pilcrow">¶</a></p>
+<p id="section-6.1-5">Further, the domain registrar <span class="bcp14">MUST</span> have its own EE credentials.<a href="#section-6.1-5" class="pilcrow">¶</a></p>
+<div id="domain-registrar-with-combined-functionality">
+<section id="section-6.1.1">
+          <h4 id="name-domain-registrar-with-combi">
+<a href="#section-6.1.1" class="section-number selfRef">6.1.1. </a><a href="#name-domain-registrar-with-combi" class="section-name selfRef">Domain Registrar with Combined Functionality</a>
+          </h4>
+<p id="section-6.1.1-1">A registrar with combined BRSKI and BRSKI-PRM functionality <span class="bcp14">MAY</span> detect if the bootstrapping is performed by the pledge directly (BRSKI case) or by a Registrar-Agent (BRSKI-PRM case) based on the utilized credential for client authentication during the TLS session establishment and switch switch the operational mode from BRSKI to BRSKI-PRM.<a href="#section-6.1.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.1.1-2">This may be supported by a specific naming in the SAN (subject alternative name) component of the EE certificate of the Registrar-Agent.<a href="#section-6.1.1-2" class="pilcrow">¶</a></p>
+<p id="section-6.1.1-3">Alternatively, this may be supported by using an LDevID certificate signed by the domain owner for the client authentication of the Registrar-Agent.
+Using an LDevID certificate also allows the registrar to verify that a Registrar-Agent is authorized to perform the bootstrapping of a pledge.
+See also agent-proximity assertion in <a href="#agt_prx" class="auto internal xref">Section 5.4</a>.<a href="#section-6.1.1-3" class="pilcrow">¶</a></p>
+<p id="section-6.1.1-4">Using an LDevID certificate for TLS client authentication of the Registrar-Agent is a deviation from <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, in which the IDevID credential of the pledge is used to perform TLS client authentication.<a href="#section-6.1.1-4" class="pilcrow">¶</a></p>
+</section>
 </div>
 </section>
 </div>
-<div id="behavior-of-registrar-agent">
-<section id="section-5.6">
-        <h3 id="name-behavior-of-registrar-agent">
-<a href="#section-5.6" class="section-number selfRef">5.6. </a><a href="#name-behavior-of-registrar-agent" class="section-name selfRef">Behavior of Registrar-Agent</a>
+<div id="registrar-agent">
+<section id="section-6.2">
+        <h3 id="name-registrar-agent">
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-registrar-agent" class="section-name selfRef">Registrar-Agent</a>
         </h3>
-<p id="section-5.6-1">The Registrar-Agent as a new component provides a message passing service between the pledge and the domain registrar.
-It facilitates the exchange of data between the pledge and the domain registrar, which are the voucher-request/response, the enrollment-request/response, as well as related telemetry and status information.<a href="#section-5.6-1" class="pilcrow">¶</a></p>
-<p id="section-5.6-2">For the communication with the pledge the Registrar-Agent utilizes communication endpoints provided by the pledge.
-The transport in this specification is based on HTTP but may also be done using other transport mechanisms.<a href="#section-5.6-2" class="pilcrow">¶</a></p>
-<p id="section-5.6-3">The communication between the Registrar-Agent and the pledge <span class="bcp14">MAY</span> be protected using TLS as outlined in <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a>.
-The details of doing TLS validation are <a href="#pledgehttps" class="auto internal xref">Appendix B</a>.<a href="#section-5.6-3" class="pilcrow">¶</a></p>
-<p id="section-5.6-4">For the communication with the registrar, the Registrar-Agent uses the endpoints of the domain registrar side already specified in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> (derived from EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span>) where suitable.
-These endpoints do not expect signature wrapped-objects, which are used b BRSKI-PRM.
-This specifically applies for the enrollment-request and the provisioning of CA certificates.
-To accommodate the use of signature-wrapped object, the following additional endpoints are defined for the <em>registrar</em>.
-Operations and their corresponding URIs:<a href="#section-5.6-4" class="pilcrow">¶</a></p>
-<span id="name-additional-endpoints-on-the"></span><div id="eppfigure2">
-<table class="center" id="table-2">
-          <caption>
-<a href="#table-2" class="selfRef">Table 2</a>:
-<a href="#name-additional-endpoints-on-the" class="selfRef">Additional endpoints on the registrar</a>
-          </caption>
-<thead>
-            <tr>
-              <th class="text-left" rowspan="1" colspan="1">Operation</th>
-              <th class="text-left" rowspan="1" colspan="1">Endpoint</th>
-              <th class="text-left" rowspan="1" colspan="1">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Supply PER to registrar - Returns enrollment-response</td>
-              <td class="text-left" rowspan="1" colspan="1">/requestenroll</td>
-              <td class="text-left" rowspan="1" colspan="1">
-                <a href="#exchanges_uc2_2_per" class="auto internal xref">Section 6.2.6</a>
-</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Request (wrapped) CA certificates - Returns wrapped CA Certificates</td>
-              <td class="text-left" rowspan="1" colspan="1">/wrappedcacerts</td>
-              <td class="text-left" rowspan="1" colspan="1">
-                <a href="#exchanges_uc2_2_wca" class="auto internal xref">Section 6.2.7</a>
-</td>
-            </tr>
-          </tbody>
-        </table>
-</div>
-<p id="section-5.6-6">For authentication to the domain registrar, the Registrar-Agent uses its EE (RegAgt) certificate.
-The provisioning of the Registrar-Agent LDevID is out of scope for this document, but may be done in advance using a separate BRSKI run or by other means like configuration.
-It is recommended to use short lived Registrar-Agent LDevIDs in the range of days or weeks as outlined in <a href="#sec_cons_reg-agt" class="auto internal xref">Section 10.3</a>.<a href="#section-5.6-6" class="pilcrow">¶</a></p>
-<p id="section-5.6-7">The Registrar-Agent will use its EE certificate when establishing a TLS session with the domain registrar for TLS client authentication.
-The EE (RegAgt) certificate <span class="bcp14">MUST</span> include a SubjectKeyIdentifier (SKID), which is used as reference in the context of an agent-signed-data object as defined in <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a>.
-Note that this is an additional requirement for issuing the certificate, as <span>[<a href="#IEEE-802.1AR" class="cite xref">IEEE-802.1AR</a>]</span> only requires the SKID to be included for intermediate CA certificates.
-<span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> makes a similar requirement.
-In BRSKI-PRM, the SKID is used in favor of providing the complete EE (RegAgt) certificate to accommodate also constraint environments and reduce bandwidth needed for communication with the pledge.
-In addition, it follows the recommendation from BRSKI to use SKID in favor of a certificate fingerprint to avoid additional computations.<a href="#section-5.6-7" class="pilcrow">¶</a></p>
-<p id="section-5.6-8">Using an LDevID for TLS client authentication of the Registrar-Agent is a deviation from <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, in which the pledge's IDevID credential is used to perform TLS client authentication.
-The use of the EE (RegAgt) certificate allows the domain registrar to distinguish, if bootstrapping is initiated from a pledge or from a Registrar-Agent and to adopt different internal handling accordingly.
-If a registrar detects a request that originates from a Registrar-Agent it is able to switch the operational mode from BRSKI to BRSKI-PRM.
-This may be supported by a specific naming in the SAN (subject alternative name) component of the EE (RegAgt) certificate.
-Alternatively, the domain may feature a CA specifically for issuing Registrar-Agent LDevID certificates.
-This allows the registrar to detect Registrar-Agents based on the issuing CA.<a href="#section-5.6-8" class="pilcrow">¶</a></p>
-<p id="section-5.6-9">As BRSKI-PRM uses authenticated self-contained data objects between the pledge and the domain registrar, the binding of the pledge identity to the requests is provided by the data object signature employing the pledge's IDevID.
-The objects exchanged between the pledge and the domain registrar used in the context of this specifications are JOSE objects.<a href="#section-5.6-9" class="pilcrow">¶</a></p>
-<p id="section-5.6-10">In addition to the EE (RegAgt) certificate, the Registrar-Agent is provided with the product-serial-number(s) of the pledge(s) to be bootstrapped.
-This is necessary to allow the discovery of pledge(s) by the Registrar-Agent using DNS-SD with mDNS (see <a href="#discovery_uc2_ppa" class="auto internal xref">Section 5.6.2</a>)
+<p id="section-6.2-1">The Registrar-Agent is a new component in BRSKI-PRM that provides a secure message passing service between pledges in responder mode and the domain registrar.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2-2">It requires the EE certificate of the domain registrar for TLS server authentication when establishing a TLS session with the domain registrar and to provide the registrar EE certificate to the pledge for creating the Pledge Voucher-Request (PVR).<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+<p id="section-6.2-3">The Registrar-Agent uses its own EE certificate for TLS client authentication when establishing a TLS session with the domain registrar and for signing agent-signed data.
+This EE certificate <span class="bcp14">MUST</span> include a SubjectKeyIdentifier (SKID), which is used as reference in the context of an agent-signed-data object as defined in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.<a href="#section-6.2-3" class="pilcrow">¶</a></p>
+<p id="section-6.2-4">Note that this is an additional requirement for issuing the certificate, as <span>[<a href="#IEEE-802.1AR" class="cite xref">IEEE-802.1AR</a>]</span> only requires the SKID to be included for intermediate CA certificates.
+<span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> has a similar requirement.
+In BRSKI-PRM, the SKID is used in favor of providing the complete EE certificate of the Registrar-Agent to accommodate also constrained environments and reduce bandwidth needed for communication with the pledge.
+In addition, it follows the recommendation from BRSKI to use SKID in favor of a certificate fingerprint to avoid additional computations.<a href="#section-6.2-4" class="pilcrow">¶</a></p>
+<p id="section-6.2-5">In addition to the EE certificates, the Registrar-Agent is provided with the product serial number(s) of the pledge(s) to be bootstrapped.
+This is necessary to allow the discovery of pledge(s) by the Registrar-Agent using DNS-SD with mDNS (see <a href="#discovery_uc2_ppa" class="auto internal xref">Section 6.2.2</a>).
 The list may be provided by prior administrative means or the Registrar-Agent may get the information via an interaction with the pledge.
-For instance, <span>[<a href="#RFC9238" class="cite xref">RFC9238</a>]</span> describes scanning of a QR code, the product-serial-number would be initialized from the 12N B005 Product Serial Number.<a href="#section-5.6-10" class="pilcrow">¶</a></p>
-<p id="section-5.6-11">According to <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> section 5.3, the domain registrar performs the pledge authorization for bootstrapping within his domain based on the pledge-voucher-request object.
-This behavior is retained also in BRSKI-PRM.<a href="#section-5.6-11" class="pilcrow">¶</a></p>
-<p id="section-5.6-12">The following information <span class="bcp14">MUST</span> be available at the Registrar-Agent before interaction with a pledge:<a href="#section-5.6-12" class="pilcrow">¶</a></p>
+For instance, <span>[<a href="#RFC9238" class="cite xref">RFC9238</a>]</span> describes scanning of a QR code, where the product serial number would be initialized from the 12N B005 Product Serial Number.<a href="#section-6.2-5" class="pilcrow">¶</a></p>
+<p id="section-6.2-6">In summary, the following information <span class="bcp14">MUST</span> be available at the Registrar-Agent before interaction with a pledge:<a href="#section-6.2-6" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-5.6-13.1">
-            <p id="section-5.6-13.1.1">EE (RegAgt) certificate and corresponding private key: own operational key pair (to sign agent-signed-data).<a href="#section-5.6-13.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-6.2-7.1">
+            <p id="section-6.2-7.1.1">Domain registrar EE certificate: certificate of the domain registrar to be provided to the pledge.<a href="#section-6.2-7.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="normal" id="section-5.6-13.2">
-            <p id="section-5.6-13.2.1">Registrar EE certificate: certificate of the domain registrar (to be provided to the pledge).<a href="#section-5.6-13.2.1" class="pilcrow">¶</a></p>
+          <li class="normal" id="section-6.2-7.2">
+            <p id="section-6.2-7.2.1">Registrar-Agent EE certificate and corresponding private key: own operational key pair to sign agent-signed-data.<a href="#section-6.2-7.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="normal" id="section-5.6-13.3">
-            <p id="section-5.6-13.3.1">Serial-number(s): product-serial-number(s) of pledge(s) to be bootstrapped (to query discovery of specific pledges based on the product-serial-number).<a href="#section-5.6-13.3.1" class="pilcrow">¶</a></p>
+          <li class="normal" id="section-6.2-7.3">
+            <p id="section-6.2-7.3.1">Serial number(s): product serial number(s) of pledge(s) to be bootstrapped for discovery.<a href="#section-6.2-7.3.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
+<p id="section-6.2-8">Further, the Registrar-Agent <span class="bcp14">SHOULD</span> have synchronized time.<a href="#section-6.2-8" class="pilcrow">¶</a></p>
+<p id="section-6.2-9">Finally, the Registrar-Agent <span class="bcp14">MAY</span> possess the IDevID (root or issuing) CA certificate of the pledge vendor/manufacturer to validate the IDevID certificate on returned PVR or in case of TLS usage for pledge communication.
+The distribution of IDevID CA certificates to the Registrar-Agent is out of scope of this document and may be done by a manual configuration.<a href="#section-6.2-9" class="pilcrow">¶</a></p>
 <div id="discovery_uc2_reg">
-<section id="section-5.6.1">
-          <h4 id="name-discovery-of-registrar-by-r">
-<a href="#section-5.6.1" class="section-number selfRef">5.6.1. </a><a href="#name-discovery-of-registrar-by-r" class="section-name selfRef">Discovery of Registrar by Registrar-Agent</a>
+<section id="section-6.2.1">
+          <h4 id="name-discovery-of-the-registrar">
+<a href="#section-6.2.1" class="section-number selfRef">6.2.1. </a><a href="#name-discovery-of-the-registrar" class="section-name selfRef">Discovery of the Registrar</a>
           </h4>
-<p id="section-5.6.1-1">As a Registrar-Agent acts as representative of the domain registrar towards the pledge or may even be collocated with the domain registrar, a separate discovery of the registrar is likely not needed as Registrar-Agent and registrar are domain components and have a trust relation.
+<p id="section-6.2.1-1">As a Registrar-Agent acts as representative of the domain registrar towards the pledge or may even be collocated with the domain registrar, a separate discovery of the registrar is likely not needed as Registrar-Agent and registrar are domain components and have a trust relation.
 Moreover, other communication (not part of this document) between the Registrar-Agent and the registrar is assumed, e.g., to exchange information about product-serial-number(s) of pledges to be discovered as outlined in <a href="#arch_nomadic" class="auto internal xref">Section 5.2</a>.
-Moreover, as the standard discovery described in section 4 and the appendix A.2 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> does not support  of registrars with an enhanced feature set (like the support of BRSKI-PRM), this standard discovery is not applicable.<a href="#section-5.6.1-1" class="pilcrow">¶</a></p>
-<p id="section-5.6.1-2">As a more general solution, the BRSKI discovery mechanism can be extended to provide upfront information on the capabilities of registrars, such as the mode of operation (pledge-responder-mode or registrar-responder-mode).
+Moreover, as the standard discovery described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-4" class="relref">Section 4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> and the <span><a href="https://rfc-editor.org/rfc/rfc8995#appendix-A.2" class="relref">Appendix A.2</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> does not support  of registrars with an enhanced feature set (like the support of BRSKI-PRM), this standard discovery is not applicable.<a href="#section-6.2.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.2.1-2">As a more general solution, the BRSKI discovery mechanism can be extended to provide upfront information on the capabilities of registrars, such as the mode of operation (pledge-responder-mode or registrar-responder-mode).
 Defining discovery extensions is out of scope of this document.
-This may be provided in <span>[<a href="#I-D.eckert-anima-brski-discovery" class="cite xref">I-D.eckert-anima-brski-discovery</a>]</span>.<a href="#section-5.6.1-2" class="pilcrow">¶</a></p>
+This may be provided in <span>[<a href="#I-D.eckert-anima-brski-discovery" class="cite xref">I-D.eckert-anima-brski-discovery</a>]</span>.<a href="#section-6.2.1-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="discovery_uc2_ppa">
-<section id="section-5.6.2">
-          <h4 id="name-discovery-of-pledge-by-regi">
-<a href="#section-5.6.2" class="section-number selfRef">5.6.2. </a><a href="#name-discovery-of-pledge-by-regi" class="section-name selfRef">Discovery of Pledge by Registrar-Agent</a>
+<section id="section-6.2.2">
+          <h4 id="name-discovery-of-the-pledge">
+<a href="#section-6.2.2" class="section-number selfRef">6.2.2. </a><a href="#name-discovery-of-the-pledge" class="section-name selfRef">Discovery of the Pledge</a>
           </h4>
-<p id="section-5.6.2-1">The discovery of the pledge by Registrar-Agent in the context of this document describes the minimum discovery approach to be supported.
-A more general discovery mechanism, also supporting GRASP besides DNS-SD with mDNS may be provided in <span>[<a href="#I-D.eckert-anima-brski-discovery" class="cite xref">I-D.eckert-anima-brski-discovery</a>]</span>.<a href="#section-5.6.2-1" class="pilcrow">¶</a></p>
-<p id="section-5.6.2-2">Discovery in BRSKI-PRM uses DNS-based Service Discovery <span>[<a href="#RFC6763" class="cite xref">RFC6763</a>]</span> over Multicast DNS <span>[<a href="#RFC6762" class="cite xref">RFC6762</a>]</span> to discover the pledge.
+<p id="section-6.2.2-1">The discovery of the pledge by Registrar-Agent in the context of this document describes the minimum discovery approach to be supported.
+A more general discovery mechanism, also supporting GRASP besides DNS-SD with mDNS may be provided in <span>[<a href="#I-D.eckert-anima-brski-discovery" class="cite xref">I-D.eckert-anima-brski-discovery</a>]</span>.<a href="#section-6.2.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2.2-2">Discovery in BRSKI-PRM uses DNS-based Service Discovery <span>[<a href="#RFC6763" class="cite xref">RFC6763</a>]</span> over Multicast DNS <span>[<a href="#RFC6762" class="cite xref">RFC6762</a>]</span> to discover the pledge.
 Note that <span>[<a href="#RFC6762" class="cite xref">RFC6762</a>]</span> Section 9 provides support for conflict resolution in situations when an DNS-SD with mDNS responder receives a mDNS response with inconsistent data.
-Note that <span>[<a href="#RFC8990" class="cite xref">RFC8990</a>]</span> does not support conflict resolution of mDNS, which may be a limitation for its application.<a href="#section-5.6.2-2" class="pilcrow">¶</a></p>
-<p id="section-5.6.2-3">The pledge constructs a local host name based on device local information (product-serial-number), which results in "product-serial-number._brski-pledge._tcp.local".
-The product-serial-number composition is manufacturer dependent and may contain information regarding the manufacturer, the product type, and further information specific to the product instance. To allow distinction of pledges, the product-serial-number therefore needs to be sufficiently unique.<a href="#section-5.6.2-3" class="pilcrow">¶</a></p>
-<p id="section-5.6.2-4">In the absence of a more general discovery as defined in <span>[<a href="#I-D.eckert-anima-brski-discovery" class="cite xref">I-D.eckert-anima-brski-discovery</a>]</span> the Registrar-Agent <span class="bcp14">MUST</span>  use<a href="#section-5.6.2-4" class="pilcrow">¶</a></p>
+Note that <span>[<a href="#RFC8990" class="cite xref">RFC8990</a>]</span> does not support conflict resolution of mDNS, which may be a limitation for its application.<a href="#section-6.2.2-2" class="pilcrow">¶</a></p>
+<p id="section-6.2.2-3">The pledge constructs a local host name based on device local information (product-serial-number), which results in "product-serial-number._brski-pledge._tcp.local".
+The product-serial-number composition is manufacturer dependent and may contain information regarding the manufacturer, the product type, and further information specific to the product instance. To allow distinction of pledges, the product-serial-number therefore needs to be sufficiently unique.<a href="#section-6.2.2-3" class="pilcrow">¶</a></p>
+<p id="section-6.2.2-4">In the absence of a more general discovery as defined in <span>[<a href="#I-D.eckert-anima-brski-discovery" class="cite xref">I-D.eckert-anima-brski-discovery</a>]</span> the Registrar-Agent <span class="bcp14">MUST</span>  use<a href="#section-6.2.2-4" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-5.6.2-5.1">
-              <p id="section-5.6.2-5.1.1">"product-serial-number._brski-pledge._tcp.local", to discover a specific pledge, e.g., when connected to a local network.<a href="#section-5.6.2-5.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-6.2.2-5.1">
+              <p id="section-6.2.2-5.1.1">"&lt;product-serial-number&gt;._brski-pledge._tcp.local", to discover a specific pledge, e.g., when connected to a local network.<a href="#section-6.2.2-5.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-5.6.2-5.2">
-              <p id="section-5.6.2-5.2.1">"_brski-pledge._tcp.local" to get a list of pledges to be bootstrapped.<a href="#section-5.6.2-5.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-6.2.2-5.2">
+              <p id="section-6.2.2-5.2.1">"_brski-pledge._tcp.local" to get a list of pledges to be bootstrapped.<a href="#section-6.2.2-5.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-5.6.2-6">A manufacturer may allow the pledge to react on DNS-SD with mDNS discovery without his product-serial-number contained. This allows a commissioning tool to discover pledges to be bootstrapped in the domain. The manufacturer support this functionality as outlined in <a href="#sec_cons_mDNS" class="auto internal xref">Section 10.4</a>.<a href="#section-5.6.2-6" class="pilcrow">¶</a></p>
-<p id="section-5.6.2-7">Establishing network connectivity of the pledge is out of scope of this document but necessary to apply DNS-SD with mDNS.
+<p id="section-6.2.2-6">A manufacturer may allow the pledge to react on DNS-SD with mDNS discovery without his product-serial-number contained. This allows a commissioning tool to discover pledges to be bootstrapped in the domain. The manufacturer support this functionality as outlined in <a href="#sec_cons_mDNS" class="auto internal xref">Section 11.4</a>.<a href="#section-6.2.2-6" class="pilcrow">¶</a></p>
+<p id="section-6.2.2-7">Establishing network connectivity of the pledge is out of scope of this document but necessary to apply DNS-SD with mDNS.
 For Ethernet it is provided by simply connecting the network cable.
 For WiFi networks, connectivity can be provided by using a pre-agreed SSID for bootstrapping, e.g., as proposed in <span>[<a href="#I-D.richardson-emu-eap-onboarding" class="cite xref">I-D.richardson-emu-eap-onboarding</a>]</span>.
 The same approach can be used by 6LoWPAN/mesh using a pre-agreed PAN ID.
-How to gain network connectivity is out of scope of this document.<a href="#section-5.6.2-7" class="pilcrow">¶</a></p>
+How to gain network connectivity is out of scope of this document.<a href="#section-6.2.2-7" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
-<div id="behavior-of-pledge-with-combined-functionality">
-<section id="section-5.7">
-        <h3 id="name-behavior-of-pledge-with-com">
-<a href="#section-5.7" class="section-number selfRef">5.7. </a><a href="#name-behavior-of-pledge-with-com" class="section-name selfRef">Behavior of Pledge with Combined Functionality</a>
+<div id="pledge_ep">
+<section id="section-6.3">
+        <h3 id="name-pledge-in-responder-mode">
+<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-pledge-in-responder-mode" class="section-name selfRef">Pledge in Responder Mode</a>
         </h3>
-<p id="section-5.7-1">Pledges <span class="bcp14">MAY</span> support both initiator or responder mode.<a href="#section-5.7-1" class="pilcrow">¶</a></p>
-<p id="section-5.7-2">A pledge in initiator mode should listen for announcement messages as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-4.1" class="relref">Section 4.1</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+<p id="section-6.3-1">The pledge is triggered by the Registrar-Agent to create the PVR and PER.
+It is also triggered for processing of the responses and the generation of status information once the Registrar-Agent has received the responses from the registrar later in the process.<a href="#section-6.3-1" class="pilcrow">¶</a></p>
+<p id="section-6.3-2">To enable interaction as responder with the Registrar-Agent, pledges in responder mode <span class="bcp14">MUST</span> act as servers and <span class="bcp14">MUST</span> provide the endpoints defined in <a href="#pledge_ep_table" class="auto internal xref">Table 2</a> within the BRSKI-defined "/.well-known/brski/" URI path.
+The endpoints are defined with short names to also accommodate for resource-constrained devices.<a href="#section-6.3-2" class="pilcrow">¶</a></p>
+<span id="name-well-known-endpoints-on-a-p"></span><div id="pledge_ep_table">
+<table class="center" id="table-2">
+          <caption>
+<a href="#table-2" class="selfRef">Table 2</a>:
+<a href="#name-well-known-endpoints-on-a-p" class="selfRef">Well-Known Endpoints on a Pledge in Responder Mode</a>
+          </caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Endpoint</th>
+              <th class="text-left" rowspan="1" colspan="1">Operation</th>
+              <th class="text-left" rowspan="1" colspan="1">Exchange and Artifacts</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">tpvr</td>
+              <td class="text-left" rowspan="1" colspan="1">Trigger Pledge Voucher-Request</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <a href="#tpvr" class="auto internal xref">Section 7.1</a>
+</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">tper</td>
+              <td class="text-left" rowspan="1" colspan="1">Trigger Pledge Enroll-Request</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <a href="#tper" class="auto internal xref">Section 7.2</a>
+</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">svr</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply Voucher to pledge</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <a href="#voucher" class="auto internal xref">Section 7.6</a>
+</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">scac</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply CA certificates to pledge</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <a href="#cacerts" class="auto internal xref">Section 7.7</a>
+</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">ser</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply Enroll-Response to pledge</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <a href="#enroll_response" class="auto internal xref">Section 7.8</a>
+</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">qps</td>
+              <td class="text-left" rowspan="1" colspan="1">Query Pledge Status</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <a href="#query" class="auto internal xref">Section 7.11</a>
+</td>
+            </tr>
+          </tbody>
+        </table>
+</div>
+<p id="section-6.3-4"><span><a href="https://rfc-editor.org/rfc/rfc9110#section-7.2" class="relref">Section 7.2</a> of [<a href="#RFC9110" class="cite xref">RFC9110</a>]</span> makes the Host header field mandatory, so it will always be present.
+The pledge <span class="bcp14">MUST</span> respond to all queries regardless of the Host header field provided by the client.<a href="#section-6.3-4" class="pilcrow">¶</a></p>
+<p id="section-6.3-5">For instance, when the Registrar-Agent reaches out to the "tpvr" endpoint on a pledge in responder mode with the full URI "http://pledge.example.com/.well-known/brski/tpvr", it sets the Host header field to "pledge.example.com" and the absolute path "/.well-known/brski/tpbr".
+In practice, however, the pledge often is only known by its IP address as returned by a discovery protocol, which will be included in the Host header field.<a href="#section-6.3-5" class="pilcrow">¶</a></p>
+<p id="section-6.3-6">As BRSKI-PRM uses authenticated self-contained data objects between the pledge and the domain registrar, the binding of the pledge identity to the requests is provided by the data object signature employing the IDevID of the pledge.
+Hence, pledges <span class="bcp14">MUST</span> have an Initial Device Identifier (IDevID) installed in them at the factory.<a href="#section-6.3-6" class="pilcrow">¶</a></p>
+<div id="pledge-with-combined-functionality">
+<section id="section-6.3.1">
+          <h4 id="name-pledge-with-combined-functi">
+<a href="#section-6.3.1" class="section-number selfRef">6.3.1. </a><a href="#name-pledge-with-combined-functi" class="section-name selfRef">Pledge with Combined Functionality</a>
+          </h4>
+<p id="section-6.3.1-1">Pledges <span class="bcp14">MAY</span> support both initiator and responder mode.<a href="#section-6.3.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.3.1-2">A pledge in initiator mode should listen for announcement messages as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-4.1" class="relref">Section 4.1</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 Upon discovery of a potential registrar, it initiates the bootstrapping to that registrar.
-At the same time (so as to avoid the Slowloris-attack described in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>), it <span class="bcp14">SHOULD</span> also respond to the triggers for responder mode described in this document.<a href="#section-5.7-2" class="pilcrow">¶</a></p>
-<p id="section-5.7-3">Once a pledge with combined functionality has been bootstrapped, it <span class="bcp14">MAY</span> act as client for enrollment of further certificates needed, e.g., using the enrollment protocol of choice.
-If it still acts as server, the defined BRSKI-PRM endpoints to trigger a pledge-enrollment-request (PER) or to provide an enrollment-response can be used for further certificates.<a href="#section-5.7-3" class="pilcrow">¶</a></p>
+At the same time (so as to avoid the Slowloris-attack described in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>), it <span class="bcp14">SHOULD</span> also respond to the triggers for responder mode described in this document.<a href="#section-6.3.1-2" class="pilcrow">¶</a></p>
+<p id="section-6.3.1-3">Once a pledge with combined functionality has been bootstrapped, it <span class="bcp14">MAY</span> act as client for enrollment of further certificates needed, e.g., using the enrollment protocol of choice.
+If it still acts as server, the defined BRSKI-PRM endpoints to trigger a Pledge Enroll-Request (PER) or to provide an Enroll-Response can be used for further certificates.<a href="#section-6.3.1-3" class="pilcrow">¶</a></p>
+</section>
+</div>
 </section>
 </div>
 </section>
 </div>
 <div id="exchanges_uc2">
-<section id="section-6">
-      <h2 id="name-bootstrapping-data-objects-">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-bootstrapping-data-objects-" class="section-name selfRef">Bootstrapping Data Objects and Corresponding Exchanges</a>
+<section id="section-7">
+      <h2 id="name-exchanges-and-artifacts">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-exchanges-and-artifacts" class="section-name selfRef">Exchanges and Artifacts</a>
       </h2>
-<p id="section-6-1">The interaction of the pledge with the Registrar-Agent may be accomplished using different transport means (protocols and/or network technologies).
-This specification utilizes HTTP as transport.
-Alternative transport channels may be CoAP, Bluetooth Low Energy (BLE), or Nearfield Communication (NFC).
-These transport means may differ from, and are independent of, the ones used between the Registrar-Agent and the registrar.
-Transport channel independence is realized by data objects, which are not bound to specific transport security and stay the same across the communication from the pledge via the Registrar-Agent to the registrar..
-Therefore, authenticated self-contained objects (here: signature-wrapped objects) are applied for data exchanges between the pledge and the registrar.<a href="#section-6-1" class="pilcrow">¶</a></p>
-<p id="section-6-2">The Registrar-Agent provides the domain registrar certificate (registrar LDevID certificate) to the pledge to be included in the PVR leaf "agent-provided-proximity-registrar-certificate".
-This enables the registrar to verify that it is the desired registrar for handling the request.<a href="#section-6-2" class="pilcrow">¶</a></p>
-<p id="section-6-3">The registrar certificate may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar.
-In addition, the Registrar-Agent provides agent-signed-data containing the pledge product-serial-number, signed with the private key corresponding to the EE (RegAgt) certificate, as described in <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a>.
-This enables the registrar to verify and log, which Registrar-Agent was in contact with the pledge, when verifying the PVR.<a href="#section-6-3" class="pilcrow">¶</a></p>
-<p id="section-6-4">The registrar <span class="bcp14">MUST</span> provide the EE (RegAgt) certificate identified by the SubjectKeyIdentifier (SKID) in the header of the agent-signed-data from the PVR in its RVR (see also <a href="#pvr-proc-reg" class="auto internal xref">Section 6.2.2</a>.<a href="#section-6-4" class="pilcrow">¶</a></p>
-<p id="section-6-5">The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-certificate" leaf and may assert the PVR as "verified" or "logged".<a href="#section-6-5" class="pilcrow">¶</a></p>
-<p id="section-6-6">In addition, the MASA <span class="bcp14">MAY</span> issue the assertion "agent-proximity" as follows:
-The MASA verifies the signature of the "agent-signed-data" contained in the "prior-signed-voucher-request", based on the provided EE (RegAgt) certificate in the "agent-sign-cert" leaf of the RVR.
+<p id="section-7-1">The interaction of the pledge with the Registrar-Agent may be accomplished using different transports (i.e., protocols and/or network technologies).
+This specification utilizes HTTP as default transport.
+Other specifications may define alternative transports such as CoAP, Bluetooth Low Energy (BLE), or Near Field Communication (NFC).
+These transports may differ from and are independent of the ones used between the Registrar-Agent and the registrar.
+Transport independence is realized through data objects that are not bound to specific transport security and stay the same along the communication path from the pledge via the Registrar-Agent to the registrar.
+Therefore, authenticated self-contained objects (e.g., signature-wrapped JWS objects) are applied for data exchanges between the pledge and the registrar.<a href="#section-7-1" class="pilcrow">¶</a></p>
+<p id="section-7-2">The Registrar-Agent provides the domain registrar EE certificate to the pledge to be included in the PVR leaf "agent-provided-proximity-registrar-certificate".
+This enables the registrar to verify that it is the desired registrar for handling the request.
+The registrar EE certificate may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar.<a href="#section-7-2" class="pilcrow">¶</a></p>
+<p id="section-7-3">In addition, the Registrar-Agent provides "agent-signed-data" containing the pledge product serial number signed with the private key corresponding to the EE certificate of the Registrar-Agent, as described in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.
+This enables the registrar to verify and log, which Registrar-Agent was in contact with the pledge, when verifying the PVR.<a href="#section-7-3" class="pilcrow">¶</a></p>
+<p id="section-7-4">The registrar provides the EE certificate of the Registrar-Agent identified by the SubjectKeyIdentifier (SKID) in the header of the "agent-signed-data" from the PVR in its RVR (see also <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a>).<a href="#section-7-4" class="pilcrow">¶</a></p>
+<p id="section-7-5">The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-certificate" leaf and may assert the PVR as "verified" or "logged".<a href="#section-7-5" class="pilcrow">¶</a></p>
+<p id="section-7-6">TODO[LDevID as EE cert for agent-proximity]
+In addition, the MASA may issue the assertion "agent-proximity" as follows:
+The MASA verifies the signature of the "agent-signed-data" contained in the "prior-signed-voucher-request", based on the provided EE certificate of the Registrar-Agent in the "agent-sign-cert" leaf of the RVR.
 If both can be verified successfully, the MASA can assert "agent-proximity" in the voucher.
 The assertion of "agent-proximity" is similar to the proximity assertion by the MASA when using BRSKI.
-Note that the different assertions do not provide a metric of strength as the security properties are not comparable.<a href="#section-6-6" class="pilcrow">¶</a></p>
-<p id="section-6-7">Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx error status code as described in section 5.6 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-When successful, the voucher will then be supplied via the registrar to the Registrar-Agent.<a href="#section-6-7" class="pilcrow">¶</a></p>
-<p id="section-6-8"><a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> provides an overview of the exchanges detailed in the following sub sections.<a href="#section-6-8" class="pilcrow">¶</a></p>
+Note that the different assertions do not provide a metric of strength as the security properties are not comparable.<a href="#section-7-6" class="pilcrow">¶</a></p>
+<p id="section-7-7">Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx response status codes as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+When successful, the Voucher will then be supplied via the registrar to the Registrar-Agent.<a href="#section-7-7" class="pilcrow">¶</a></p>
+<p id="section-7-8"><a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> provides an overview of the exchanges detailed in the following subsections.<a href="#section-7-8" class="pilcrow">¶</a></p>
 <span id="name-overview-pledge-responder-m"></span><div id="exchangesfig_uc2_all">
 <figure id="figure-4">
-        <div id="section-6-9.1">
-          <div class="alignLeft art-svg artwork" id="section-6-9.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="1088" width="560" viewBox="0 0 560 1088" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
-              <path d="M 8,32 L 8,96" fill="none" stroke="black"></path>
-              <path d="M 32,104 L 32,208" fill="none" stroke="black"></path>
-              <path d="M 32,248 L 32,336" fill="none" stroke="black"></path>
-              <path d="M 32,392 L 32,592" fill="none" stroke="black"></path>
-              <path d="M 32,632 L 32,712" fill="none" stroke="black"></path>
-              <path d="M 32,728 L 32,752" fill="none" stroke="black"></path>
-              <path d="M 32,808 L 32,896" fill="none" stroke="black"></path>
-              <path d="M 32,952 L 32,1072" fill="none" stroke="black"></path>
-              <path d="M 80,32 L 80,96" fill="none" stroke="black"></path>
-              <path d="M 112,32 L 112,96" fill="none" stroke="black"></path>
-              <path d="M 168,104 L 168,208" fill="none" stroke="black"></path>
-              <path d="M 168,256 L 168,336" fill="none" stroke="black"></path>
-              <path d="M 168,384 L 168,592" fill="none" stroke="black"></path>
-              <path d="M 168,624 L 168,704" fill="none" stroke="black"></path>
-              <path d="M 168,736 L 168,752" fill="none" stroke="black"></path>
-              <path d="M 168,816 L 168,896" fill="none" stroke="black"></path>
-              <path d="M 168,960 L 168,1072" fill="none" stroke="black"></path>
-              <path d="M 208,32 L 208,96" fill="none" stroke="black"></path>
-              <path d="M 240,32 L 240,96" fill="none" stroke="black"></path>
-              <path d="M 312,104 L 312,208" fill="none" stroke="black"></path>
-              <path d="M 312,256 L 312,336" fill="none" stroke="black"></path>
-              <path d="M 312,512 L 312,592" fill="none" stroke="black"></path>
-              <path d="M 312,640 L 312,704" fill="none" stroke="black"></path>
-              <path d="M 312,736 L 312,752" fill="none" stroke="black"></path>
-              <path d="M 312,816 L 312,896" fill="none" stroke="black"></path>
-              <path d="M 312,960 L 312,1008" fill="none" stroke="black"></path>
-              <path d="M 312,1040 L 312,1072" fill="none" stroke="black"></path>
-              <path d="M 336,32 L 336,96" fill="none" stroke="black"></path>
-              <path d="M 376,32 L 376,96" fill="none" stroke="black"></path>
-              <path d="M 432,104 L 432,208" fill="none" stroke="black"></path>
-              <path d="M 432,256 L 432,336" fill="none" stroke="black"></path>
-              <path d="M 432,400 L 432,496" fill="none" stroke="black"></path>
-              <path d="M 432,576 L 432,592" fill="none" stroke="black"></path>
-              <path d="M 432,640 L 432,704" fill="none" stroke="black"></path>
-              <path d="M 432,736 L 432,752" fill="none" stroke="black"></path>
-              <path d="M 432,816 L 432,896" fill="none" stroke="black"></path>
-              <path d="M 432,960 L 432,976" fill="none" stroke="black"></path>
-              <path d="M 432,1040 L 432,1072" fill="none" stroke="black"></path>
-              <path d="M 448,32 L 448,96" fill="none" stroke="black"></path>
-              <path d="M 472,32 L 472,96" fill="none" stroke="black"></path>
-              <path d="M 536,104 L 536,208" fill="none" stroke="black"></path>
-              <path d="M 536,256 L 536,336" fill="none" stroke="black"></path>
-              <path d="M 536,400 L 536,512" fill="none" stroke="black"></path>
-              <path d="M 536,560 L 536,592" fill="none" stroke="black"></path>
-              <path d="M 536,640 L 536,704" fill="none" stroke="black"></path>
-              <path d="M 536,736 L 536,752" fill="none" stroke="black"></path>
-              <path d="M 536,816 L 536,896" fill="none" stroke="black"></path>
-              <path d="M 536,960 L 536,1008" fill="none" stroke="black"></path>
-              <path d="M 536,1040 L 536,1072" fill="none" stroke="black"></path>
-              <path d="M 552,32 L 552,96" fill="none" stroke="black"></path>
+        <div id="section-7-9.1">
+          <div class="alignLeft art-svg artwork" id="section-7-9.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="1776" width="560" viewBox="0 0 560 1776" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+              <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+              <path d="M 32,88 L 32,192" fill="none" stroke="black"></path>
+              <path d="M 32,256 L 32,320" fill="none" stroke="black"></path>
+              <path d="M 32,384 L 32,448" fill="none" stroke="black"></path>
+              <path d="M 32,512 L 32,736" fill="none" stroke="black"></path>
+              <path d="M 32,800 L 32,912" fill="none" stroke="black"></path>
+              <path d="M 32,976 L 32,1024" fill="none" stroke="black"></path>
+              <path d="M 32,1088 L 32,1152" fill="none" stroke="black"></path>
+              <path d="M 32,1216 L 32,1280" fill="none" stroke="black"></path>
+              <path d="M 32,1344 L 32,1392" fill="none" stroke="black"></path>
+              <path d="M 32,1456 L 32,1552" fill="none" stroke="black"></path>
+              <path d="M 32,1616 L 32,1648" fill="none" stroke="black"></path>
+              <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+              <path d="M 112,32 L 112,80" fill="none" stroke="black"></path>
+              <path d="M 168,88 L 168,192" fill="none" stroke="black"></path>
+              <path d="M 168,256 L 168,320" fill="none" stroke="black"></path>
+              <path d="M 168,384 L 168,448" fill="none" stroke="black"></path>
+              <path d="M 168,512 L 168,736" fill="none" stroke="black"></path>
+              <path d="M 168,800 L 168,912" fill="none" stroke="black"></path>
+              <path d="M 168,976 L 168,1024" fill="none" stroke="black"></path>
+              <path d="M 168,1088 L 168,1152" fill="none" stroke="black"></path>
+              <path d="M 168,1216 L 168,1280" fill="none" stroke="black"></path>
+              <path d="M 168,1344 L 168,1392" fill="none" stroke="black"></path>
+              <path d="M 168,1456 L 168,1552" fill="none" stroke="black"></path>
+              <path d="M 168,1616 L 168,1648" fill="none" stroke="black"></path>
+              <path d="M 208,32 L 208,80" fill="none" stroke="black"></path>
+              <path d="M 240,32 L 240,80" fill="none" stroke="black"></path>
+              <path d="M 312,88 L 312,192" fill="none" stroke="black"></path>
+              <path d="M 312,256 L 312,320" fill="none" stroke="black"></path>
+              <path d="M 312,384 L 312,448" fill="none" stroke="black"></path>
+              <path d="M 312,512 L 312,528" fill="none" stroke="black"></path>
+              <path d="M 312,624 L 312,736" fill="none" stroke="black"></path>
+              <path d="M 312,800 L 312,912" fill="none" stroke="black"></path>
+              <path d="M 312,976 L 312,1024" fill="none" stroke="black"></path>
+              <path d="M 312,1088 L 312,1152" fill="none" stroke="black"></path>
+              <path d="M 312,1216 L 312,1280" fill="none" stroke="black"></path>
+              <path d="M 312,1344 L 312,1392" fill="none" stroke="black"></path>
+              <path d="M 312,1456 L 312,1520" fill="none" stroke="black"></path>
+              <path d="M 312,1616 L 312,1648" fill="none" stroke="black"></path>
+              <path d="M 336,32 L 336,80" fill="none" stroke="black"></path>
+              <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+              <path d="M 432,88 L 432,192" fill="none" stroke="black"></path>
+              <path d="M 432,256 L 432,320" fill="none" stroke="black"></path>
+              <path d="M 432,384 L 432,448" fill="none" stroke="black"></path>
+              <path d="M 432,512 L 432,624" fill="none" stroke="black"></path>
+              <path d="M 432,720 L 432,736" fill="none" stroke="black"></path>
+              <path d="M 432,800 L 432,912" fill="none" stroke="black"></path>
+              <path d="M 432,976 L 432,1024" fill="none" stroke="black"></path>
+              <path d="M 432,1088 L 432,1152" fill="none" stroke="black"></path>
+              <path d="M 432,1216 L 432,1280" fill="none" stroke="black"></path>
+              <path d="M 432,1344 L 432,1392" fill="none" stroke="black"></path>
+              <path d="M 432,1456 L 432,1488" fill="none" stroke="black"></path>
+              <path d="M 432,1616 L 432,1648" fill="none" stroke="black"></path>
+              <path d="M 448,32 L 448,80" fill="none" stroke="black"></path>
+              <path d="M 472,32 L 472,80" fill="none" stroke="black"></path>
+              <path d="M 536,88 L 536,192" fill="none" stroke="black"></path>
+              <path d="M 536,256 L 536,320" fill="none" stroke="black"></path>
+              <path d="M 536,384 L 536,448" fill="none" stroke="black"></path>
+              <path d="M 536,512 L 536,656" fill="none" stroke="black"></path>
+              <path d="M 536,704 L 536,736" fill="none" stroke="black"></path>
+              <path d="M 536,800 L 536,912" fill="none" stroke="black"></path>
+              <path d="M 536,976 L 536,1024" fill="none" stroke="black"></path>
+              <path d="M 536,1088 L 536,1152" fill="none" stroke="black"></path>
+              <path d="M 536,1216 L 536,1280" fill="none" stroke="black"></path>
+              <path d="M 536,1344 L 536,1392" fill="none" stroke="black"></path>
+              <path d="M 536,1456 L 536,1520" fill="none" stroke="black"></path>
+              <path d="M 536,1616 L 536,1648" fill="none" stroke="black"></path>
+              <path d="M 552,32 L 552,80" fill="none" stroke="black"></path>
               <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
               <path d="M 112,32 L 208,32" fill="none" stroke="black"></path>
               <path d="M 240,32 L 336,32" fill="none" stroke="black"></path>
               <path d="M 376,32 L 448,32" fill="none" stroke="black"></path>
               <path d="M 472,32 L 552,32" fill="none" stroke="black"></path>
-              <path d="M 8,96 L 80,96" fill="none" stroke="black"></path>
-              <path d="M 112,96 L 208,96" fill="none" stroke="black"></path>
-              <path d="M 240,96 L 336,96" fill="none" stroke="black"></path>
-              <path d="M 376,96 L 448,96" fill="none" stroke="black"></path>
-              <path d="M 472,96 L 552,96" fill="none" stroke="black"></path>
+              <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+              <path d="M 112,80 L 208,80" fill="none" stroke="black"></path>
+              <path d="M 240,80 L 336,80" fill="none" stroke="black"></path>
+              <path d="M 376,80 L 448,80" fill="none" stroke="black"></path>
+              <path d="M 472,80 L 552,80" fill="none" stroke="black"></path>
+              <path d="M 40,160 L 160,160" fill="none" stroke="black"></path>
               <path d="M 40,176 L 160,176" fill="none" stroke="black"></path>
-              <path d="M 40,192 L 160,192" fill="none" stroke="black"></path>
-              <path d="M 40,256 L 56,256" fill="none" stroke="black"></path>
-              <path d="M 136,256 L 160,256" fill="none" stroke="black"></path>
-              <path d="M 40,272 L 80,272" fill="none" stroke="black"></path>
-              <path d="M 136,272 L 160,272" fill="none" stroke="black"></path>
-              <path d="M 40,288 L 80,288" fill="none" stroke="black"></path>
+              <path d="M 40,272 L 56,272" fill="none" stroke="black"></path>
+              <path d="M 144,272 L 160,272" fill="none" stroke="black"></path>
+              <path d="M 40,288 L 72,288" fill="none" stroke="black"></path>
               <path d="M 128,288 L 160,288" fill="none" stroke="black"></path>
-              <path d="M 40,320 L 80,320" fill="none" stroke="black"></path>
-              <path d="M 136,320 L 160,320" fill="none" stroke="black"></path>
-              <path d="M 40,336 L 80,336" fill="none" stroke="black"></path>
-              <path d="M 128,336 L 160,336" fill="none" stroke="black"></path>
-              <path d="M 176,400 L 216,400" fill="none" stroke="black"></path>
-              <path d="M 264,400 L 304,400" fill="none" stroke="black"></path>
-              <path d="M 176,448 L 208,448" fill="none" stroke="black"></path>
-              <path d="M 256,448 L 304,448" fill="none" stroke="black"></path>
-              <path d="M 320,512 L 408,512" fill="none" stroke="black"></path>
-              <path d="M 456,512 L 528,512" fill="none" stroke="black"></path>
-              <path d="M 320,560 L 392,560" fill="none" stroke="black"></path>
-              <path d="M 472,560 L 528,560" fill="none" stroke="black"></path>
-              <path d="M 176,576 L 200,576" fill="none" stroke="black"></path>
-              <path d="M 280,576 L 304,576" fill="none" stroke="black"></path>
-              <path d="M 176,640 L 216,640" fill="none" stroke="black"></path>
-              <path d="M 264,640 L 304,640" fill="none" stroke="black"></path>
-              <path d="M 320,656 L 344,656" fill="none" stroke="black"></path>
-              <path d="M 392,656 L 424,656" fill="none" stroke="black"></path>
-              <path d="M 320,672 L 344,672" fill="none" stroke="black"></path>
-              <path d="M 400,672 L 424,672" fill="none" stroke="black"></path>
-              <path d="M 176,688 L 192,688" fill="none" stroke="black"></path>
-              <path d="M 288,688 L 304,688" fill="none" stroke="black"></path>
-              <path d="M 288,736 L 304,736" fill="none" stroke="black"></path>
-              <path d="M 176,752 L 192,752" fill="none" stroke="black"></path>
-              <path d="M 40,816 L 56,816" fill="none" stroke="black"></path>
-              <path d="M 136,816 L 160,816" fill="none" stroke="black"></path>
-              <path d="M 40,832 L 64,832" fill="none" stroke="black"></path>
-              <path d="M 144,832 L 160,832" fill="none" stroke="black"></path>
-              <path d="M 40,848 L 64,848" fill="none" stroke="black"></path>
-              <path d="M 144,848 L 160,848" fill="none" stroke="black"></path>
-              <path d="M 40,864 L 64,864" fill="none" stroke="black"></path>
-              <path d="M 144,864 L 160,864" fill="none" stroke="black"></path>
-              <path d="M 40,880 L 56,880" fill="none" stroke="black"></path>
-              <path d="M 40,896 L 56,896" fill="none" stroke="black"></path>
-              <path d="M 136,896 L 160,896" fill="none" stroke="black"></path>
-              <path d="M 176,960 L 224,960" fill="none" stroke="black"></path>
-              <path d="M 272,960 L 304,960" fill="none" stroke="black"></path>
-              <path d="M 176,976 L 200,976" fill="none" stroke="black"></path>
-              <path d="M 288,976 L 304,976" fill="none" stroke="black"></path>
-              <path d="M 320,992 L 336,992" fill="none" stroke="black"></path>
-              <path d="M 512,992 L 528,992" fill="none" stroke="black"></path>
-              <path d="M 320,1008 L 352,1008" fill="none" stroke="black"></path>
-              <path d="M 504,1008 L 528,1008" fill="none" stroke="black"></path>
-              <path d="M 176,1056 L 200,1056" fill="none" stroke="black"></path>
-              <path d="M 280,1056 L 304,1056" fill="none" stroke="black"></path>
-              <polygon class="arrowhead" points="536,992 524,986.4 524,997.6" fill="black" transform="rotate(0,528,992)"></polygon>
-              <polygon class="arrowhead" points="536,512 524,506.4 524,517.6" fill="black" transform="rotate(0,528,512)"></polygon>
-              <polygon class="arrowhead" points="432,656 420,650.4 420,661.6" fill="black" transform="rotate(0,424,656)"></polygon>
-              <polygon class="arrowhead" points="328,1008 316,1002.4 316,1013.6" fill="black" transform="rotate(180,320,1008)"></polygon>
-              <polygon class="arrowhead" points="328,672 316,666.4 316,677.6" fill="black" transform="rotate(180,320,672)"></polygon>
-              <polygon class="arrowhead" points="328,560 316,554.4 316,565.6" fill="black" transform="rotate(180,320,560)"></polygon>
-              <polygon class="arrowhead" points="312,1056 300,1050.4 300,1061.6" fill="black" transform="rotate(0,304,1056)"></polygon>
-              <polygon class="arrowhead" points="312,976 300,970.4 300,981.6" fill="black" transform="rotate(0,304,976)"></polygon>
-              <polygon class="arrowhead" points="312,960 300,954.4 300,965.6" fill="black" transform="rotate(0,304,960)"></polygon>
-              <polygon class="arrowhead" points="312,736 300,730.4 300,741.6" fill="black" transform="rotate(0,304,736)"></polygon>
-              <polygon class="arrowhead" points="312,640 300,634.4 300,645.6" fill="black" transform="rotate(0,304,640)"></polygon>
-              <polygon class="arrowhead" points="312,448 300,442.4 300,453.6" fill="black" transform="rotate(0,304,448)"></polygon>
-              <polygon class="arrowhead" points="312,400 300,394.4 300,405.6" fill="black" transform="rotate(0,304,400)"></polygon>
-              <polygon class="arrowhead" points="184,960 172,954.4 172,965.6" fill="black" transform="rotate(180,176,960)"></polygon>
-              <polygon class="arrowhead" points="184,752 172,746.4 172,757.6" fill="black" transform="rotate(180,176,752)"></polygon>
-              <polygon class="arrowhead" points="184,688 172,682.4 172,693.6" fill="black" transform="rotate(180,176,688)"></polygon>
-              <polygon class="arrowhead" points="184,576 172,570.4 172,581.6" fill="black" transform="rotate(180,176,576)"></polygon>
-              <polygon class="arrowhead" points="184,400 172,394.4 172,405.6" fill="black" transform="rotate(180,176,400)"></polygon>
-              <polygon class="arrowhead" points="168,896 156,890.4 156,901.6" fill="black" transform="rotate(0,160,896)"></polygon>
-              <polygon class="arrowhead" points="168,848 156,842.4 156,853.6" fill="black" transform="rotate(0,160,848)"></polygon>
-              <polygon class="arrowhead" points="168,816 156,810.4 156,821.6" fill="black" transform="rotate(0,160,816)"></polygon>
-              <polygon class="arrowhead" points="168,336 156,330.4 156,341.6" fill="black" transform="rotate(0,160,336)"></polygon>
-              <polygon class="arrowhead" points="168,288 156,282.4 156,293.6" fill="black" transform="rotate(0,160,288)"></polygon>
-              <polygon class="arrowhead" points="168,256 156,250.4 156,261.6" fill="black" transform="rotate(0,160,256)"></polygon>
-              <polygon class="arrowhead" points="168,192 156,186.4 156,197.6" fill="black" transform="rotate(0,160,192)"></polygon>
-              <polygon class="arrowhead" points="48,880 36,874.4 36,885.6" fill="black" transform="rotate(180,40,880)"></polygon>
-              <polygon class="arrowhead" points="48,864 36,858.4 36,869.6" fill="black" transform="rotate(180,40,864)"></polygon>
-              <polygon class="arrowhead" points="48,832 36,826.4 36,837.6" fill="black" transform="rotate(180,40,832)"></polygon>
-              <polygon class="arrowhead" points="48,816 36,810.4 36,821.6" fill="black" transform="rotate(180,40,816)"></polygon>
-              <polygon class="arrowhead" points="48,320 36,314.4 36,325.6" fill="black" transform="rotate(180,40,320)"></polygon>
+              <path d="M 40,304 L 72,304" fill="none" stroke="black"></path>
+              <path d="M 120,304 L 160,304" fill="none" stroke="black"></path>
+              <path d="M 40,400 L 56,400" fill="none" stroke="black"></path>
+              <path d="M 144,400 L 160,400" fill="none" stroke="black"></path>
+              <path d="M 40,416 L 72,416" fill="none" stroke="black"></path>
+              <path d="M 128,416 L 160,416" fill="none" stroke="black"></path>
+              <path d="M 40,432 L 72,432" fill="none" stroke="black"></path>
+              <path d="M 120,432 L 160,432" fill="none" stroke="black"></path>
+              <path d="M 176,528 L 208,528" fill="none" stroke="black"></path>
+              <path d="M 264,528 L 304,528" fill="none" stroke="black"></path>
+              <path d="M 176,576 L 208,576" fill="none" stroke="black"></path>
+              <path d="M 256,576 L 304,576" fill="none" stroke="black"></path>
+              <path d="M 320,640 L 400,640" fill="none" stroke="black"></path>
+              <path d="M 456,640 L 528,640" fill="none" stroke="black"></path>
+              <path d="M 320,656 L 408,656" fill="none" stroke="black"></path>
+              <path d="M 456,656 L 528,656" fill="none" stroke="black"></path>
+              <path d="M 320,704 L 392,704" fill="none" stroke="black"></path>
+              <path d="M 472,704 L 528,704" fill="none" stroke="black"></path>
+              <path d="M 176,720 L 200,720" fill="none" stroke="black"></path>
+              <path d="M 280,720 L 304,720" fill="none" stroke="black"></path>
+              <path d="M 176,816 L 208,816" fill="none" stroke="black"></path>
+              <path d="M 264,816 L 304,816" fill="none" stroke="black"></path>
+              <path d="M 176,832 L 208,832" fill="none" stroke="black"></path>
+              <path d="M 256,832 L 304,832" fill="none" stroke="black"></path>
+              <path d="M 320,848 L 344,848" fill="none" stroke="black"></path>
+              <path d="M 400,848 L 424,848" fill="none" stroke="black"></path>
+              <path d="M 320,864 L 344,864" fill="none" stroke="black"></path>
+              <path d="M 392,864 L 424,864" fill="none" stroke="black"></path>
+              <path d="M 176,896 L 192,896" fill="none" stroke="black"></path>
+              <path d="M 288,896 L 304,896" fill="none" stroke="black"></path>
+              <path d="M 288,992 L 304,992" fill="none" stroke="black"></path>
+              <path d="M 176,1008 L 192,1008" fill="none" stroke="black"></path>
+              <path d="M 40,1104 L 56,1104" fill="none" stroke="black"></path>
+              <path d="M 136,1104 L 160,1104" fill="none" stroke="black"></path>
+              <path d="M 40,1120 L 64,1120" fill="none" stroke="black"></path>
+              <path d="M 144,1120 L 160,1120" fill="none" stroke="black"></path>
+              <path d="M 40,1136 L 64,1136" fill="none" stroke="black"></path>
+              <path d="M 144,1136 L 160,1136" fill="none" stroke="black"></path>
+              <path d="M 40,1232 L 56,1232" fill="none" stroke="black"></path>
+              <path d="M 136,1232 L 160,1232" fill="none" stroke="black"></path>
+              <path d="M 40,1248 L 64,1248" fill="none" stroke="black"></path>
+              <path d="M 144,1248 L 160,1248" fill="none" stroke="black"></path>
+              <path d="M 40,1264 L 56,1264" fill="none" stroke="black"></path>
+              <path d="M 136,1264 L 160,1264" fill="none" stroke="black"></path>
+              <path d="M 40,1360 L 56,1360" fill="none" stroke="black"></path>
+              <path d="M 40,1376 L 56,1376" fill="none" stroke="black"></path>
+              <path d="M 136,1376 L 160,1376" fill="none" stroke="black"></path>
+              <path d="M 176,1472 L 208,1472" fill="none" stroke="black"></path>
+              <path d="M 264,1472 L 304,1472" fill="none" stroke="black"></path>
+              <path d="M 176,1488 L 200,1488" fill="none" stroke="black"></path>
+              <path d="M 280,1488 L 304,1488" fill="none" stroke="black"></path>
+              <path d="M 320,1504 L 336,1504" fill="none" stroke="black"></path>
+              <path d="M 512,1504 L 528,1504" fill="none" stroke="black"></path>
+              <path d="M 320,1520 L 352,1520" fill="none" stroke="black"></path>
+              <path d="M 504,1520 L 528,1520" fill="none" stroke="black"></path>
+              <path d="M 176,1632 L 200,1632" fill="none" stroke="black"></path>
+              <path d="M 280,1632 L 304,1632" fill="none" stroke="black"></path>
+              <polygon class="arrowhead" points="536,1504 524,1498.4 524,1509.6" fill="black" transform="rotate(0,528,1504)"></polygon>
+              <polygon class="arrowhead" points="536,656 524,650.4 524,661.6" fill="black" transform="rotate(0,528,656)"></polygon>
+              <polygon class="arrowhead" points="536,640 524,634.4 524,645.6" fill="black" transform="rotate(0,528,640)"></polygon>
+              <polygon class="arrowhead" points="432,864 420,858.4 420,869.6" fill="black" transform="rotate(0,424,864)"></polygon>
+              <polygon class="arrowhead" points="432,848 420,842.4 420,853.6" fill="black" transform="rotate(0,424,848)"></polygon>
+              <polygon class="arrowhead" points="328,1520 316,1514.4 316,1525.6" fill="black" transform="rotate(180,320,1520)"></polygon>
+              <polygon class="arrowhead" points="328,848 316,842.4 316,853.6" fill="black" transform="rotate(180,320,848)"></polygon>
+              <polygon class="arrowhead" points="328,704 316,698.4 316,709.6" fill="black" transform="rotate(180,320,704)"></polygon>
+              <polygon class="arrowhead" points="328,640 316,634.4 316,645.6" fill="black" transform="rotate(180,320,640)"></polygon>
+              <polygon class="arrowhead" points="312,1632 300,1626.4 300,1637.6" fill="black" transform="rotate(0,304,1632)"></polygon>
+              <polygon class="arrowhead" points="312,1488 300,1482.4 300,1493.6" fill="black" transform="rotate(0,304,1488)"></polygon>
+              <polygon class="arrowhead" points="312,1472 300,1466.4 300,1477.6" fill="black" transform="rotate(0,304,1472)"></polygon>
+              <polygon class="arrowhead" points="312,992 300,986.4 300,997.6" fill="black" transform="rotate(0,304,992)"></polygon>
+              <polygon class="arrowhead" points="312,832 300,826.4 300,837.6" fill="black" transform="rotate(0,304,832)"></polygon>
+              <polygon class="arrowhead" points="312,816 300,810.4 300,821.6" fill="black" transform="rotate(0,304,816)"></polygon>
+              <polygon class="arrowhead" points="312,576 300,570.4 300,581.6" fill="black" transform="rotate(0,304,576)"></polygon>
+              <polygon class="arrowhead" points="312,528 300,522.4 300,533.6" fill="black" transform="rotate(0,304,528)"></polygon>
+              <polygon class="arrowhead" points="184,1472 172,1466.4 172,1477.6" fill="black" transform="rotate(180,176,1472)"></polygon>
+              <polygon class="arrowhead" points="184,1008 172,1002.4 172,1013.6" fill="black" transform="rotate(180,176,1008)"></polygon>
+              <polygon class="arrowhead" points="184,896 172,890.4 172,901.6" fill="black" transform="rotate(180,176,896)"></polygon>
+              <polygon class="arrowhead" points="184,816 172,810.4 172,821.6" fill="black" transform="rotate(180,176,816)"></polygon>
+              <polygon class="arrowhead" points="184,720 172,714.4 172,725.6" fill="black" transform="rotate(180,176,720)"></polygon>
+              <polygon class="arrowhead" points="184,528 172,522.4 172,533.6" fill="black" transform="rotate(180,176,528)"></polygon>
+              <polygon class="arrowhead" points="168,1376 156,1370.4 156,1381.6" fill="black" transform="rotate(0,160,1376)"></polygon>
+              <polygon class="arrowhead" points="168,1264 156,1258.4 156,1269.6" fill="black" transform="rotate(0,160,1264)"></polygon>
+              <polygon class="arrowhead" points="168,1232 156,1226.4 156,1237.6" fill="black" transform="rotate(0,160,1232)"></polygon>
+              <polygon class="arrowhead" points="168,1136 156,1130.4 156,1141.6" fill="black" transform="rotate(0,160,1136)"></polygon>
+              <polygon class="arrowhead" points="168,1104 156,1098.4 156,1109.6" fill="black" transform="rotate(0,160,1104)"></polygon>
+              <polygon class="arrowhead" points="168,432 156,426.4 156,437.6" fill="black" transform="rotate(0,160,432)"></polygon>
+              <polygon class="arrowhead" points="168,400 156,394.4 156,405.6" fill="black" transform="rotate(0,160,400)"></polygon>
+              <polygon class="arrowhead" points="168,304 156,298.4 156,309.6" fill="black" transform="rotate(0,160,304)"></polygon>
+              <polygon class="arrowhead" points="168,272 156,266.4 156,277.6" fill="black" transform="rotate(0,160,272)"></polygon>
+              <polygon class="arrowhead" points="168,176 156,170.4 156,181.6" fill="black" transform="rotate(0,160,176)"></polygon>
+              <polygon class="arrowhead" points="48,1360 36,1354.4 36,1365.6" fill="black" transform="rotate(180,40,1360)"></polygon>
+              <polygon class="arrowhead" points="48,1248 36,1242.4 36,1253.6" fill="black" transform="rotate(180,40,1248)"></polygon>
+              <polygon class="arrowhead" points="48,1232 36,1226.4 36,1237.6" fill="black" transform="rotate(180,40,1232)"></polygon>
+              <polygon class="arrowhead" points="48,1120 36,1114.4 36,1125.6" fill="black" transform="rotate(180,40,1120)"></polygon>
+              <polygon class="arrowhead" points="48,1104 36,1098.4 36,1109.6" fill="black" transform="rotate(180,40,1104)"></polygon>
+              <polygon class="arrowhead" points="48,416 36,410.4 36,421.6" fill="black" transform="rotate(180,40,416)"></polygon>
+              <polygon class="arrowhead" points="48,400 36,394.4 36,405.6" fill="black" transform="rotate(180,40,400)"></polygon>
+              <polygon class="arrowhead" points="48,288 36,282.4 36,293.6" fill="black" transform="rotate(180,40,288)"></polygon>
               <polygon class="arrowhead" points="48,272 36,266.4 36,277.6" fill="black" transform="rotate(180,40,272)"></polygon>
-              <polygon class="arrowhead" points="48,256 36,250.4 36,261.6" fill="black" transform="rotate(180,40,256)"></polygon>
-              <polygon class="arrowhead" points="48,176 36,170.4 36,181.6" fill="black" transform="rotate(180,40,176)"></polygon>
-              <path class="jump" d="M 32,728 C 26,728 26,712 32,712" fill="none" stroke="black"></path>
-              <circle cx="168" cy="384" r="6" class="opendot" fill="white" stroke="black"></circle>
-              <circle cx="168" cy="624" r="6" class="opendot" fill="white" stroke="black"></circle>
+              <polygon class="arrowhead" points="48,160 36,154.4 36,165.6" fill="black" transform="rotate(180,40,160)"></polygon>
               <g class="text">
                 <text x="44" y="52">Pledge</text>
                 <text x="164" y="52">Registrar-</text>
                 <text x="276" y="52">Domain</text>
                 <text x="412" y="52">Domain</text>
-                <text x="508" y="52">Vendor</text>
+                <text x="500" y="52">MASA</text>
                 <text x="144" y="68">Agent</text>
                 <text x="288" y="68">Registrar</text>
                 <text x="396" y="68">CA</text>
-                <text x="512" y="68">Service</text>
-                <text x="156" y="84">(RegAgt)</text>
-                <text x="280" y="84">(JRC)</text>
-                <text x="508" y="84">(MASA)</text>
-                <text x="492" y="116">Internet</text>
-                <text x="92" y="132">discover</text>
-                <text x="92" y="148">pledge</text>
-                <text x="60" y="164">mDNS</text>
-                <text x="104" y="164">query</text>
-                <text x="40" y="244">(1)</text>
-                <text x="88" y="244">trigger</text>
-                <text x="136" y="244">PVR</text>
-                <text x="180" y="244">(tPVR)</text>
-                <text x="224" y="244">and</text>
-                <text x="256" y="244">PER</text>
-                <text x="300" y="244">(tPER)</text>
-                <text x="372" y="244">generation</text>
-                <text x="428" y="244">on</text>
-                <text x="468" y="244">pledge</text>
-                <text x="76" y="260">opt.</text>
-                <text x="112" y="260">TLS</text>
-                <text x="108" y="276">tPVR</text>
-                <text x="104" y="292">PVR</text>
-                <text x="108" y="324">tPER</text>
-                <text x="104" y="340">PER</text>
-                <text x="32" y="356">~</text>
-                <text x="168" y="356">~</text>
-                <text x="312" y="356">~</text>
-                <text x="432" y="356">~</text>
-                <text x="536" y="356">~</text>
-                <text x="40" y="388">(2)</text>
-                <text x="88" y="388">provide</text>
-                <text x="136" y="388">PVR</text>
-                <text x="160" y="388">t</text>
-                <text x="236" y="388">infrastructure</text>
-                <text x="240" y="404">TLS</text>
-                <text x="312" y="404">|</text>
-                <text x="276" y="420">[Reg-Agt</text>
-                <text x="368" y="420">authenticated</text>
-                <text x="264" y="436">and</text>
-                <text x="332" y="436">authorized?]</text>
-                <text x="232" y="452">PVR</text>
-                <text x="312" y="452">|</text>
-                <text x="276" y="468">[Reg-Agt</text>
-                <text x="364" y="468">authorized?]</text>
-                <text x="272" y="484">[accept</text>
-                <text x="340" y="484">device?]</text>
-                <text x="276" y="500">[contact</text>
-                <text x="344" y="500">vendor]</text>
-                <text x="432" y="516">RVR</text>
-                <text x="436" y="532">[extract</text>
-                <text x="512" y="532">DomainID]</text>
-                <text x="432" y="548">[update</text>
-                <text x="488" y="548">audit</text>
-                <text x="532" y="548">log]</text>
-                <text x="432" y="564">Voucher</text>
-                <text x="240" y="580">Voucher</text>
-                <text x="40" y="628">(2)</text>
-                <text x="88" y="628">provide</text>
-                <text x="136" y="628">PER</text>
-                <text x="160" y="628">t</text>
-                <text x="236" y="628">infrastructure</text>
-                <text x="240" y="644">PER</text>
-                <text x="368" y="660">CSR</text>
-                <text x="372" y="676">Cert</text>
-                <text x="240" y="692">Enroll-Resp</text>
-                <text x="44" y="724">2)</text>
-                <text x="80" y="724">query</text>
-                <text x="136" y="724">cACerts</text>
-                <text x="188" y="724">from</text>
-                <text x="268" y="724">infrastructure</text>
-                <text x="180" y="740">--</text>
-                <text x="236" y="740">cACert-Req</text>
-                <text x="256" y="756">cACert-Resp--</text>
-                <text x="32" y="772">~</text>
-                <text x="168" y="772">~</text>
-                <text x="312" y="772">~</text>
-                <text x="432" y="772">~</text>
-                <text x="536" y="772">~</text>
-                <text x="40" y="804">(3)</text>
-                <text x="88" y="804">provide</text>
-                <text x="152" y="804">voucher</text>
-                <text x="200" y="804">and</text>
-                <text x="264" y="804">certificate</text>
-                <text x="328" y="804">and</text>
-                <text x="376" y="804">collect</text>
-                <text x="436" y="804">status</text>
-                <text x="484" y="804">info</text>
-                <text x="76" y="820">opt.</text>
-                <text x="112" y="820">TLS</text>
-                <text x="104" y="836">Voucher</text>
-                <text x="104" y="852">vStatus</text>
-                <text x="104" y="868">cACerts</text>
-                <text x="112" y="884">Enroll-Resp--</text>
-                <text x="96" y="900">eStatus</text>
-                <text x="32" y="916">~</text>
-                <text x="168" y="916">~</text>
-                <text x="312" y="916">~</text>
-                <text x="432" y="916">~</text>
-                <text x="536" y="916">~</text>
-                <text x="40" y="948">(4)</text>
-                <text x="88" y="948">provide</text>
-                <text x="152" y="948">voucher</text>
-                <text x="212" y="948">status</text>
-                <text x="256" y="948">and</text>
-                <text x="300" y="948">enroll</text>
-                <text x="356" y="948">status</text>
-                <text x="396" y="948">to</text>
-                <text x="448" y="948">registrar</text>
-                <text x="248" y="964">TLS</text>
-                <text x="248" y="980">vStatus</text>
-                <text x="360" y="996">req</text>
-                <text x="404" y="996">device</text>
-                <text x="456" y="996">audit</text>
-                <text x="496" y="996">log</text>
-                <text x="388" y="1012">device</text>
-                <text x="440" y="1012">audit</text>
-                <text x="480" y="1012">log</text>
-                <text x="288" y="1028">[verify</text>
-                <text x="344" y="1028">audit</text>
-                <text x="388" y="1028">log]</text>
-                <text x="240" y="1060">eStatus</text>
+                <text x="492" y="100">Internet</text>
+                <text x="92" y="116">discover</text>
+                <text x="92" y="132">pledge</text>
+                <text x="60" y="148">mDNS</text>
+                <text x="104" y="148">query</text>
+                <text x="32" y="212">~</text>
+                <text x="168" y="212">~</text>
+                <text x="312" y="212">~</text>
+                <text x="432" y="212">~</text>
+                <text x="536" y="212">~</text>
+                <text x="40" y="228">(1)</text>
+                <text x="88" y="228">Trigger</text>
+                <text x="148" y="228">Pledge</text>
+                <text x="240" y="228">Voucher-Request</text>
+                <text x="32" y="244">~</text>
+                <text x="168" y="244">~</text>
+                <text x="312" y="244">~</text>
+                <text x="432" y="244">~</text>
+                <text x="536" y="244">~</text>
+                <text x="84" y="276">opt.</text>
+                <text x="120" y="276">TLS</text>
+                <text x="100" y="292">tPVR</text>
+                <text x="96" y="308">PVR</text>
+                <text x="32" y="340">~</text>
+                <text x="168" y="340">~</text>
+                <text x="312" y="340">~</text>
+                <text x="432" y="340">~</text>
+                <text x="536" y="340">~</text>
+                <text x="40" y="356">(2)</text>
+                <text x="88" y="356">Trigger</text>
+                <text x="148" y="356">Pledge</text>
+                <text x="236" y="356">Enroll-Request</text>
+                <text x="32" y="372">~</text>
+                <text x="168" y="372">~</text>
+                <text x="312" y="372">~</text>
+                <text x="432" y="372">~</text>
+                <text x="536" y="372">~</text>
+                <text x="84" y="404">opt.</text>
+                <text x="120" y="404">TLS</text>
+                <text x="100" y="420">tPER</text>
+                <text x="96" y="436">PER</text>
+                <text x="32" y="468">~</text>
+                <text x="168" y="468">~</text>
+                <text x="312" y="468">~</text>
+                <text x="432" y="468">~</text>
+                <text x="536" y="468">~</text>
+                <text x="40" y="484">(3)</text>
+                <text x="88" y="484">Request</text>
+                <text x="152" y="484">Voucher</text>
+                <text x="204" y="484">from</text>
+                <text x="240" y="484">the</text>
+                <text x="296" y="484">Registrar</text>
+                <text x="32" y="500">~</text>
+                <text x="168" y="500">~</text>
+                <text x="312" y="500">~</text>
+                <text x="432" y="500">~</text>
+                <text x="536" y="500">~</text>
+                <text x="236" y="532">mTLS</text>
+                <text x="308" y="548">[Registrar-Agent</text>
+                <text x="308" y="564">authenticated&amp;authorized?]</text>
+                <text x="232" y="580">PVR</text>
+                <text x="312" y="580">|</text>
+                <text x="272" y="596">[accept</text>
+                <text x="340" y="596">device?]</text>
+                <text x="276" y="612">[contact</text>
+                <text x="344" y="612">vendor]</text>
+                <text x="428" y="644">mTLS</text>
+                <text x="432" y="660">RVR</text>
+                <text x="436" y="676">[extract</text>
+                <text x="512" y="676">DomainID]</text>
+                <text x="432" y="692">[update</text>
+                <text x="488" y="692">audit</text>
+                <text x="532" y="692">log]</text>
+                <text x="432" y="708">Voucher</text>
+                <text x="240" y="724">Voucher</text>
+                <text x="32" y="756">~</text>
+                <text x="168" y="756">~</text>
+                <text x="312" y="756">~</text>
+                <text x="432" y="756">~</text>
+                <text x="536" y="756">~</text>
+                <text x="40" y="772">(4)</text>
+                <text x="84" y="772">Supply</text>
+                <text x="128" y="772">PER</text>
+                <text x="156" y="772">to</text>
+                <text x="208" y="772">Registrar</text>
+                <text x="32" y="788">~</text>
+                <text x="168" y="788">~</text>
+                <text x="312" y="788">~</text>
+                <text x="432" y="788">~</text>
+                <text x="536" y="788">~</text>
+                <text x="236" y="820">mTLS</text>
+                <text x="232" y="836">PER</text>
+                <text x="372" y="852">mTLS</text>
+                <text x="368" y="868">RER</text>
+                <text x="348" y="884">&lt;-Enroll</text>
+                <text x="408" y="884">Resp-</text>
+                <text x="220" y="900">Enroll</text>
+                <text x="268" y="900">Resp</text>
+                <text x="32" y="932">~</text>
+                <text x="168" y="932">~</text>
+                <text x="312" y="932">~</text>
+                <text x="432" y="932">~</text>
+                <text x="536" y="932">~</text>
+                <text x="40" y="948">(5)</text>
+                <text x="88" y="948">Request</text>
+                <text x="132" y="948">CA</text>
+                <text x="196" y="948">Certificates</text>
+                <text x="32" y="964">~</text>
+                <text x="168" y="964">~</text>
+                <text x="312" y="964">~</text>
+                <text x="432" y="964">~</text>
+                <text x="536" y="964">~</text>
+                <text x="180" y="996">--</text>
+                <text x="236" y="996">cACert-Req</text>
+                <text x="256" y="1012">cACert-Resp--</text>
+                <text x="32" y="1044">~</text>
+                <text x="168" y="1044">~</text>
+                <text x="312" y="1044">~</text>
+                <text x="432" y="1044">~</text>
+                <text x="536" y="1044">~</text>
+                <text x="40" y="1060">(6)</text>
+                <text x="84" y="1060">Supply</text>
+                <text x="144" y="1060">Voucher</text>
+                <text x="188" y="1060">to</text>
+                <text x="228" y="1060">Pledge</text>
+                <text x="32" y="1076">~</text>
+                <text x="168" y="1076">~</text>
+                <text x="312" y="1076">~</text>
+                <text x="432" y="1076">~</text>
+                <text x="536" y="1076">~</text>
+                <text x="76" y="1108">opt.</text>
+                <text x="112" y="1108">TLS</text>
+                <text x="104" y="1124">Voucher</text>
+                <text x="104" y="1140">vStatus</text>
+                <text x="32" y="1172">~</text>
+                <text x="168" y="1172">~</text>
+                <text x="312" y="1172">~</text>
+                <text x="432" y="1172">~</text>
+                <text x="536" y="1172">~</text>
+                <text x="40" y="1188">(7)</text>
+                <text x="84" y="1188">Supply</text>
+                <text x="124" y="1188">CA</text>
+                <text x="188" y="1188">certificates</text>
+                <text x="252" y="1188">to</text>
+                <text x="292" y="1188">Pledge</text>
+                <text x="32" y="1204">~</text>
+                <text x="168" y="1204">~</text>
+                <text x="312" y="1204">~</text>
+                <text x="432" y="1204">~</text>
+                <text x="536" y="1204">~</text>
+                <text x="76" y="1236">opt.</text>
+                <text x="112" y="1236">TLS</text>
+                <text x="104" y="1252">cACerts</text>
+                <text x="96" y="1268">cACerts</text>
+                <text x="32" y="1300">~</text>
+                <text x="168" y="1300">~</text>
+                <text x="312" y="1300">~</text>
+                <text x="432" y="1300">~</text>
+                <text x="536" y="1300">~</text>
+                <text x="40" y="1316">(8)</text>
+                <text x="84" y="1316">Supply</text>
+                <text x="176" y="1316">Enroll-Response</text>
+                <text x="252" y="1316">to</text>
+                <text x="292" y="1316">Pledge</text>
+                <text x="32" y="1332">~</text>
+                <text x="168" y="1332">~</text>
+                <text x="312" y="1332">~</text>
+                <text x="432" y="1332">~</text>
+                <text x="536" y="1332">~</text>
+                <text x="84" y="1364">Enroll</text>
+                <text x="140" y="1364">Resp--</text>
+                <text x="96" y="1380">eStatus</text>
+                <text x="32" y="1412">~</text>
+                <text x="168" y="1412">~</text>
+                <text x="312" y="1412">~</text>
+                <text x="432" y="1412">~</text>
+                <text x="536" y="1412">~</text>
+                <text x="40" y="1428">(9)</text>
+                <text x="88" y="1428">Voucher</text>
+                <text x="148" y="1428">Status</text>
+                <text x="216" y="1428">Telemetry</text>
+                <text x="32" y="1444">~</text>
+                <text x="168" y="1444">~</text>
+                <text x="312" y="1444">~</text>
+                <text x="432" y="1444">~</text>
+                <text x="536" y="1444">~</text>
+                <text x="236" y="1476">mTLS</text>
+                <text x="240" y="1492">vStatus</text>
+                <text x="360" y="1508">req</text>
+                <text x="404" y="1508">device</text>
+                <text x="456" y="1508">audit</text>
+                <text x="496" y="1508">log</text>
+                <text x="388" y="1524">device</text>
+                <text x="440" y="1524">audit</text>
+                <text x="480" y="1524">log</text>
+                <text x="288" y="1540">[verify</text>
+                <text x="344" y="1540">audit</text>
+                <text x="388" y="1540">log]</text>
+                <text x="312" y="1556">|</text>
+                <text x="432" y="1556">|</text>
+                <text x="536" y="1556">|</text>
+                <text x="32" y="1572">~</text>
+                <text x="168" y="1572">~</text>
+                <text x="312" y="1572">~</text>
+                <text x="432" y="1572">~</text>
+                <text x="536" y="1572">~</text>
+                <text x="44" y="1588">(10)</text>
+                <text x="92" y="1588">Enroll</text>
+                <text x="148" y="1588">Status</text>
+                <text x="216" y="1588">Telemetry</text>
+                <text x="32" y="1604">~</text>
+                <text x="168" y="1604">~</text>
+                <text x="312" y="1604">~</text>
+                <text x="432" y="1604">~</text>
+                <text x="536" y="1604">~</text>
+                <text x="240" y="1636">eStatus</text>
+                <text x="32" y="1668">~</text>
+                <text x="168" y="1668">~</text>
+                <text x="312" y="1668">~</text>
+                <text x="432" y="1668">~</text>
+                <text x="536" y="1668">~</text>
+                <text x="44" y="1684">(11)</text>
+                <text x="88" y="1684">Query</text>
+                <text x="140" y="1684">Pledge</text>
+                <text x="196" y="1684">Status</text>
+                <text x="32" y="1700">~</text>
+                <text x="168" y="1700">~</text>
+                <text x="312" y="1700">~</text>
+                <text x="432" y="1700">~</text>
+                <text x="536" y="1700">~</text>
+                <text x="32" y="1716">|</text>
+                <text x="168" y="1716">|</text>
+                <text x="312" y="1716">|</text>
+                <text x="432" y="1716">|</text>
+                <text x="536" y="1716">|</text>
+                <text x="44" y="1732">TODO</text>
+                <text x="32" y="1748">|</text>
+                <text x="168" y="1748">|</text>
+                <text x="312" y="1748">|</text>
+                <text x="432" y="1748">|</text>
+                <text x="536" y="1748">|</text>
+                <text x="32" y="1764">~</text>
+                <text x="168" y="1764">~</text>
+                <text x="312" y="1764">~</text>
+                <text x="432" y="1764">~</text>
+                <text x="536" y="1764">~</text>
               </g>
-            </svg><a href="#section-6-9.1.1" class="pilcrow">¶</a>
+            </svg><a href="#section-7-9.1.1" class="pilcrow">¶</a>
 </div>
 </div>
 <figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
 <a href="#name-overview-pledge-responder-m" class="selfRef">Overview pledge-responder-mode exchanges</a>
         </figcaption></figure>
 </div>
-<p id="section-6-10">The following sub sections split the interactions shown in <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> between the different components into:<a href="#section-6-10" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-6-11">
-<li id="section-6-11.1">
-          <p id="section-6-11.1.1"><a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a> describes the request object acquisition by the Registrar-Agent from pledge.<a href="#section-6-11.1.1" class="pilcrow">¶</a></p>
+<p id="section-7-10">TODO[where general status req/res]<a href="#section-7-10" class="pilcrow">¶</a></p>
+<p id="section-7-11">The following sub sections split the interactions shown in <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> between the different components into:<a href="#section-7-11" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-7-12">
+<li id="section-7-12.1">
+          <p id="section-7-12.1.1"><a href="#tpvr" class="auto internal xref">Section 7.1</a> describes the request object acquisition by the Registrar-Agent from pledge.<a href="#section-7-12.1.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-6-11.2">
-          <p id="section-6-11.2.1"><a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a> describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA and the domain CA including the response object processing by these entities.<a href="#section-6-11.2.1" class="pilcrow">¶</a></p>
+        <li id="section-7-12.2">
+          <p id="section-7-12.2.1"><a href="#tper" class="auto internal xref">Section 7.2</a> TODO<a href="#section-7-12.2.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-6-11.3">
-          <p id="section-6-11.3.1"><a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a> describes the supply of response objects between the Registrar-Agent and the pledge including the status information.<a href="#section-6-11.3.1" class="pilcrow">¶</a></p>
+        <li id="section-7-12.3">
+          <p id="section-7-12.3.1"><a href="#pvr" class="auto internal xref">Section 7.3</a> describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA and the domain CA including the response object processing by these entities.<a href="#section-7-12.3.1" class="pilcrow">¶</a></p>
 </li>
-        <li id="section-6-11.4">
-          <p id="section-6-11.4.1"><a href="#exchanges_uc2_5" class="auto internal xref">Section 6.4</a> describes the general status handling and addresses corresponding exchanges between the Registrar-Agent and the registrar.<a href="#section-6-11.4.1" class="pilcrow">¶</a></p>
+        <li id="section-7-12.4">
+          <p id="section-7-12.4.1"><a href="#voucher" class="auto internal xref">Section 7.6</a> describes the supply of the Voucher from the Registrar-Agent to the pledge including the returned status information.<a href="#section-7-12.4.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-7-12.5">
+          <p id="section-7-12.5.1"><a href="#enroll_response" class="auto internal xref">Section 7.8</a> describes the supply of the Enroll Reponse from the Registrar-Agent to the pledge including the returned status information.<a href="#section-7-12.5.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-7-12.6">
+          <p id="section-7-12.6.1"><a href="#vstatus" class="auto internal xref">Section 7.9</a> and <a href="#estatus" class="auto internal xref">Section 7.10</a> describe the general status handling and addresses corresponding exchanges between the Registrar-Agent and the registrar.<a href="#section-7-12.6.1" class="pilcrow">¶</a></p>
 </li>
       </ol>
-<div id="exchanges_uc2_1">
-<section id="section-6.1">
-        <h3 id="name-request-objects-acquisition">
-<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-request-objects-acquisition" class="section-name selfRef">Request Objects Acquisition by Registrar-Agent from Pledge</a>
+<div id="tpvr">
+<section id="section-7.1">
+        <h3 id="name-trigger-pledge-voucher-requ">
+<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-trigger-pledge-voucher-requ" class="section-name selfRef">Trigger Pledge Voucher-Request</a>
         </h3>
-<p id="section-6.1-1">The following description assumes that the Registrar-Agent has already discovered the pledge.
-This may be done as described in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 5.6.2</a> and <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> based on DNS-SD or similar.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
-<p id="section-6.1-2">The focus is on the exchange of signature-wrapped objects using endpoints defined for the pledge in <a href="#pledge_ep" class="auto internal xref">Section 5.5</a>.<a href="#section-6.1-2" class="pilcrow">¶</a></p>
-<p id="section-6.1-3">Preconditions:<a href="#section-6.1-3" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-6.1-4.1">
-            <p id="section-6.1-4.1.1">Pledge: possesses IDevID<a href="#section-6.1-4.1.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="normal" id="section-6.1-4.2">
-            <p id="section-6.1-4.2.1">Registrar-Agent:<a href="#section-6.1-4.2.1" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-6.1-4.2.2.1">
-                <p id="section-6.1-4.2.2.1.1">possesses own credentials (EE (RegAgt) certificate and corresponding private key) for the registrar domain.<a href="#section-6.1-4.2.2.1.1" class="pilcrow">¶</a></p>
-</li>
-              <li class="normal" id="section-6.1-4.2.2.2">
-                <p id="section-6.1-4.2.2.2.1"><span class="bcp14">MAY</span> possess the IDevID CA certificate of the pledge vendor/manufacturer to validate IDevID certificate on returned PVR or in case of TLS usage for pledge communication.
-The distribution of IDevID CA certificates to the Registrar-Agent is out of scope of this document and may be done by a manual configuration.
-In addition, the Registrar-Agent <span class="bcp14">SHOULD</span> know the product-serial-number(s) of the pledge(s) to be bootstrapped.
-The Registrar-Agent <span class="bcp14">MAY</span> be provided with the product-serial-number(s) in different ways:<a href="#section-6.1-4.2.2.2.1" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-6.1-4.2.2.2.2.1">
-                    <p id="section-6.1-4.2.2.2.2.1.1">configured, e.g., as a list of pledges to be bootstrapped via QR code scanning<a href="#section-6.1-4.2.2.2.2.1.1" class="pilcrow">¶</a></p>
-</li>
-                  <li class="normal" id="section-6.1-4.2.2.2.2.2">
-                    <p id="section-6.1-4.2.2.2.2.2.1">discovered by using standard approaches like DNS-SD with mDNS as described in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 5.6.2</a><a href="#section-6.1-4.2.2.2.2.2.1" class="pilcrow">¶</a></p>
-</li>
-                  <li class="normal" id="section-6.1-4.2.2.2.2.3">
-                    <p id="section-6.1-4.2.2.2.2.3.1">discovered by using a manufacturer specific approach, e.g., RF beacons.
-If the product-serial-number(s) are not known in advance, the Registrar-Agent cannot perform a distinct triggering of pledges but and triggers  all pledges discovered .<a href="#section-6.1-4.2.2.2.2.3.1" class="pilcrow">¶</a></p>
-</li>
-                </ul>
-</li>
-            </ul>
-<p id="section-6.1-4.2.3">
-The Registrar-Agent <span class="bcp14">SHOULD</span> have synchronized time.<a href="#section-6.1-4.2.3" class="pilcrow">¶</a></p>
-</li>
-          <li class="normal" id="section-6.1-4.3">
-            <p id="section-6.1-4.3.1">Registrar (same as in BRSKI): possesses/trusts IDevID CA certificate and has own registrar EE credentials.<a href="#section-6.1-4.3.1" class="pilcrow">¶</a></p>
-</li>
-        </ul>
-<span id="name-request-collection-registra"></span><div id="exchangesfig_uc2_1">
-<figure id="figure-5">
-          <div id="section-6.1-5.1">
-            <div class="alignLeft art-svg artwork" id="section-6.1-5.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="352" width="576" viewBox="0 0 576 352" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
-                <path d="M 8,32 L 8,96" fill="none" stroke="black"></path>
-                <path d="M 40,104 L 40,336" fill="none" stroke="black"></path>
-                <path d="M 80,32 L 80,96" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,96" fill="none" stroke="black"></path>
-                <path d="M 424,104 L 424,336" fill="none" stroke="black"></path>
-                <path d="M 472,32 L 472,96" fill="none" stroke="black"></path>
-                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 472,32" fill="none" stroke="black"></path>
-                <path d="M 8,96 L 80,96" fill="none" stroke="black"></path>
-                <path d="M 376,96 L 472,96" fill="none" stroke="black"></path>
-                <path d="M 48,144 L 64,144" fill="none" stroke="black"></path>
-                <path d="M 352,144 L 416,144" fill="none" stroke="black"></path>
-                <path d="M 48,176 L 72,176" fill="none" stroke="black"></path>
-                <path d="M 336,176 L 416,176" fill="none" stroke="black"></path>
-                <path d="M 48,240 L 80,240" fill="none" stroke="black"></path>
-                <path d="M 280,240 L 416,240" fill="none" stroke="black"></path>
-                <path d="M 48,272 L 88,272" fill="none" stroke="black"></path>
-                <path d="M 376,272 L 416,272" fill="none" stroke="black"></path>
-                <path d="M 48,320 L 88,320" fill="none" stroke="black"></path>
-                <path d="M 312,320 L 416,320" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="424,320 412,314.4 412,325.6" fill="black" transform="rotate(0,416,320)"></polygon>
-                <polygon class="arrowhead" points="424,240 412,234.4 412,245.6" fill="black" transform="rotate(0,416,240)"></polygon>
-                <polygon class="arrowhead" points="56,272 44,266.4 44,277.6" fill="black" transform="rotate(180,48,272)"></polygon>
-                <polygon class="arrowhead" points="56,176 44,170.4 44,181.6" fill="black" transform="rotate(180,48,176)"></polygon>
-                <polygon class="arrowhead" points="56,144 44,138.4 44,149.6" fill="black" transform="rotate(180,48,144)"></polygon>
-                <g class="text">
-                  <text x="44" y="52">Pledge</text>
-                  <text x="428" y="52">Registrar-</text>
-                  <text x="408" y="68">Agent</text>
-                  <text x="420" y="84">(RegAgt)</text>
-                  <text x="456" y="116">-create</text>
-                  <text x="504" y="132">agent-signed-data</text>
-                  <text x="108" y="148">optional</text>
-                  <text x="184" y="148">establish</text>
-                  <text x="240" y="148">TLS</text>
-                  <text x="300" y="148">connection</text>
-                  <text x="112" y="180">trigger</text>
-                  <text x="236" y="180">pledge-voucher-request</text>
-                  <text x="244" y="196">-agent-provided-proximity-registrar-cert</text>
-                  <text x="156" y="212">-agent-signed-data</text>
-                  <text x="180" y="244">pledge-voucher-request</text>
-                  <text x="452" y="244">-store</text>
-                  <text x="496" y="244">PVR</text>
-                  <text x="128" y="276">trigger</text>
-                  <text x="264" y="276">pledge-enrollment-request</text>
-                  <text x="128" y="292">(empty)</text>
-                  <text x="200" y="324">pledge-enrollment-request</text>
-                  <text x="452" y="324">-store</text>
-                  <text x="504" y="324">(PER)</text>
-                </g>
-              </svg><a href="#section-6.1-5.1.1" class="pilcrow">¶</a>
-</div>
-</div>
-<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
-<a href="#name-request-collection-registra" class="selfRef">Request collection (Registrar-Agent - pledge)</a>
-          </figcaption></figure>
-</div>
-<p id="section-6.1-6">TLS <span class="bcp14">MAY</span> be optionally used to provide privacy for the interaction between the Registrar-Agent and the pledge, see <a href="#pledgehttps" class="auto internal xref">Appendix B</a>.<a href="#section-6.1-6" class="pilcrow">¶</a></p>
-<p id="section-6.1-7">Note: The Registrar-Agent may trigger the pledge for the PVR or the PER or both. It is expected that this will be aligned with a service technician workflow, visiting and installing each pledge.<a href="#section-6.1-7" class="pilcrow">¶</a></p>
-<div id="pvrt">
-<section id="section-6.1.1">
-          <h4 id="name-pledge-voucher-request-pvr-">
-<a href="#section-6.1.1" class="section-number selfRef">6.1.1. </a><a href="#name-pledge-voucher-request-pvr-" class="section-name selfRef">Pledge-Voucher-Request (PVR) - Trigger</a>
+<p id="section-7.1-1">This exchange assumes that the Registrar-Agent has already discovered the pledge.
+This may be done as described in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 6.2.2</a> and <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> based on DNS-SD or similar.<a href="#section-7.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.1-2">TLS <span class="bcp14">MAY</span> be optionally used to provide privacy for this exchange between the Registrar-Agent and the pledge, see <a href="#pledgehttps" class="auto internal xref">Appendix B</a>.<a href="#section-7.1-2" class="pilcrow">¶</a></p>
+<div id="request-artifact-pledge-voucher-request-trigger-tpvr">
+<section id="section-7.1.1">
+          <h4 id="name-request-artifact-pledge-vou">
+<a href="#section-7.1.1" class="section-number selfRef">7.1.1. </a><a href="#name-request-artifact-pledge-vou" class="section-name selfRef">Request Artifact: Pledge Voucher-Request Trigger (tPVR)</a>
           </h4>
-<p id="section-6.1.1-1">Triggering the pledge to create the PVR is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tpvr"<a href="#section-6.1.1-1" class="pilcrow">¶</a></p>
-<p id="section-6.1.1-2">The Registrar-Agent PVR trigger Content-Type header is: <code>application/json</code>.
-Following parameters are provided in the JSON object:<a href="#section-6.1.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-1">Triggering the pledge to create the PVR is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tpvr"<a href="#section-7.1.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-2">The Registrar-Agent PVR trigger Content-Type header is: <code>application/json</code>.
+Following parameters are provided in the JSON object:<a href="#section-7.1.1-2" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.1.1-3.1">
-              <p id="section-6.1.1-3.1.1">agent-provided-proximity-registrar-cert: base64-encoded registrar EE TLS certificate.<a href="#section-6.1.1-3.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.1.1-3.1">
+              <p id="section-7.1.1-3.1.1">agent-provided-proximity-registrar-cert: base64-encoded registrar EE TLS certificate.<a href="#section-7.1.1-3.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.1-3.2">
-              <p id="section-6.1.1-3.2.1">agent-signed-data: base64-encoded JSON-in-JWS object.<a href="#section-6.1.1-3.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.1-3.2">
+              <p id="section-7.1.1-3.2.1">agent-signed-data: base64-encoded JSON-in-JWS object.<a href="#section-7.1.1-3.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.1.1-4">The trigger for the pledge to create a PVR is depicted in the following figure:<a href="#section-6.1.1-4" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-4">The trigger for the pledge to create a PVR is depicted in the following figure:<a href="#section-7.1.1-4" class="pilcrow">¶</a></p>
 <span id="name-representation-of-trigger-t"></span><div id="pavrt">
-<figure id="figure-6">
-            <div class="alignLeft art-text artwork" id="section-6.1.1-5.1">
+<figure id="figure-5">
+            <div class="alignLeft art-text artwork" id="section-7.1.1-5.1">
 <pre>
 {
   "agent-provided-proximity-registrar-cert": "base64encodedvalue==",
@@ -3011,56 +3183,54 @@ Following parameters are provided in the JSON object:<a href="#section-6.1.1-2" 
 }
 </pre>
 </div>
-<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
+<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
 <a href="#name-representation-of-trigger-t" class="selfRef">Representation of trigger to create PVR</a>
             </figcaption></figure>
 </div>
-<p id="section-6.1.1-6">Note that at the time of receiving the PVR trigger, the pledge cannot verify the registrar LDevID certificate and has no proof-of-possession of the corresponding private key for the certificate. The pledge therefore accepts the registrar LDevID certificate provisionally until it receives the voucher as described in <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a>.<a href="#section-6.1.1-6" class="pilcrow">¶</a></p>
-<p id="section-6.1.1-7">The pledge will also be unable to verify the agent-signed-data itself as it does not possess the EE (RegAgt) certificate and the domain trust has not been established at this point of the communication.
-Verification <span class="bcp14">SHOULD</span> be done, after the voucher has been received.<a href="#section-6.1.1-7" class="pilcrow">¶</a></p>
-<p id="section-6.1.1-8">The agent-signed-data is a JSON-in-JWS object and contains the following information:<a href="#section-6.1.1-8" class="pilcrow">¶</a></p>
-<p id="section-6.1.1-9">The header of the agent-signed-data contains:<a href="#section-6.1.1-9" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-6">Note that at the time of receiving the PVR trigger, the pledge cannot verify the registrar LDevID certificate and has no proof-of-possession of the corresponding private key for the certificate. The pledge therefore accepts the registrar LDevID certificate provisionally until it receives the voucher as described in <a href="#voucher" class="auto internal xref">Section 7.6</a>.<a href="#section-7.1.1-6" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-7">The pledge will also be unable to verify the agent-signed-data itself as it does not possess the EE (RegAgt) certificate and the domain trust has not been established at this point of the communication.
+Verification <span class="bcp14">SHOULD</span> be done, after the voucher has been received.<a href="#section-7.1.1-7" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-8">The agent-signed-data is a JSON-in-JWS object and contains the following information:<a href="#section-7.1.1-8" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-9">The header of the agent-signed-data contains:<a href="#section-7.1.1-9" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.1.1-10.1">
-              <p id="section-6.1.1-10.1.1">alg: algorithm used for creating the object signature.<a href="#section-6.1.1-10.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.1.1-10.1">
+              <p id="section-7.1.1-10.1.1">alg: algorithm used for creating the object signature.<a href="#section-7.1.1-10.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.1-10.2">
-              <p id="section-6.1.1-10.2.1">kid: <span class="bcp14">MUST</span> contain the base64-encoded bytes of the SubjectKeyIdentifier (the "KeyIdentifier" OCTET STRING value) of the EE (RegAgt) certificate.<a href="#section-6.1.1-10.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.1-10.2">
+              <p id="section-7.1.1-10.2.1">kid: <span class="bcp14">MUST</span> contain the base64-encoded bytes of the SubjectKeyIdentifier (the "KeyIdentifier" OCTET STRING value) of the EE (RegAgt) certificate.<a href="#section-7.1.1-10.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.1.1-11">The body of the agent-signed-data contains an "ietf-voucher-request:agent-signed-data" element (defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>):<a href="#section-6.1.1-11" class="pilcrow">¶</a></p>
+<p id="section-7.1.1-11">The body of the agent-signed-data contains an "ietf-voucher-request:agent-signed-data" element (defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>):<a href="#section-7.1.1-11" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.1.1-12.1">
-              <p id="section-6.1.1-12.1.1">created-on: <span class="bcp14">MUST</span> contain the creation date and time in yang:date-and-time format.<a href="#section-6.1.1-12.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.1.1-12.1">
+              <p id="section-7.1.1-12.1.1">created-on: <span class="bcp14">MUST</span> contain the creation date and time in yang:date-and-time format.<a href="#section-7.1.1-12.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.1-12.2">
-              <p id="section-6.1.1-12.2.1">serial-number: <span class="bcp14">MUST</span> contain the product-serial-number as type string as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, section 2.3.1.
-The serial-number corresponds with the product-serial-number contained in the X520SerialNumber field of the IDevID certificate of the pledge.<a href="#section-6.1.1-12.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.1-12.2">
+              <p id="section-7.1.1-12.2.1">serial-number: <span class="bcp14">MUST</span> contain the product serial number as type string as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-2.3.1" class="relref">Section 2.3.1</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+The serial-number corresponds with the product-serial-number contained in the X520SerialNumber field of the IDevID certificate of the pledge.<a href="#section-7.1.1-12.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 <span id="name-representation-of-agent-sig"></span><div id="asd">
-<figure id="figure-7">
-            <div class="alignLeft art-text artwork" id="section-6.1.1-13.1">
+<figure id="figure-6">
+            <div class="alignLeft art-text artwork" id="section-7.1.1-13.1">
 <pre>
 # The agent-signed-data in General JWS Serialization syntax
 {
-  "payload": BASE64URL(ietf-voucher-request:agent-signed-data),
+  "payload": "BASE64URL(ietf-voucher-request-prm:agent-signed-data)",
   "signatures": [
     {
-      "protected": BASE64URL(UTF8(JWS Protected Header)),
+      "protected": "BASE64URL(UTF8(JWS Protected Header))",
       "signature": BASE64URL(JWS Signature)
     }
   ]
 }
 
 # Example: Decoded payload representation in JSON syntax of
-  "ietf-voucher-request:agent-signed-data"
+  "ietf-voucher-request-prm:agent-signed-data"
 
-{
-  "ietf-voucher-request:agent-signed-data": {
-    "created-on": "2021-04-16T00:00:01.000Z",
-    "serial-number": "callee4711"
-  }
+"ietf-voucher-request-prm:agent-signed-data": {
+  "created-on": "2021-04-16T00:00:01.000Z",
+  "serial-number": "callee4711"
 }
 
 # Example: Decoded "JWS Protected Header" representation
@@ -3071,74 +3241,74 @@ The serial-number corresponds with the product-serial-number contained in the X5
 }
 </pre>
 </div>
-<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
+<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
 <a href="#name-representation-of-agent-sig" class="selfRef">Representation of agent-signed-data in General JWS Serialization syntax</a>
             </figcaption></figure>
 </div>
 </section>
 </div>
-<div id="pvrr">
-<section id="section-6.1.2">
-          <h4 id="name-pledge-voucher-request-pvr-r">
-<a href="#section-6.1.2" class="section-number selfRef">6.1.2. </a><a href="#name-pledge-voucher-request-pvr-r" class="section-name selfRef">Pledge-Voucher-Request (PVR) - Response</a>
+<div id="response-artifact-pledge-voucher-request-pvr">
+<section id="section-7.1.2">
+          <h4 id="name-response-artifact-pledge-vo">
+<a href="#section-7.1.2" class="section-number selfRef">7.1.2. </a><a href="#name-response-artifact-pledge-vo" class="section-name selfRef">Response Artifact: Pledge Voucher-Request (PVR)</a>
           </h4>
-<p id="section-6.1.2-1">Upon receiving the voucher-request trigger, the pledge <span class="bcp14">SHALL</span> construct the body of the PVR as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+<p id="section-7.1.2-1">Upon receiving the voucher-request trigger, the pledge <span class="bcp14">SHALL</span> construct the body of the PVR as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 It will contain additional information provided by the Registrar-Agent as specified in the following.
 This PVR becomes a JSON-in-JWS object as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
-If the pledge is unable to construct the PVR it <span class="bcp14">SHOULD</span> respond with a HTTP error code to the Registrar-Agent to indicate that it is not able to create the PVR.<a href="#section-6.1.2-1" class="pilcrow">¶</a></p>
-<p id="section-6.1.2-2">The following client error responses <span class="bcp14">MAY</span> be used:<a href="#section-6.1.2-2" class="pilcrow">¶</a></p>
+If the pledge is unable to construct the PVR it <span class="bcp14">SHOULD</span> respond with a HTTP error code to the Registrar-Agent to indicate that it is not able to create the PVR.<a href="#section-7.1.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-2">The following client error responses <span class="bcp14">MAY</span> be used:<a href="#section-7.1.2-2" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.1.2-3.1">
-              <p id="section-6.1.2-3.1.1">400 Bad Request: if the pledge detected an error in the format of the request, e.g. missing field, wrong data types, etc. or if the request is not valid JSON even though the PVR media type was set to <code>application/json</code>.<a href="#section-6.1.2-3.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.1.2-3.1">
+              <p id="section-7.1.2-3.1.1">400 Bad Request: if the pledge detected an error in the format of the request, e.g. missing field, wrong data types, etc. or if the request is not valid JSON even though the PVR media type was set to <code>application/json</code>.<a href="#section-7.1.2-3.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.2-3.2">
-              <p id="section-6.1.2-3.2.1">403 Forbidden: if the pledge detected that one or more security parameters from the trigger message to create the PVR were not valid, e.g., the LDevID (Reg) certificate.<a href="#section-6.1.2-3.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.2-3.2">
+              <p id="section-7.1.2-3.2.1">403 Forbidden: if the pledge detected that one or more security parameters from the trigger message to create the PVR were not valid, e.g., the LDevID (Reg) certificate.<a href="#section-7.1.2-3.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.1.2-4">The header of the PVR <span class="bcp14">SHALL</span> contain the following parameters as defined in <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span> to support JWS signing of the object:<a href="#section-6.1.2-4" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-4">The header of the PVR <span class="bcp14">SHALL</span> contain the following parameters as defined in <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span> to support JWS signing of the object:<a href="#section-7.1.2-4" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.1.2-5.1">
-              <p id="section-6.1.2-5.1.1">alg: algorithm used for creating the object signature.<a href="#section-6.1.2-5.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.1.2-5.1">
+              <p id="section-7.1.2-5.1.1">alg: algorithm used for creating the object signature.<a href="#section-7.1.2-5.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.2-5.2">
-              <p id="section-6.1.2-5.2.1">x5c: contains the base64-encoded pledge IDevID certificate.
-It <span class="bcp14">MAY</span> optionally contain the certificate chain for this certificate. If the certificate chain is not included it <span class="bcp14">MUST</span> be available at the registrar for verification of the IDevID certificate.<a href="#section-6.1.2-5.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.2-5.2">
+              <p id="section-7.1.2-5.2.1">x5c: contains the base64-encoded pledge IDevID certificate.
+It <span class="bcp14">MAY</span> optionally contain the certificate chain for this certificate. If the certificate chain is not included it <span class="bcp14">MUST</span> be available at the registrar for verification of the IDevID certificate.<a href="#section-7.1.2-5.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.1.2-6">The payload of the PVR <span class="bcp14">MUST</span> contain the following parameters as part of the ietf-voucher-request:voucher as defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>:<a href="#section-6.1.2-6" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-6">The payload of the PVR <span class="bcp14">MUST</span> contain the following parameters as part of the ietf-voucher-request-prm:voucher as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>:<a href="#section-7.1.2-6" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.1.2-7.1">
-              <p id="section-6.1.2-7.1.1">created-on: <span class="bcp14">SHALL</span> contain the current date and time in yang:date-and-time format.
-If the pledge does not have synchronized time, it <span class="bcp14">SHALL</span> use the created-on time from the agent-signed-data, received in the trigger to create a PVR.<a href="#section-6.1.2-7.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.1.2-7.1">
+              <p id="section-7.1.2-7.1.1">created-on: <span class="bcp14">SHALL</span> contain the current date and time in yang:date-and-time format.
+If the pledge does not have synchronized time, it <span class="bcp14">SHALL</span> use the created-on time from the agent-signed-data, received in the trigger to create a PVR.<a href="#section-7.1.2-7.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.2-7.2">
-              <p id="section-6.1.2-7.2.1">nonce: <span class="bcp14">SHALL</span> contain a cryptographically strong pseudo-random number.<a href="#section-6.1.2-7.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.2-7.2">
+              <p id="section-7.1.2-7.2.1">nonce: <span class="bcp14">SHALL</span> contain a cryptographically strong pseudo-random number.<a href="#section-7.1.2-7.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.2-7.3">
-              <p id="section-6.1.2-7.3.1">serial-number: <span class="bcp14">SHALL</span> contain the pledge product-serial-number as X520SerialNumber.<a href="#section-6.1.2-7.3.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.2-7.3">
+              <p id="section-7.1.2-7.3.1">serial-number: <span class="bcp14">SHALL</span> contain the pledge product-serial-number as X520SerialNumber.<a href="#section-7.1.2-7.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.2-7.4">
-              <p id="section-6.1.2-7.4.1">assertion: <span class="bcp14">SHALL</span> contain the requested voucher assertion "agent-proximity" (different value as in RFC 8995)..<a href="#section-6.1.2-7.4.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.2-7.4">
+              <p id="section-7.1.2-7.4.1">assertion: <span class="bcp14">SHALL</span> contain the requested voucher assertion "agent-proximity" (different value as in RFC 8995)..<a href="#section-7.1.2-7.4.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.1.2-8">The ietf-voucher-request:voucher is extended with additional parameters:<a href="#section-6.1.2-8" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-8">The ietf-voucher-request:voucher is extended with additional parameters:<a href="#section-7.1.2-8" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.1.2-9.1">
-              <p id="section-6.1.2-9.1.1">agent-provided-proximity-registrar-cert: <span class="bcp14">MUST</span> be included and contains the base64-encoded registrar LDevID certificate (provided as PVR trigger parameter by the Registrar-Agent).<a href="#section-6.1.2-9.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.1.2-9.1">
+              <p id="section-7.1.2-9.1.1">agent-provided-proximity-registrar-cert: <span class="bcp14">MUST</span> be included and contains the base64-encoded registrar LDevID certificate (provided as PVR trigger parameter by the Registrar-Agent).<a href="#section-7.1.2-9.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.2-9.2">
-              <p id="section-6.1.2-9.2.1">agent-signed-data: <span class="bcp14">MUST</span> contain the base64-encoded agent-signed-data (as defined in <a href="#asd" class="auto internal xref">Figure 7</a>) and provided as a PVR trigger parameter by the Registrar-Agent.<a href="#section-6.1.2-9.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.1.2-9.2">
+              <p id="section-7.1.2-9.2.1">agent-signed-data: <span class="bcp14">MUST</span> contain the base64-encoded agent-signed-data (as defined in <a href="#asd" class="auto internal xref">Figure 6</a>) and provided as a PVR trigger parameter by the Registrar-Agent.<a href="#section-7.1.2-9.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.1.2-10">The enhancements of the YANG module for the ietf-voucher-request with these new leaves are defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>.<a href="#section-6.1.2-10" class="pilcrow">¶</a></p>
-<p id="section-6.1.2-11">The PVR is signed using the pledge's IDevID credential contained as x5c parameter of the JOSE header.<a href="#section-6.1.2-11" class="pilcrow">¶</a></p>
-<span id="name-representation-of-pvr"></span><div id="pvr">
-<figure id="figure-8">
-            <div class="alignLeft art-text artwork" id="section-6.1.2-12.1">
+<p id="section-7.1.2-10">The enhancements of the YANG module for the ietf-voucher-request with these new leaves are defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>.<a href="#section-7.1.2-10" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-11">The PVR is signed using the pledge's IDevID credential contained as x5c parameter of the JOSE header.<a href="#section-7.1.2-11" class="pilcrow">¶</a></p>
+<span id="name-representation-of-pvr"></span><div id="pvr_example">
+<figure id="figure-7">
+            <div class="alignLeft art-text artwork" id="section-7.1.2-12.1">
 <pre>
 # The PVR in General JWS Serialization syntax
 {
-  "payload": BASE64URL(ietf-voucher-request:voucher),
+  "payload": BASE64URL(UTF8(ietf-voucher-request-prm:voucher)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -3147,134 +3317,139 @@ If the pledge does not have synchronized time, it <span class="bcp14">SHALL</spa
   ]
 }
 
-# Example: Decoded Payload "ietf-voucher-request:voucher"
+# Example: Decoded Payload "ietf-voucher-request-prm:voucher"
   representation in JSON syntax
-{
-  "ietf-voucher-request:voucher": {
-     "created-on": "2021-04-16T00:00:02.000Z",
-     "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
-     "serial-number": "callee4711",
-     "assertion": "agent-proximity",
-     "agent-provided-proximity-registrar-cert": "base64encodedvalue==",
-     "agent-signed-data": "base64encodedvalue=="
-  }
+"ietf-voucher-request-prm:voucher": {
+   "created-on": "2021-04-16T00:00:02.000Z",
+   "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
+   "serial-number": "callee4711",
+   "assertion": "agent-proximity",
+   "agent-provided-proximity-registrar-cert": "base64encodedvalue==",
+   "agent-signed-data": "base64encodedvalue=="
 }
 
 # Example: Decoded "JWS Protected Header" representation
   in JSON syntax
 {
     "alg": "ES256",
+    "typ": "voucher-jws+json",
     "x5c": [
       "base64encodedvalue==",
       "base64encodedvalue=="
-    ],
-    "typ": "voucher-jws+json"
+    ]
 }
 </pre>
 </div>
-<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
 <a href="#name-representation-of-pvr" class="selfRef">Representation of PVR</a>
             </figcaption></figure>
 </div>
-<p id="section-6.1.2-13">The PVR Media-Type is defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span> as <code>application/voucher-jws+json</code>.<a href="#section-6.1.2-13" class="pilcrow">¶</a></p>
-<p id="section-6.1.2-14">The pledge <span class="bcp14">MUST</span> include this Media-Type header field indicating the included media type for the PVR.
-The PVR is included by the registrar in its RCR as described in <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a>.<a href="#section-6.1.2-14" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-13">The PVR Media-Type is defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span> as <code>application/voucher-jws+json</code>.<a href="#section-7.1.2-13" class="pilcrow">¶</a></p>
+<p id="section-7.1.2-14">The pledge <span class="bcp14">MUST</span> include this Media-Type header field indicating the included media type for the PVR.
+The PVR is included by the registrar in its RVR as described in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-7.1.2-14" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="pledge-enrollment-request-per-trigger">
-<section id="section-6.1.3">
-          <h4 id="name-pledge-enrollment-request-p">
-<a href="#section-6.1.3" class="section-number selfRef">6.1.3. </a><a href="#name-pledge-enrollment-request-p" class="section-name selfRef">Pledge-Enrollment-Request (PER) - Trigger</a>
+</section>
+</div>
+<div id="tper">
+<section id="section-7.2">
+        <h3 id="name-trigger-pledge-enroll-reque">
+<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-trigger-pledge-enroll-reque" class="section-name selfRef">Trigger Pledge Enroll-Request</a>
+        </h3>
+<div id="request-artifact-pledge-enroll-request-trigger-tper">
+<section id="section-7.2.1">
+          <h4 id="name-request-artifact-pledge-enr">
+<a href="#section-7.2.1" class="section-number selfRef">7.2.1. </a><a href="#name-request-artifact-pledge-enr" class="section-name selfRef">Request Artifact: Pledge Enroll-Request Trigger (tPER)</a>
           </h4>
-<p id="section-6.1.3-1">Once the Registrar-Agent has received the PVR it can trigger the pledge to generate a PER.
+<p id="section-7.2.1-1">Once the Registrar-Agent has received the PVR it can trigger the pledge to generate a PER.
 As in BRSKI the PER contains a PKCS#10, but additionally signed using the pledge's IDevID.
-Note, as the initial enrollment aims to request a generic certificate, no certificate attributes are provided to the pledge.<a href="#section-6.1.3-1" class="pilcrow">¶</a></p>
-<p id="section-6.1.3-2">Triggering the pledge to create the enrollment-request is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tper"<a href="#section-6.1.3-2" class="pilcrow">¶</a></p>
-<p id="section-6.1.3-3">The Registrar-Agent PER trigger Content-Type header is: <code>application/json</code> with an empty body by default.
+Note, as the initial enrollment aims to request a generic certificate, no certificate attributes are provided to the pledge.<a href="#section-7.2.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.2.1-2">Triggering the pledge to create the Enroll-Request is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tper"<a href="#section-7.2.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.2.1-3">The Registrar-Agent PER trigger Content-Type header is: <code>application/json</code> with an empty body by default.
 Note that using HTTP POST allows for an empty body, but also to provide additional data, like CSR attributes or information about the enroll type "enroll-generic-cert" or "re-enroll-generic-cert".
-The "enroll-generic-cert" case is shown in <a href="#raer" class="auto internal xref">Figure 9</a>.<a href="#section-6.1.3-3" class="pilcrow">¶</a></p>
+The "enroll-generic-cert" case is shown in <a href="#raer" class="auto internal xref">Figure 8</a>.<a href="#section-7.2.1-3" class="pilcrow">¶</a></p>
 <span id="name-example-of-trigger-to-creat"></span><div id="raer">
-<figure id="figure-9">
-            <div class="alignLeft art-text artwork" id="section-6.1.3-4.1">
+<figure id="figure-8">
+            <div class="alignLeft art-text artwork" id="section-7.2.1-4.1">
 <pre>
 {
   "enroll-type" : "enroll-generic-cert"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
+<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
 <a href="#name-example-of-trigger-to-creat" class="selfRef">Example of trigger to create a PER</a>
             </figcaption></figure>
 </div>
-<p id="section-6.1.3-5">This document specifies the request of a generic certificate with no CSR attributes provided to the pledge.
+<p id="section-7.2.1-5">This document specifies the request of a generic certificate with no CSR attributes provided to the pledge.
 If specific attributes in the certificate are required, they have to be inserted by the issuing RA/CA.
-How the HTTP POST can be used to provide CSR attributes is out of scope for this specification.<a href="#section-6.1.3-5" class="pilcrow">¶</a></p>
+How the HTTP POST can be used to provide CSR attributes is out of scope for this specification.<a href="#section-7.2.1-5" class="pilcrow">¶</a></p>
+<p id="section-7.2.1-6">In the following the enrollment is described as initial enrollment with an empty HTTP POST body.<a href="#section-7.2.1-6" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="PER-response">
-<section id="section-6.1.4">
-          <h4 id="name-pledge-enrollment-request-pe">
-<a href="#section-6.1.4" class="section-number selfRef">6.1.4. </a><a href="#name-pledge-enrollment-request-pe" class="section-name selfRef">Pledge-Enrollment-Request (PER) - Response</a>
+<div id="response-artifact-pledge-enroll-request-per">
+<section id="section-7.2.2">
+          <h4 id="name-response-artifact-pledge-en">
+<a href="#section-7.2.2" class="section-number selfRef">7.2.2. </a><a href="#name-response-artifact-pledge-en" class="section-name selfRef">Response Artifact: Pledge Enroll-Request (PER)</a>
           </h4>
-<p id="section-6.1.4-1">In the following the enrollment is described as initial enrollment with an empty HTTP POST body.<a href="#section-6.1.4-1" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-2">Upon receiving the PER  trigger, the pledge <span class="bcp14">SHALL</span> construct the PER as authenticated self-contained object.
+<p id="section-7.2.2-1">Upon receiving the PER trigger, the pledge <span class="bcp14">SHALL</span> construct the PER as authenticated self-contained object.
 The CSR already assures POP of the private key corresponding to the contained public key.
 In addition, based on the PER signature using the IDevID, POI is provided.
-Here, a JOSE object is being created in which the body utilizes the YANG module ietf-ztp-types with the grouping for csr-grouping for the CSR as defined in <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span>.<a href="#section-6.1.4-2" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-3">Depending on the capability of the pledge, it constructs the pledge-enrollment-request (PER) as plain PKCS#10.
+Here, a JOSE object is being created in which the body utilizes the YANG module ietf-ztp-types with the grouping for csr-grouping for the CSR as defined in <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span>.<a href="#section-7.2.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-2">Depending on the capability of the pledge, it constructs the Pledge Enroll-Request (PER) as plain PKCS#10.
 Note, the focus in this use case is placed on PKCS#10 as PKCS#10 can be transmitted in different enrollment protocols in the infrastructure like EST, CMP, CMS, and SCEP.
 If the pledge has already implemented an enrollment protocol, it may leverage that functionality for the creation of the CSR.
-Note, <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span> also allows for inclusion of certification requests in different formats used by CMP or CMC.<a href="#section-6.1.4-3" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-4">The pledge <span class="bcp14">MUST</span> construct the PER as PKCS#10.
-In BRSKI-PRM it <span class="bcp14">MUST</span> sign it additionally with its IDevID credentials to provide proof-of-identity bound to the PKCS#10 as described below.<a href="#section-6.1.4-4" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-5">If the pledge is unable to construct the PER it <span class="bcp14">SHOULD</span> respond with a HTTP 4xx/5xx error code to the Registrar-Agent to indicate that it is not able to create the PER.<a href="#section-6.1.4-5" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-6">The following 4xx client error codes <span class="bcp14">MAY</span> be used:<a href="#section-6.1.4-6" class="pilcrow">¶</a></p>
+Note, <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span> also allows for inclusion of certification requests in different formats used by CMP or CMC.<a href="#section-7.2.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-3">The pledge <span class="bcp14">MUST</span> construct the PER as PKCS#10.
+In BRSKI-PRM it <span class="bcp14">MUST</span> sign it additionally with its IDevID credentials to provide proof-of-identity bound to the PKCS#10 as described below.<a href="#section-7.2.2-3" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-4">If the pledge is unable to construct the PER it <span class="bcp14">SHOULD</span> respond with a HTTP 4xx/5xx error code to the Registrar-Agent to indicate that it is not able to create the PER.<a href="#section-7.2.2-4" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-5">The following 4xx client error codes <span class="bcp14">MAY</span> be used:<a href="#section-7.2.2-5" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.1.4-7.1">
-              <p id="section-6.1.4-7.1.1">400 Bad Request: if the pledge detected an error in the format of the request or detected invalid JSON even though the PER media type was set to <code>application/json</code>.<a href="#section-6.1.4-7.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.2.2-6.1">
+              <p id="section-7.2.2-6.1.1">400 Bad Request: if the pledge detected an error in the format of the request or detected invalid JSON even though the PER media type was set to <code>application/json</code>.<a href="#section-7.2.2-6.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.4-7.2">
-              <p id="section-6.1.4-7.2.1">403 Forbidden: if the pledge detected that one or more security parameters (if provided) from the trigger message to create the PER are not valid.<a href="#section-6.1.4-7.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.2.2-6.2">
+              <p id="section-7.2.2-6.2.1">403 Forbidden: if the pledge detected that one or more security parameters (if provided) from the trigger message to create the PER are not valid.<a href="#section-7.2.2-6.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.4-7.3">
-              <p id="section-6.1.4-7.3.1">406 Not Acceptable: if the request's Accept header indicates a type that is unknown or unsupported. For example, a type other than <code>application/jose+json</code>.<a href="#section-6.1.4-7.3.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.2.2-6.3">
+              <p id="section-7.2.2-6.3.1">406 Not Acceptable: if the request's Accept header indicates a type that is unknown or unsupported. For example, a type other than <code>application/jose+json</code>.<a href="#section-7.2.2-6.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.4-7.4">
-              <p id="section-6.1.4-7.4.1">415 Unsupported Media Type: if the request's Content-Type header indicates a type that is unknown or unsupported. For example, a type other than 'application/json'.<a href="#section-6.1.4-7.4.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.2.2-6.4">
+              <p id="section-7.2.2-6.4.1">415 Unsupported Media Type: if the request's Content-Type header indicates a type that is unknown or unsupported. For example, a type other than 'application/json'.<a href="#section-7.2.2-6.4.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.1.4-8">A successful enrollment will result in a generic LDevID certificate for the pledge in the new domain, which can be used to request further (application specific) LDevID certificates if necessary for operation.
-The Registrar-Agent <span class="bcp14">SHALL</span> use the endpoints specified in this document.<a href="#section-6.1.4-8" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-9"><span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span> considers PKCS#10 but also CMP and CMC as certification request format.
-Note that the wrapping of the PER signature is only necessary for plain PKCS#10 as other request formats like CMP and CMS support the signature wrapping as part of their own certificate request format.<a href="#section-6.1.4-9" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-10">The Registrar-Agent enrollment-request Content-Type header for a signature-wrapped PKCS#10 is: <code>application/jose+json</code><a href="#section-6.1.4-10" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-11">The header of the pledge-enrollment-request <span class="bcp14">SHALL</span> contain the following parameter as defined in <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>:<a href="#section-6.1.4-11" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-7">A successful enrollment will result in a generic LDevID certificate for the pledge in the new domain, which can be used to request further (application specific) LDevID certificates if necessary for operation.
+The Registrar-Agent <span class="bcp14">SHALL</span> use the endpoints specified in this document.<a href="#section-7.2.2-7" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-8"><span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span> considers PKCS#10 but also CMP and CMC as certification request format.
+Note that the wrapping of the PER signature is only necessary for plain PKCS#10 as other request formats like CMP and CMS support the signature wrapping as part of their own certificate request format.<a href="#section-7.2.2-8" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-9">The Registrar-Agent Enroll-Request Content-Type header for a signature-wrapped PKCS#10 is: <code>application/jose+json</code><a href="#section-7.2.2-9" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-10">The header of the Pledge Enroll-Request <span class="bcp14">SHALL</span> contain the following parameter as defined in <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>:<a href="#section-7.2.2-10" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.1.4-12.1">
-              <p id="section-6.1.4-12.1.1">alg: algorithm used for creating the object signature.<a href="#section-6.1.4-12.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.2.2-11.1">
+              <p id="section-7.2.2-11.1.1">alg: algorithm used for creating the object signature.<a href="#section-7.2.2-11.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.4-12.2">
-              <p id="section-6.1.4-12.2.1">x5c: contains the base64-encoded pledge IDevID certificate.
+            <li class="normal" id="section-7.2.2-11.2">
+              <p id="section-7.2.2-11.2.1">x5c: contains the base64-encoded pledge IDevID certificate.
 It <span class="bcp14">MAY</span> optionally contain the certificate chain for this certificate. If the certificate chain is not included it <span class="bcp14">MUST</span> be available at the registrar for verification of the IDevID certificate.
-The body of the pledge-enrollment-request <span class="bcp14">SHOULD</span> contain a P10 parameter (for PKCS#10) as defined for ietf-ztp-types:p10-csr in <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span><a href="#section-6.1.4-12.2.1" class="pilcrow">¶</a></p>
+The body of the Pledge Enroll-Request <span class="bcp14">SHOULD</span> contain a P10 parameter (for PKCS#10) as defined for ietf-ztp-types:p10-csr in <span>[<a href="#I-D.ietf-netconf-sztp-csr" class="cite xref">I-D.ietf-netconf-sztp-csr</a>]</span><a href="#section-7.2.2-11.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.1.4-12.3">
-              <p id="section-6.1.4-12.3.1">P10: contains the base64-encoded PKCS#10 of the pledge.<a href="#section-6.1.4-12.3.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.2.2-11.3">
+              <p id="section-7.2.2-11.3.1">P10: contains the base64-encoded PKCS#10 of the pledge.<a href="#section-7.2.2-11.3.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.1.4-13">The JOSE object is signed using the pledge's IDevID credential, which corresponds to the certificate signaled in the JOSE header.<a href="#section-6.1.4-13" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-14">While BRSKI-PRM targets the initial enrollment, re-enrollment <span class="bcp14">SHOULD</span> be supported as described in a similar way as for enrollment in this document, if no other re-enrollment mechanism is supported.
-Note that in this case the current LDevID credential is used instead of the IDevID credential to create the signature of the PKCS#10 request.<a href="#section-6.1.4-14" class="pilcrow">¶</a></p>
-<span id="name-representation-of-per"></span><div id="per">
-<figure id="figure-10">
-            <div class="alignLeft art-text artwork" id="section-6.1.4-15.1">
+<p id="section-7.2.2-12">The JOSE object is signed using the pledge's IDevID credential, which corresponds to the certificate signaled in the JOSE header.<a href="#section-7.2.2-12" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-13">While BRSKI-PRM targets the initial enrollment, re-enrollment <span class="bcp14">SHOULD</span> be supported as described in a similar way as for enrollment in this document, if no other re-enrollment mechanism is supported.
+Note that in this case the current LDevID credential is used instead of the IDevID credential to create the signature of the PKCS#10 request.<a href="#section-7.2.2-13" class="pilcrow">¶</a></p>
+<span id="name-representation-of-per"></span><div id="per_example">
+<figure id="figure-9">
+            <div class="alignLeft art-text artwork" id="section-7.2.2-14.1">
 <pre>
 # The PER in General JWS Serialization syntax
 {
-  "payload": BASE64URL(ietf-ztp-types),
+  "payload": "BASE64URL(ietf-ztp-types)",
   "signatures": [
     {
-      "protected": BASE64URL(UTF8(JWS Protected Header)),
+      "protected": "BASE64URL(UTF8(JWS Protected Header))",
       "signature": BASE64URL(JWS Signature)
     }
   ]
@@ -3282,10 +3457,8 @@ Note that in this case the current LDevID credential is used instead of the IDev
 
 # Example: Decoded Payload "ietf-ztp-types" Representation
   in JSON Syntax
-{
-  "ietf-ztp-types": {
-    "p10-csr": "base64encodedvalue=="
-  }
+"ietf-ztp-types": {
+  "p10-csr": "base64encodedvalue=="
 }
 
 # Example: Decoded "JWS Protected Header" Representation
@@ -3301,292 +3474,110 @@ Note that in this case the current LDevID credential is used instead of the IDev
 }
 </pre>
 </div>
-<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
+<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
 <a href="#name-representation-of-per" class="selfRef">Representation of PER</a>
             </figcaption></figure>
 </div>
-<p id="section-6.1.4-16">With the collected PVR and PER, the Registrar-Agent starts the interaction with the domain registrar.<a href="#section-6.1.4-16" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-17">The new protected header field "created-on" is introduced to reflect freshness of the PER.
-The field is marked critical "crit" to ensure that it must be understood and validated by the receiver (here the domain registrar) according to section 4.1.11 of <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>.
+<p id="section-7.2.2-15">With the collected PVR and PER, the Registrar-Agent starts the interaction with the domain registrar.<a href="#section-7.2.2-15" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-16">The new protected header field "created-on" is introduced to reflect freshness of the PER.
+The field is marked critical "crit" to ensure that it must be understood and validated by the receiver (here the domain registrar) according to <span><a href="https://rfc-editor.org/rfc/rfc7515#section-4.1.11" class="relref">Section 4.1.11</a> of [<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>.
 It allows the registrar to verify the timely correlation between the PER and previously exchanged messages, i.e., created-on of PER &gt;= created-on of PVR &gt;= created-on of PVR trigger.
-The registrar <span class="bcp14">MAY</span> consider to ignore any but the newest PER from the same pledge in the case the registrar has at any point in time more than one pending PER from the pledge.<a href="#section-6.1.4-17" class="pilcrow">¶</a></p>
-<p id="section-6.1.4-18">As the Registrar-Agent is intended to facilitate communication between the pledge and the domain registrar, a collection of requests from more than one pledge is possible.
-This allows bulk bootstrapping of several pledges using the same connection between the Registrar-Agent and the domain registrar.<a href="#section-6.1.4-18" class="pilcrow">¶</a></p>
+The registrar <span class="bcp14">MAY</span> consider to ignore any but the newest PER from the same pledge in the case the registrar has at any point in time more than one pending PER from the pledge.<a href="#section-7.2.2-16" class="pilcrow">¶</a></p>
+<p id="section-7.2.2-17">As the Registrar-Agent is intended to facilitate communication between the pledge and the domain registrar, a collection of requests from more than one pledge is possible.
+This allows bulk bootstrapping of several pledges using the same connection between the Registrar-Agent and the domain registrar.<a href="#section-7.2.2-17" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
-<div id="exchanges_uc2_2">
-<section id="section-6.2">
-        <h3 id="name-request-object-handling-ini">
-<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-request-object-handling-ini" class="section-name selfRef">Request Object Handling initiated by the Registrar-Agent on Registrar, MASA and Domain CA</a>
+<div id="pvr">
+<section id="section-7.3">
+        <h3 id="name-request-voucher-from-the-re">
+<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-request-voucher-from-the-re" class="section-name selfRef">Request Voucher from the Registrar</a>
         </h3>
-<p id="section-6.2-1">The BRSKI-PRM bootstrapping exchanges between Registrar-Agent and domain registrar resemble the BRSKI exchanges between pledge and domain registrar (pledge-initiator-mode) with some deviations.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
-<p id="section-6.2-2">Preconditions:<a href="#section-6.2-2" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-6.2-3.1">
-            <p id="section-6.2-3.1.1">Registrar-Agent: possesses its own credentials (EE (RegAgt) certificate and corresponding private key) of the domain.
-In addition, it <span class="bcp14">MAY</span> possess the IDevID CA certificate of the pledge vendor/manufacturer to verify the pledge certificate in the received request messages.
-It has the address of the domain registrar through configuration or by discovery, e.g., DNS-SD with mDNS.
-The Registrar-Agent has acquired one or more PVR and PER objects.<a href="#section-6.2-3.1.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="normal" id="section-6.2-3.2">
-            <p id="section-6.2-3.2.1">Registrar (same as in BRSKI): possesses the IDevID CA certificate of the pledge vendor/manufacturer and its own registrar EE credentials of the domain.<a href="#section-6.2-3.2.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="normal" id="section-6.2-3.3">
-            <p id="section-6.2-3.3.1">MASA (same as in BRSKI): possesses its own vendor/manufacturer credentials (voucher signing key and certificate, TLS server certificate and private key) related to pledges IDevID and <span class="bcp14">MAY</span> possess the site-specific domain CA certificate.<a href="#section-6.2-3.3.1" class="pilcrow">¶</a></p>
-</li>
-        </ul>
-<span id="name-request-processing-between-"></span><div id="exchangesfig_uc2_2">
-<figure id="figure-11">
-          <div id="section-6.2-4.1">
-            <div class="alignLeft art-svg artwork" id="section-6.2-4.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="624" width="504" viewBox="0 0 504 624" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
-                <path d="M 8,32 L 8,96" fill="none" stroke="black"></path>
-                <path d="M 40,144 L 40,608" fill="none" stroke="black"></path>
-                <path d="M 104,32 L 104,96" fill="none" stroke="black"></path>
-                <path d="M 152,32 L 152,96" fill="none" stroke="black"></path>
-                <path d="M 200,104 L 200,176" fill="none" stroke="black"></path>
-                <path d="M 200,224 L 200,256" fill="none" stroke="black"></path>
-                <path d="M 200,320 L 200,608" fill="none" stroke="black"></path>
-                <path d="M 248,32 L 248,96" fill="none" stroke="black"></path>
-                <path d="M 312,32 L 312,96" fill="none" stroke="black"></path>
-                <path d="M 352,104 L 352,288" fill="none" stroke="black"></path>
-                <path d="M 352,416 L 352,608" fill="none" stroke="black"></path>
-                <path d="M 384,32 L 384,96" fill="none" stroke="black"></path>
-                <path d="M 416,32 L 416,96" fill="none" stroke="black"></path>
-                <path d="M 456,104 L 456,352" fill="none" stroke="black"></path>
-                <path d="M 456,400 L 456,608" fill="none" stroke="black"></path>
-                <path d="M 496,32 L 496,96" fill="none" stroke="black"></path>
-                <path d="M 8,32 L 104,32" fill="none" stroke="black"></path>
-                <path d="M 152,32 L 248,32" fill="none" stroke="black"></path>
-                <path d="M 312,32 L 384,32" fill="none" stroke="black"></path>
-                <path d="M 416,32 L 496,32" fill="none" stroke="black"></path>
-                <path d="M 8,96 L 104,96" fill="none" stroke="black"></path>
-                <path d="M 152,96 L 248,96" fill="none" stroke="black"></path>
-                <path d="M 312,96 L 384,96" fill="none" stroke="black"></path>
-                <path d="M 416,96 L 496,96" fill="none" stroke="black"></path>
-                <path d="M 48,176 L 88,176" fill="none" stroke="black"></path>
-                <path d="M 144,176 L 192,176" fill="none" stroke="black"></path>
-                <path d="M 48,240 L 64,240" fill="none" stroke="black"></path>
-                <path d="M 176,240 L 192,240" fill="none" stroke="black"></path>
-                <path d="M 208,320 L 304,320" fill="none" stroke="black"></path>
-                <path d="M 360,320 L 448,320" fill="none" stroke="black"></path>
-                <path d="M 208,336 L 272,336" fill="none" stroke="black"></path>
-                <path d="M 384,336 L 448,336" fill="none" stroke="black"></path>
-                <path d="M 208,400 L 288,400" fill="none" stroke="black"></path>
-                <path d="M 368,400 L 448,400" fill="none" stroke="black"></path>
-                <path d="M 48,416 L 80,416" fill="none" stroke="black"></path>
-                <path d="M 160,416 L 192,416" fill="none" stroke="black"></path>
-                <path d="M 48,448 L 64,448" fill="none" stroke="black"></path>
-                <path d="M 168,448 L 192,448" fill="none" stroke="black"></path>
-                <path d="M 208,480 L 248,480" fill="none" stroke="black"></path>
-                <path d="M 304,480 L 344,480" fill="none" stroke="black"></path>
-                <path d="M 208,496 L 224,496" fill="none" stroke="black"></path>
-                <path d="M 328,496 L 344,496" fill="none" stroke="black"></path>
-                <path d="M 208,528 L 224,528" fill="none" stroke="black"></path>
-                <path d="M 328,528 L 344,528" fill="none" stroke="black"></path>
-                <path d="M 48,544 L 64,544" fill="none" stroke="black"></path>
-                <path d="M 176,544 L 192,544" fill="none" stroke="black"></path>
-                <path d="M 48,576 L 64,576" fill="none" stroke="black"></path>
-                <path d="M 176,576 L 192,576" fill="none" stroke="black"></path>
-                <path d="M 48,592 L 64,592" fill="none" stroke="black"></path>
-                <path d="M 176,592 L 192,592" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="456,336 444,330.4 444,341.6" fill="black" transform="rotate(0,448,336)"></polygon>
-                <polygon class="arrowhead" points="456,320 444,314.4 444,325.6" fill="black" transform="rotate(0,448,320)"></polygon>
-                <polygon class="arrowhead" points="352,496 340,490.4 340,501.6" fill="black" transform="rotate(0,344,496)"></polygon>
-                <polygon class="arrowhead" points="352,480 340,474.4 340,485.6" fill="black" transform="rotate(0,344,480)"></polygon>
-                <polygon class="arrowhead" points="216,528 204,522.4 204,533.6" fill="black" transform="rotate(180,208,528)"></polygon>
-                <polygon class="arrowhead" points="216,480 204,474.4 204,485.6" fill="black" transform="rotate(180,208,480)"></polygon>
-                <polygon class="arrowhead" points="216,400 204,394.4 204,405.6" fill="black" transform="rotate(180,208,400)"></polygon>
-                <polygon class="arrowhead" points="200,576 188,570.4 188,581.6" fill="black" transform="rotate(0,192,576)"></polygon>
-                <polygon class="arrowhead" points="200,448 188,442.4 188,453.6" fill="black" transform="rotate(0,192,448)"></polygon>
-                <polygon class="arrowhead" points="200,240 188,234.4 188,245.6" fill="black" transform="rotate(0,192,240)"></polygon>
-                <polygon class="arrowhead" points="200,176 188,170.4 188,181.6" fill="black" transform="rotate(0,192,176)"></polygon>
-                <polygon class="arrowhead" points="56,592 44,586.4 44,597.6" fill="black" transform="rotate(180,48,592)"></polygon>
-                <polygon class="arrowhead" points="56,544 44,538.4 44,549.6" fill="black" transform="rotate(180,48,544)"></polygon>
-                <polygon class="arrowhead" points="56,416 44,410.4 44,421.6" fill="black" transform="rotate(180,48,416)"></polygon>
-                <polygon class="arrowhead" points="56,176 44,170.4 44,181.6" fill="black" transform="rotate(180,48,176)"></polygon>
-                <g class="text">
-                  <text x="60" y="52">Registrar-</text>
-                  <text x="188" y="52">Domain</text>
-                  <text x="348" y="52">Domain</text>
-                  <text x="452" y="52">Vendor</text>
-                  <text x="40" y="68">Agent</text>
-                  <text x="200" y="68">Registrar</text>
-                  <text x="332" y="68">CA</text>
-                  <text x="456" y="68">Service</text>
-                  <text x="52" y="84">(RegAgt)</text>
-                  <text x="192" y="84">(JRC)</text>
-                  <text x="452" y="84">(MASA)</text>
-                  <text x="40" y="116">|</text>
-                  <text x="412" y="116">Internet</text>
-                  <text x="36" y="132">[voucher</text>
-                  <text x="80" y="132">+</text>
-                  <text x="136" y="132">enrollment]</text>
-                  <text x="20" y="148">[PVR</text>
-                  <text x="64" y="148">PER</text>
-                  <text x="120" y="148">available</text>
-                  <text x="168" y="148">]</text>
-                  <text x="116" y="180">mTLS</text>
-                  <text x="164" y="196">[Reg-Agt</text>
-                  <text x="256" y="196">authenticated</text>
-                  <text x="152" y="212">and</text>
-                  <text x="220" y="212">authorized?]</text>
-                  <text x="120" y="244">Voucher-Req</text>
-                  <text x="120" y="260">(PVR)</text>
-                  <text x="164" y="276">[Reg-Agt</text>
-                  <text x="252" y="276">authorized?]</text>
-                  <text x="160" y="292">[accept</text>
-                  <text x="228" y="292">device?]</text>
-                  <text x="164" y="308">[contact</text>
-                  <text x="232" y="308">vendor]</text>
-                  <text x="332" y="324">mTLS</text>
-                  <text x="328" y="340">Voucher-Req</text>
-                  <text x="328" y="356">(RVR)</text>
-                  <text x="388" y="372">[extract</text>
-                  <text x="464" y="372">DomainID]</text>
-                  <text x="384" y="388">[update</text>
-                  <text x="440" y="388">audit</text>
-                  <text x="484" y="388">log]</text>
-                  <text x="328" y="404">Voucher</text>
-                  <text x="120" y="420">Voucher</text>
-                  <text x="116" y="452">Enroll-Req</text>
-                  <text x="112" y="468">(PER)</text>
-                  <text x="276" y="484">mTLS</text>
-                  <text x="276" y="500">Enroll-Req</text>
-                  <text x="264" y="516">(RER)</text>
-                  <text x="280" y="532">Enroll-Resp</text>
-                  <text x="120" y="548">Enroll-Resp</text>
-                  <text x="120" y="580">caCerts-Req</text>
-                  <text x="120" y="596">caCerts-Res</text>
-                </g>
-              </svg><a href="#section-6.2-4.1.1" class="pilcrow">¶</a>
-</div>
-</div>
-<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
-<a href="#name-request-processing-between-" class="selfRef">Request processing between Registrar-Agent and bootstrapping services</a>
-          </figcaption></figure>
-</div>
-<p id="section-6.2-5">The Registrar-Agent establishes a TLS connection to the registrar.
+<p id="section-7.3-1">Similar to BRSKI "requestvoucher" endpoint in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.2" class="relref">Section 5.2</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3-1" class="pilcrow">¶</a></p>
+<p id="section-7.3-2">The Registrar-Agent has acquired one or more PVR and PER object pairs<a href="#section-7.3-2" class="pilcrow">¶</a></p>
+<p id="section-7.3-3">The Registrar-Agent establishes a TLS connection to the registrar.
 As already stated in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the use of TLS 1.3 (or newer) is encouraged.
 TLS 1.2 or newer is <span class="bcp14">REQUIRED</span> on the Registrar-Agent side.
 TLS 1.3 (or newer) <span class="bcp14">SHOULD</span> be available on the registrar, but TLS 1.2 <span class="bcp14">MAY</span> be used.
-TLS 1.3 (or newer) <span class="bcp14">SHOULD</span> be available on the MASA, but TLS 1.2 <span class="bcp14">MAY</span> be used.<a href="#section-6.2-5" class="pilcrow">¶</a></p>
-<div id="connection-establishment-registrar-agent-to-registrar">
-<section id="section-6.2.1">
-          <h4 id="name-connection-establishment-re">
-<a href="#section-6.2.1" class="section-number selfRef">6.2.1. </a><a href="#name-connection-establishment-re" class="section-name selfRef">Connection Establishment (Registrar-Agent to Registrar)</a>
-          </h4>
-<p id="section-6.2.1-1">In contrast to BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> TLS client authentication to the registrar is achieved by using Registrar-Agent EE credentials instead of pledge IDevID credentials.
+TLS 1.3 (or newer) <span class="bcp14">SHOULD</span> be available on the MASA, but TLS 1.2 <span class="bcp14">MAY</span> be used.<a href="#section-7.3-3" class="pilcrow">¶</a></p>
+<p id="section-7.3-4">In contrast to BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> TLS client authentication to the registrar is achieved by using Registrar-Agent EE credentials instead of pledge IDevID credentials.
 Consequently BRSKI (pledge-initiator-mode) is distinguishable from BRSKI-PRM (pledge-responder-mode) by the registrar.
 The registrar <span class="bcp14">SHOULD</span> verify that the Registrar-Agent is authorized to establish a connection to the registrar based on the TLS client authentication.
 If the connection from Registrar-Agent to registrar is established, the authorization <span class="bcp14">SHOULD</span> be verified again based on agent-signed-data contained in the PVR.
-This ensures that the pledge has been triggered by an authorized Registrar-Agent.<a href="#section-6.2.1-1" class="pilcrow">¶</a></p>
-<p id="section-6.2.1-2">With BRSKI-PRM, the pledge generates PVR and PER as JSON-in-JWS objects and the Registrar-Agent forwards them to the registrar.
-In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the pledge generates PVR as CMS-signed JSON and PER as PKCS#10 or PKCS#7 according to <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> and inherited by <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-6.2.1-2" class="pilcrow">¶</a></p>
-<p id="section-6.2.1-3">For BRSKI-PRM, the Registrar-Agent sends the PVR by HTTP POST to the same registrar endpoint as introduced by BRSKI: "/.well-
-known/brski/requestvoucher", but with a Content-Type header field for JSON-in-JWS"<a href="#section-6.2.1-3" class="pilcrow">¶</a></p>
-<p id="section-6.2.1-4">The Content-Type header field for JSON-in-JWS PVR is: <code>application/voucher-jws+json</code> (see <a href="#pvr" class="auto internal xref">Figure 8</a> for the content definition), as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-6.2.1-4" class="pilcrow">¶</a></p>
-<p id="section-6.2.1-5">The Registrar-Agent sets the Accept field in the request-header indicating the acceptable Content-Type for the voucher-response.
-The voucher-response Content-Type header field is set to <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-6.2.1-5" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="pvr-proc-reg">
-<section id="section-6.2.2">
-          <h4 id="name-pledge-voucher-request-pvr-p">
-<a href="#section-6.2.2" class="section-number selfRef">6.2.2. </a><a href="#name-pledge-voucher-request-pvr-p" class="section-name selfRef">Pledge-Voucher-Request (PVR) Processing by Registrar</a>
+This ensures that the pledge has been triggered by an authorized Registrar-Agent.<a href="#section-7.3-4" class="pilcrow">¶</a></p>
+<p id="section-7.3-5">With BRSKI-PRM, the pledge generates PVR and PER as JSON-in-JWS objects and the Registrar-Agent forwards them to the registrar.
+In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the pledge generates PVR as CMS-signed JSON and PER as PKCS#10 or PKCS#7 according to <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> and inherited by <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3-5" class="pilcrow">¶</a></p>
+<div id="request-artifact-pvr">
+<section id="section-7.3.1">
+          <h4 id="name-request-artifact-pvr">
+<a href="#section-7.3.1" class="section-number selfRef">7.3.1. </a><a href="#name-request-artifact-pvr" class="section-name selfRef">Request Artifact: PVR</a>
           </h4>
-<p id="section-6.2.2-1">After receiving the PVR from Registrar-Agent, the registrar <span class="bcp14">SHALL</span> perform the verification as defined in section 5.3 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-In addition, the registrar <span class="bcp14">SHALL</span> verify the following parameters from the PVR:<a href="#section-6.2.2-1" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-6.2.2-2.1">
-              <p id="section-6.2.2-2.1.1">agent-provided-proximity-registrar-cert: <span class="bcp14">MUST</span> contain registrar's own registrar LDevID certificate to ensure the registrar in proximity of the Registrar-Agent is the desired registrar for this PVR.<a href="#section-6.2.2-2.1.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-6.2.2-2.2">
-              <p id="section-6.2.2-2.2.1">agent-signed-data: The registrar <span class="bcp14">MUST</span> verify that the Registrar-Agent provided data has been signed with the private key corresponding to the EE (RegAgt) certificate indicated in the "kid" JOSE header parameter.
-The registrar <span class="bcp14">MUST</span> verify that the LDevID(ReAgt) certificate, corresponding to the signature, is still valid.
-If the certificate is already expired, the registrar <span class="bcp14">SHALL</span> reject the request.
-Validity of used signing certificates at the time of signing the agent-signed-data is necessary to avoid that a rogue Registrar-Agent generates agent-signed-data objects to onboard arbitrary pledges at a later point in time, see also <a href="#sec_cons_reg-agt" class="auto internal xref">Section 10.3</a>.
-The registrar <span class="bcp14">MUST</span> fetch the EE (RegAgt) certificate, based on the provided SubjectKeyIdentifier (SKID) contained in the "kid" header parameter of the agent-signed-data, and perform this verification.
-This requires, that the registrar has access to the EE (RegAgt) certificate data (including intermediate CA certificates if existent) based on the SKID.
-Note, the registrar may have stored the EE (RegAgt) certificate if used during TLS establishment between Registrar-Agent and registrar or it may be provided via a repository.<a href="#section-6.2.2-2.2.1" class="pilcrow">¶</a></p>
-</li>
-          </ul>
-<p id="section-6.2.2-3">If the registrar is unable to validate the PVR it <span class="bcp14">SHOULD</span> respond with a HTTP 4xx/5xx error code to the Registrar-Agent.<a href="#section-6.2.2-3" class="pilcrow">¶</a></p>
-<p id="section-6.2.2-4">The following 4xx client error codes <span class="bcp14">SHOULD</span> be used:<a href="#section-6.2.2-4" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-6.2.2-5.1">
-              <p id="section-6.2.2-5.1.1">403 Forbidden: if the registrar detected that one or more security related parameters are not valid.<a href="#section-6.2.2-5.1.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-6.2.2-5.2">
-              <p id="section-6.2.2-5.2.1">404 Not Found status code if the pledge provided information could not be used with automated allowance, as described in section 5.3 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-6.2.2-5.2.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-6.2.2-5.3">
-              <p id="section-6.2.2-5.3.1">406 Not Acceptable: if the Content-Type indicated by the Accept header is unknown or unsupported.<a href="#section-6.2.2-5.3.1" class="pilcrow">¶</a></p>
-</li>
-          </ul>
-<p id="section-6.2.2-6">If the validation succeeds, the registrar performs pledge authorization according to <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, Section 5.3 followed by obtaining a voucher from the pledge's MASA according to <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, Section 5.4 with the modifications described below in <a href="#rvr-proc" class="auto internal xref">Section 6.2.3</a>.<a href="#section-6.2.2-6" class="pilcrow">¶</a></p>
+<p id="section-7.3.1-1">For BRSKI-PRM, the Registrar-Agent sends the PVR by HTTP POST to the same registrar endpoint as introduced by BRSKI: "/.well-
+known/brski/requestvoucher", but with a Content-Type header field for JSON-in-JWS"<a href="#section-7.3.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.3.1-2">The Content-Type header field for JSON-in-JWS PVR is: <code>application/voucher-jws+json</code> (see <a href="#tpvr" class="auto internal xref">Section 7.1</a> for the content definition), as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.3.1-3">The Registrar-Agent sets the Accept field in the request-header indicating the acceptable Content-Type for the voucher-response.
+The voucher-response Content-Type header field is set to <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.1-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="rvr-proc">
-<section id="section-6.2.3">
+<section id="section-7.3.2">
           <h4 id="name-registrar-voucher-request-r">
-<a href="#section-6.2.3" class="section-number selfRef">6.2.3. </a><a href="#name-registrar-voucher-request-r" class="section-name selfRef">Registrar-Voucher-Request (RVR) Processing (Registrar to MASA)</a>
+<a href="#section-7.3.2" class="section-number selfRef">7.3.2. </a><a href="#name-registrar-voucher-request-r" class="section-name selfRef">Registrar Voucher-Request (RVR) Processing (Registrar to MASA)</a>
           </h4>
-<p id="section-6.2.3-1">If the MASA address/URI is learned from the <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> Section 2.3 IDevID MASA URI extension, then the MASA on that URI <span class="bcp14">MUST</span> support the procedures defined in this document if the PVR used JSON-JWS encoding.
-If the MASA is only configured on the registrar, then a registrar supporting BRKSI-PRM and other voucher encoding formats (such as those in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>) <span class="bcp14">SHOULD</span> support per-message-format MASA address/URI configuration for the same IDevID trust anchor."<a href="#section-6.2.3-1" class="pilcrow">¶</a></p>
-<p id="section-6.2.3-2">The registrar <span class="bcp14">SHALL</span> construct the payload of the RVR as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, Section 5.5.
-The RVR encoding <span class="bcp14">SHALL</span> be JSON-in-JWS as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-6.2.3-2" class="pilcrow">¶</a></p>
-<p id="section-6.2.3-3">The header of the RVR <span class="bcp14">SHALL</span> contain the following parameter as defined for JWS <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>:<a href="#section-6.2.3-3" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-1">If the MASA address/URI is learned from the IDevID MASA URI extension (<span><a href="https://rfc-editor.org/rfc/rfc8995#section-2.3" class="relref">Section 2.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>), then the MASA on that URI <span class="bcp14">MUST</span> support the procedures defined in this document if the PVR used JSON-JWS encoding.
+If the MASA is only configured on the registrar, then a registrar supporting BRKSI-PRM and other voucher encoding formats (such as those in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>) <span class="bcp14">SHOULD</span> support per-message-format MASA address/URI configuration for the same IDevID trust anchor."<a href="#section-7.3.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-2">The registrar <span class="bcp14">SHALL</span> construct the payload of the RVR as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, Section 5.5.
+The RVR encoding <span class="bcp14">SHALL</span> be JSON-in-JWS as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-3">The header of the RVR <span class="bcp14">SHALL</span> contain the following parameter as defined for JWS <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>:<a href="#section-7.3.2-3" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.2.3-4.1">
-              <p id="section-6.2.3-4.1.1">alg: algorithm used to create the object signature<a href="#section-6.2.3-4.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.3.2-4.1">
+              <p id="section-7.3.2-4.1.1">alg: algorithm used to create the object signature<a href="#section-7.3.2-4.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.2.3-4.2">
-              <p id="section-6.2.3-4.2.1">x5c: base64-encoded registrar LDevID certificate(s)
-(It optionally contains the certificate chain for this certificate)<a href="#section-6.2.3-4.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.3.2-4.2">
+              <p id="section-7.3.2-4.2.1">x5c: base64-encoded registrar LDevID certificate(s)
+(It optionally contains the certificate chain for this certificate)<a href="#section-7.3.2-4.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.2.3-5">The payload of the RVR <span class="bcp14">MUST</span> contain the following parameter as part of the voucher-request as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>:<a href="#section-6.2.3-5" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-5">The payload of the RVR <span class="bcp14">MUST</span> contain the following parameter as part of the voucher-request as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>:<a href="#section-7.3.2-5" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.2.3-6.1">
-              <p id="section-6.2.3-6.1.1">created-on: current date and time in yang:date-and-time format of RVR creation<a href="#section-6.2.3-6.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.3.2-6.1">
+              <p id="section-7.3.2-6.1.1">created-on: current date and time in yang:date-and-time format of RVR creation<a href="#section-7.3.2-6.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.2.3-6.2">
-              <p id="section-6.2.3-6.2.1">nonce: copied from the PVR<a href="#section-6.2.3-6.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.3.2-6.2">
+              <p id="section-7.3.2-6.2.1">nonce: copied from the PVR<a href="#section-7.3.2-6.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.2.3-6.3">
-              <p id="section-6.2.3-6.3.1">serial-number: product-serial-number of pledge.
+            <li class="normal" id="section-7.3.2-6.3">
+              <p id="section-7.3.2-6.3.1">serial-number: product-serial-number of pledge.
 The registrar <span class="bcp14">MUST</span> verify that the IDevID certificate subject serialNumber of the pledge (X520SerialNumber) matches the serial-number value in the PVR.
-In addition, it <span class="bcp14">MUST</span> be equal to the serial-number value contained in the agent-signed data of PVR.<a href="#section-6.2.3-6.3.1" class="pilcrow">¶</a></p>
+In addition, it <span class="bcp14">MUST</span> be equal to the serial-number value contained in the agent-signed data of PVR.<a href="#section-7.3.2-6.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.2.3-6.4">
-              <p id="section-6.2.3-6.4.1">assertion: voucher assertion requested by the pledge (agent-proximity).
-The registrar provides this information to assure successful verification of Registrar-Agent proximity based on the agent-signed-data.<a href="#section-6.2.3-6.4.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.3.2-6.4">
+              <p id="section-7.3.2-6.4.1">assertion: voucher assertion requested by the pledge (agent-proximity).
+The registrar provides this information to assure successful verification of Registrar-Agent proximity based on the agent-signed-data.<a href="#section-7.3.2-6.4.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.2.3-6.5">
-              <p id="section-6.2.3-6.5.1">prior-signed-voucher-request: PVR as received from Registrar-Agent, see <a href="#pvrr" class="auto internal xref">Section 6.1.2</a><a href="#section-6.2.3-6.5.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.3.2-6.5">
+              <p id="section-7.3.2-6.5.1">prior-signed-voucher-request: PVR as received from Registrar-Agent, see <a href="#tpvr" class="auto internal xref">Section 7.1</a><a href="#section-7.3.2-6.5.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.2.3-7">The RVR <span class="bcp14">MUST</span> be extended with the following parameter, when the assertion "agent-proximity" is requested, as defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>:<a href="#section-6.2.3-7" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-7">The RVR <span class="bcp14">MUST</span> be extended with the following parameter, when the assertion "agent-proximity" is requested, as defined in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span>:<a href="#section-7.3.2-7" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.2.3-8.1">
-              <p id="section-6.2.3-8.1.1">agent-sign-cert: EE (RegAgt) certificate or the EE (RegAgt) certificate including certificate chain.
+<li class="normal" id="section-7.3.2-8.1">
+              <p id="section-7.3.2-8.1.1">agent-sign-cert: EE (RegAgt) certificate or the EE (RegAgt) certificate including certificate chain.
 In the context of this document it is a JSON array of base64encoded certificate information and handled in the same way as x5c header objects.
 If only a single object is contained in the x5c it <span class="bcp14">MUST</span> be the base64-encoded EE (RegAgt) certificate.
-If multiple certificates are included in the x5c, the first <span class="bcp14">MUST</span> be the base64-encoded EE (RegAgt) certificate.<a href="#section-6.2.3-8.1.1" class="pilcrow">¶</a></p>
+If multiple certificates are included in the x5c, the first <span class="bcp14">MUST</span> be the base64-encoded EE (RegAgt) certificate.<a href="#section-7.3.2-8.1.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.2.3-9">The MASA uses this information for verification that the Registrar-Agent is in proximity to the registrar to state the corresponding assertion "agent-proximity".<a href="#section-6.2.3-9" class="pilcrow">¶</a></p>
-<p id="section-6.2.3-10">The object is signed using the registrar LDevID credentials, which corresponds to the certificate referenced in the JOSE header.<a href="#section-6.2.3-10" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-9">The MASA uses this information for verification that the Registrar-Agent is in proximity to the registrar to state the corresponding assertion "agent-proximity".<a href="#section-7.3.2-9" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-10">The object is signed using the registrar LDevID credentials, which corresponds to the certificate referenced in the JOSE header.<a href="#section-7.3.2-10" class="pilcrow">¶</a></p>
 <span id="name-representation-of-rvr"></span><div id="rvr">
-<figure id="figure-12">
-            <div class="alignLeft art-text artwork" id="section-6.2.3-11.1">
+<figure id="figure-10">
+            <div class="alignLeft art-text artwork" id="section-7.3.2-11.1">
 <pre>
 # The RVR in General JWS Serialization syntax
 {
-  "payload": BASE64URL(ietf-voucher-request:voucher),
+  "payload": BASE64URL(UTF8(ietf-voucher-request-prm:voucher)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -3595,21 +3586,19 @@ If multiple certificates are included in the x5c, the first <span class="bcp14">
   ]
 }
 
-# Example: Decoded payload "ietf-voucher-request:voucher"
+# Example: Decoded payload "ietf-voucher-request-prm:voucher"
   representation in JSON syntax
-{
-  "ietf-voucher-request:voucher": {
-     "created-on": "2022-01-04T02:37:39.235Z",
-     "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
-     "serial-number": "callee4711",
-     "assertion": "agent-proximity",
-     "prior-signed-voucher-request": "base64encodedvalue==",
-     "agent-sign-cert": [
-       "base64encodedvalue==",
-       "base64encodedvalue==",
-       "..."
-     ]
-  }
+"ietf-voucher-request-prm:voucher": {
+   "created-on": "2022-01-04T02:37:39.235Z",
+   "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
+   "serial-number": "callee4711",
+   "assertion": "agent-proximity",
+   "prior-signed-voucher-request": "base64encodedvalue==",
+   "agent-sign-cert": [
+     "base64encodedvalue==",
+     "base64encodedvalue==",
+     "..."
+   ]
 }
 
 # Example: Decoded "JWS Protected Header" representation
@@ -3624,53 +3613,53 @@ If multiple certificates are included in the x5c, the first <span class="bcp14">
 }
 </pre>
 </div>
-<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
+<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
 <a href="#name-representation-of-rvr" class="selfRef">Representation of RVR</a>
             </figcaption></figure>
 </div>
-<p id="section-6.2.3-12">The registrar <span class="bcp14">SHALL</span> send the RVR to the MASA endpoint by HTTP POST: "/.well-known/brski/requestvoucher"<a href="#section-6.2.3-12" class="pilcrow">¶</a></p>
-<p id="section-6.2.3-13">The RVR Content-Type header field is defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span> as: <code>application/voucher-jws+json</code><a href="#section-6.2.3-13" class="pilcrow">¶</a></p>
-<p id="section-6.2.3-14">The registrar <span class="bcp14">SHOULD</span> set the Accept header of the RVR indicating the desired media type for the voucher-response.
-The media type is <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-6.2.3-14" class="pilcrow">¶</a></p>
-<p id="section-6.2.3-15">This document uses the JSON-in-JWS format throughout the definition of exchanges and in the examples.
-Nevertheless, alternative encodings of the voucher as used in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with JSON-in-CMS or CBOR-in-COSE_Sign <span>[<a href="#RFC8152" class="cite xref">RFC8152</a>]</span> for constraint environments are possible as well.
+<p id="section-7.3.2-12">The registrar <span class="bcp14">SHALL</span> send the RVR to the MASA endpoint by HTTP POST: "/.well-known/brski/requestvoucher"<a href="#section-7.3.2-12" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-13">The RVR Content-Type header field is defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span> as: <code>application/voucher-jws+json</code><a href="#section-7.3.2-13" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-14">The registrar <span class="bcp14">SHOULD</span> set the Accept header of the RVR indicating the desired media type for the voucher-response.
+The media type is <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.<a href="#section-7.3.2-14" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-15">This document uses the JSON-in-JWS format throughout the definition of exchanges and in the examples.
+Nevertheless, alternative encodings of the voucher as used in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with JSON-in-CMS or CBOR-in-COSE_Sign <span>[<a href="#RFC9052" class="cite xref">RFC9052</a>]</span> for constraint environments are possible as well.
 The assumption is that a pledge typically supports a single encoding variant and creates the PVR in the supported format.
-To ensure that the pledge is able to process the voucher, the registrar <span class="bcp14">MUST</span> use the media type for Accept header in the RVR based on the media type used for the PVR.<a href="#section-6.2.3-15" class="pilcrow">¶</a></p>
-<p id="section-6.2.3-16">Once the MASA receives the RVR it <span class="bcp14">SHALL</span> perform the verification as described in Section 5.5 in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-6.2.3-16" class="pilcrow">¶</a></p>
-<p id="section-6.2.3-17">In addition, the following processing <span class="bcp14">SHALL</span> be performed for PVR contained in RVR "prior-signed-voucher-request" field:<a href="#section-6.2.3-17" class="pilcrow">¶</a></p>
+To ensure that the pledge is able to process the voucher, the registrar <span class="bcp14">MUST</span> use the media type for Accept header in the RVR based on the media type used for the PVR.<a href="#section-7.3.2-15" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-16">Once the MASA receives the RVR it <span class="bcp14">SHALL</span> perform the verification as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.5" class="relref">Section 5.5</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3.2-16" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-17">In addition, the following processing <span class="bcp14">SHALL</span> be performed for PVR contained in RVR "prior-signed-voucher-request" field:<a href="#section-7.3.2-17" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.2.3-18.1">
-              <p id="section-6.2.3-18.1.1">agent-provided-proximity-registrar-cert: The MASA <span class="bcp14">MAY</span> verify that this field contains the registrar LDevID certificate.
+<li class="normal" id="section-7.3.2-18.1">
+              <p id="section-7.3.2-18.1.1">agent-provided-proximity-registrar-cert: The MASA <span class="bcp14">MAY</span> verify that this field contains the registrar LDevID certificate.
 If so, it <span class="bcp14">MUST</span> correspond to the registrar LDevID credentials used to sign the RVR.
-Note: Correspond here relates to the case that a single registrar LDevID certificate is used or that different registrar LDevID certificates are used, which are issued by the same CA.<a href="#section-6.2.3-18.1.1" class="pilcrow">¶</a></p>
+Note: Correspond here relates to the case that a single registrar LDevID certificate is used or that different registrar LDevID certificates are used, which are issued by the same CA.<a href="#section-7.3.2-18.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.2.3-18.2">
-              <p id="section-6.2.3-18.2.1">agent-signed-data: The MASA <span class="bcp14">MAY</span> verify this data to issue "agent-proximity" assertion.
+            <li class="normal" id="section-7.3.2-18.2">
+              <p id="section-7.3.2-18.2.1">agent-signed-data: The MASA <span class="bcp14">MAY</span> verify this data to issue "agent-proximity" assertion.
 If so, the agent-signed-data <span class="bcp14">MUST</span> contain the pledge product-serial-number, contained in the "serial-number" field of the PVR (from "prior-signed-voucher-request" field) and also in "serial-number" field of the RVR.
 The EE (RegAgt) certificate to be used for signature verification is identified by the "kid" parameter of the JOSE header.
 If the assertion "agent-proximity" is requested, the RVR <span class="bcp14">MUST</span> contain the corresponding EE (RegAgt) certificate data in the "agent-sign-cert" field of the RVR.
 It <span class="bcp14">MUST</span> be verified by the MASA to the same domain CA as the registrar LDevID certificate.
 If the "agent-sign-cert" field is not set, the MASA <span class="bcp14">MAY</span> state a lower level assertion value, e.g.: "logged" or "verified".
 Note: Sub-CA certificate(s) <span class="bcp14">MUST</span> also be carried by "agent-sign-cert", in case the EE (RegAgt) certificate is issued by a sub-CA and not the domain CA known to the MASA.
-As the "agent-sign-cert" field is defined as array (x5c), it can handle multiple certificates.<a href="#section-6.2.3-18.2.1" class="pilcrow">¶</a></p>
+As the "agent-sign-cert" field is defined as array (x5c), it can handle multiple certificates.<a href="#section-7.3.2-18.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.2.3-19">If validation fails, the MASA <span class="bcp14">SHOULD</span> respond with an HTTP 4xx client error status code to the registrar.
-The HTTP error status codes are kept the same as defined in Section 5.6 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> and comprise the codes: 403, 404, 406, and 415.<a href="#section-6.2.3-19" class="pilcrow">¶</a></p>
+<p id="section-7.3.2-19">If validation fails, the MASA <span class="bcp14">SHOULD</span> respond with an HTTP 4xx client error status code to the registrar.
+The HTTP error status codes are kept the same as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> and comprise the codes: 403, 404, 406, and 415.<a href="#section-7.3.2-19" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="exchanges_uc2_2_vc">
-<section id="section-6.2.4">
+<section id="section-7.3.3">
           <h4 id="name-voucher-issuance-by-masa">
-<a href="#section-6.2.4" class="section-number selfRef">6.2.4. </a><a href="#name-voucher-issuance-by-masa" class="section-name selfRef">Voucher Issuance by MASA</a>
+<a href="#section-7.3.3" class="section-number selfRef">7.3.3. </a><a href="#name-voucher-issuance-by-masa" class="section-name selfRef">Voucher Issuance by MASA</a>
           </h4>
-<p id="section-6.2.4-1">The MASA creates a voucher with Media-Type of <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
+<p id="section-7.3.3-1">The MASA creates a voucher with Media-Type of <code>application/voucher-jws+json</code> as defined in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
 If the MASA detects that the Accept header of the PVR does not match <code>application/voucher-jws+json</code> it <span class="bcp14">SHOULD</span> respond with the HTTP status code "406 Not Acceptable" as the pledge will not be able to parse the response.
-The voucher is according to <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> but uses the new assertion value specified <a href="#agt_prx" class="auto internal xref">Section 5.4</a>.<a href="#section-6.2.4-1" class="pilcrow">¶</a></p>
-<p id="section-6.2.4-2"><a href="#MASA-vr" class="auto internal xref">Figure 13</a> shows an example of the contents of a voucher.<a href="#section-6.2.4-2" class="pilcrow">¶</a></p>
+The voucher is according to <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> but uses the new assertion value specified <a href="#agt_prx" class="auto internal xref">Section 5.4</a>.<a href="#section-7.3.3-1" class="pilcrow">¶</a></p>
+<p id="section-7.3.3-2"><a href="#MASA-vr" class="auto internal xref">Figure 11</a> shows an example of the contents of a voucher.<a href="#section-7.3.3-2" class="pilcrow">¶</a></p>
 <span id="name-representation-of-masa-issu"></span><div id="MASA-vr">
-<figure id="figure-13">
-            <div class="alignLeft art-text artwork" id="section-6.2.4-3.1">
+<figure id="figure-11">
+            <div class="alignLeft art-text artwork" id="section-7.3.3-3.1">
 <pre>
 # The MASA issued voucher in General JWS Serialization syntax
 {
@@ -3685,14 +3674,12 @@ The voucher is according to <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="c
 
 # Example: Decoded payload "ietf-voucher:voucher" representation
   in JSON syntax
-{
-  "ietf-voucher:voucher": {
-    "assertion": "agent-proximity",
-    "serial-number": "callee4711",
-    "nonce": "base64encodedvalue==",
-    "created-on": "2022-01-04T00:00:02.000Z",
-    "pinned-domain-cert": "base64encodedvalue=="
-  }
+"ietf-voucher:voucher": {
+  "assertion": "agent-proximity",
+  "serial-number": "callee4711",
+  "nonce": "base64encodedvalue==",
+  "created-on": "2022-01-04T00:00:02.000Z",
+  "pinned-domain-cert": "base64encodedvalue=="
 }
 
 # Example: Decoded "JWS Protected Header" representation
@@ -3707,37 +3694,37 @@ The voucher is according to <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="c
 }
 </pre>
 </div>
-<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
+<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
 <a href="#name-representation-of-masa-issu" class="selfRef">Representation of MASA issued voucher</a>
             </figcaption></figure>
 </div>
-<p id="section-6.2.4-4">The pinned-domain certificate to be put into the voucher is determined by the MASA as described in section 5.5 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-The MASA returns the voucher-response (voucher) to the registrar.<a href="#section-6.2.4-4" class="pilcrow">¶</a></p>
+<p id="section-7.3.3-4">The pinned-domain certificate to be put into the voucher is determined by the MASA as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.5" class="relref">Section 5.5</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+The MASA returns the voucher-response (voucher) to the registrar.<a href="#section-7.3.3-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="exchanges_uc2_2_vs">
-<section id="section-6.2.5">
+<section id="section-7.3.4">
           <h4 id="name-masa-issued-voucher-process">
-<a href="#section-6.2.5" class="section-number selfRef">6.2.5. </a><a href="#name-masa-issued-voucher-process" class="section-name selfRef">MASA issued Voucher Processing by Registrar</a>
+<a href="#section-7.3.4" class="section-number selfRef">7.3.4. </a><a href="#name-masa-issued-voucher-process" class="section-name selfRef">MASA issued Voucher Processing by Registrar</a>
           </h4>
-<p id="section-6.2.5-1">After receiving the voucher the registrar <span class="bcp14">SHOULD</span> evaluate it for transparency and logging purposes as outlined in Section 5.6 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-The registrar <span class="bcp14">MUST</span> add an additional signature to the MASA provided voucher using its registrar EE credentials.<a href="#section-6.2.5-1" class="pilcrow">¶</a></p>
-<p id="section-6.2.5-2">The signature is created by signing the original "JWS Payload" produced by MASA and the registrar added "JWS Protected Header" using the registrar EE credentials (see <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>, Section 5.2 point 8.
+<p id="section-7.3.4-1">After receiving the voucher the registrar <span class="bcp14">SHOULD</span> evaluate it for transparency and logging purposes as outlined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6" class="relref">Section 5.6</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+The registrar <span class="bcp14">MUST</span> add an additional signature to the MASA provided voucher using its registrar EE credentials.<a href="#section-7.3.4-1" class="pilcrow">¶</a></p>
+<p id="section-7.3.4-2">The signature is created by signing the original "JWS Payload" produced by MASA and the registrar added "JWS Protected Header" using the registrar EE credentials (see <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span>, Section 5.2 point 8.
 The x5c component of the "JWS Protected Header" <span class="bcp14">MUST</span> contain the registrar EE certificate as well as potential subordinate CA certificates up to (but not including) the pinned domain certificate.
-The pinned domain certificate is already contained in the voucher payload ("pinned-domain-cert").<a href="#section-6.2.5-2" class="pilcrow">¶</a></p>
-<p id="section-6.2.5-3">(For many installations, with a single registrar credential, the registrar credential is what is pinned)<a href="#section-6.2.5-3" class="pilcrow">¶</a></p>
-<p id="section-6.2.5-4">In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the Registrar proved possession of the it's credential when the TLS session was setup.
-While the pledge could not, at the time, validate the certificate truly belonged the registrar, it did validate that the certificate it was provided was able to authenticate the TLS connection.<a href="#section-6.2.5-4" class="pilcrow">¶</a></p>
-<p id="section-6.2.5-5">In the BRSKI-PRM mode, with the Registrar-Agent mediating all communication, the Pledge has not as yet been able to witness that the intended Registrar really does possess the relevant private key.
-This second signature provides for the same level of assurance to the pledge, and that it matches the public key that the pledge received in the trigger for the PVR (see <a href="#pavrt" class="auto internal xref">Figure 6</a>).<a href="#section-6.2.5-5" class="pilcrow">¶</a></p>
-<p id="section-6.2.5-6">The registrar <span class="bcp14">MUST</span> use the same registrar EE credentials used for authentication in the TLS handshake to authenticate towards the Registrar-Agent.
-This has some operational implications when the registrar may be part of a scalable framework as described in <span>[<a href="#I-D.richardson-anima-registrar-considerations" class="cite xref">I-D.richardson-anima-registrar-considerations</a>], <a href="https://datatracker.ietf.org/doc/html/draft-richardson-anima-registrar-considerations-07#section-1.3.1" class="relref">Section 1.3.1</a></span>.<a href="#section-6.2.5-6" class="pilcrow">¶</a></p>
-<p id="section-6.2.5-7">The second signature <span class="bcp14">MUST</span> either be done with the private key associated with the registrar EE certificate provided to the Registrar-Agent, or the use of a certificate chain is necessary.
-This ensures that the same registrar EE certificate can be used to verify the signature as transmitted in the voucher-request as also transferred in the PVR in the "agent-provided-proximity-registrar-cert".<a href="#section-6.2.5-7" class="pilcrow">¶</a></p>
-<p id="section-6.2.5-8"><a href="#MASA-REG-vr" class="auto internal xref">Figure 14</a> below provides an example of the voucher with two signatures.<a href="#section-6.2.5-8" class="pilcrow">¶</a></p>
+The pinned domain certificate is already contained in the voucher payload ("pinned-domain-cert").<a href="#section-7.3.4-2" class="pilcrow">¶</a></p>
+<p id="section-7.3.4-3">(For many installations, with a single registrar credential, the registrar credential is what is pinned)<a href="#section-7.3.4-3" class="pilcrow">¶</a></p>
+<p id="section-7.3.4-4">In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the Registrar proved possession of the it's credential when the TLS session was setup.
+While the pledge could not, at the time, validate the certificate truly belonged the registrar, it did validate that the certificate it was provided was able to authenticate the TLS connection.<a href="#section-7.3.4-4" class="pilcrow">¶</a></p>
+<p id="section-7.3.4-5">In the BRSKI-PRM mode, with the Registrar-Agent mediating all communication, the Pledge has not as yet been able to witness that the intended Registrar really does possess the relevant private key.
+This second signature provides for the same level of assurance to the pledge, and that it matches the public key that the pledge received in the trigger for the PVR (see <a href="#pavrt" class="auto internal xref">Figure 5</a>).<a href="#section-7.3.4-5" class="pilcrow">¶</a></p>
+<p id="section-7.3.4-6">The registrar <span class="bcp14">MUST</span> use the same registrar EE credentials used for authentication in the TLS handshake to authenticate towards the Registrar-Agent.
+This has some operational implications when the registrar may be part of a scalable framework as described in <span>[<a href="#I-D.richardson-anima-registrar-considerations" class="cite xref">I-D.richardson-anima-registrar-considerations</a>], <a href="https://datatracker.ietf.org/doc/html/draft-richardson-anima-registrar-considerations-07#section-1.3.1" class="relref">Section 1.3.1</a></span>.<a href="#section-7.3.4-6" class="pilcrow">¶</a></p>
+<p id="section-7.3.4-7">The second signature <span class="bcp14">MUST</span> either be done with the private key associated with the registrar EE certificate provided to the Registrar-Agent, or the use of a certificate chain is necessary.
+This ensures that the same registrar EE certificate can be used to verify the signature as transmitted in the voucher-request as also transferred in the PVR in the "agent-provided-proximity-registrar-cert".<a href="#section-7.3.4-7" class="pilcrow">¶</a></p>
+<p id="section-7.3.4-8"><a href="#MASA-REG-vr" class="auto internal xref">Figure 12</a> below provides an example of the voucher with two signatures.<a href="#section-7.3.4-8" class="pilcrow">¶</a></p>
 <span id="name-representation-of-masa-issue"></span><div id="MASA-REG-vr">
-<figure id="figure-14">
-            <div class="alignLeft art-text artwork" id="section-6.2.5-9.1">
+<figure id="figure-12">
+            <div class="alignLeft art-text artwork" id="section-7.3.4-9.1">
 <pre>
 # The MASA issued voucher with additional registrar signature in
   General JWS Serialization syntax
@@ -3757,25 +3744,23 @@ This ensures that the same registrar EE certificate can be used to verify the si
 
 # Example: Decoded payload "ietf-voucher:voucher" representation in
   JSON syntax
-{
-  "ietf-voucher:voucher": {
-     "assertion": "agent-proximity",
-     "serial-number": "callee4711",
-     "nonce": "base64encodedvalue==",
-     "created-on": "2022-01-04T00:00:02.000Z",
-     "pinned-domain-cert": "base64encodedvalue=="
-  }
+"ietf-voucher:voucher": {
+   "assertion": "agent-proximity",
+   "serial-number": "callee4711",
+   "nonce": "base64encodedvalue==",
+   "created-on": "2022-01-04T00:00:02.000Z",
+   "pinned-domain-cert": "base64encodedvalue=="
 }
 
 # Example: Decoded "JWS Protected Header (MASA)" representation
   in JSON syntax
 {
   "alg": "ES256",
+  "typ": "voucher-jws+json",
   "x5c": [
     "base64encodedvalue==",
     "base64encodedvalue=="
-  ],
-  "typ": "voucher-jws+json"
+  ]
 }
 
 # Example: Decoded "JWS Protected Header (Reg)" representation
@@ -3789,70 +3774,140 @@ This ensures that the same registrar EE certificate can be used to verify the si
 }
 </pre>
 </div>
-<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
+<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
 <a href="#name-representation-of-masa-issue" class="selfRef">Representation of MASA issued voucher with additional registrar signature</a>
             </figcaption></figure>
 </div>
-<p id="section-6.2.5-10">Depending on the security policy of the operator, this signature can also be interpreted by the pledge as explicit authorization of the registrar to install the contained trust anchor.
-The registrar sends the voucher to the Registrar-Agent.<a href="#section-6.2.5-10" class="pilcrow">¶</a></p>
+<p id="section-7.3.4-10">Depending on the security policy of the operator, this signature can also be interpreted by the pledge as explicit authorization of the registrar to install the contained trust anchor.
+The registrar sends the voucher to the Registrar-Agent.<a href="#section-7.3.4-10" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="exchanges_uc2_2_per">
-<section id="section-6.2.6">
-          <h4 id="name-pledge-enrollment-request-per">
-<a href="#section-6.2.6" class="section-number selfRef">6.2.6. </a><a href="#name-pledge-enrollment-request-per" class="section-name selfRef">Pledge-Enrollment-Request (PER) Processing (Registrar-Agent to Registrar)</a>
+<div id="response-artifact-voucher">
+<section id="section-7.3.5">
+          <h4 id="name-response-artifact-voucher">
+<a href="#section-7.3.5" class="section-number selfRef">7.3.5. </a><a href="#name-response-artifact-voucher" class="section-name selfRef">Response Artifact: Voucher</a>
           </h4>
-<p id="section-6.2.6-1">After receiving the voucher, the Registrar-Agent sends the PER to the registrar in the same HTTP-over-TLS connection. Which is similar to the PER processing described in Section 5.2 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-In case the PER cannot be send in the same HTTP-over-TLS connection the Registrar-Agent may send the PER in a new HTTP-over-TLS connection. The registrar is able to correlate the PVR and the PER based on the signatures and the contained product-serial-number information.
-Note, this also addresses situations in which a nonceless voucher is used and may be pre-provisioned to the pledge.
-As specified in <a href="#PER-response" class="auto internal xref">Section 6.1.4</a> deviating from BRSKI the PER is not a raw PKCS#10.
-As the Registrar-Agent is involved in the exchange, the PKCS#10 is wrapped in a JWS object by the pledge and signed with pledge's IDevID to ensure proof-of-identity as outlined in <a href="#per" class="auto internal xref">Figure 10</a>.<a href="#section-6.2.6-1" class="pilcrow">¶</a></p>
-<p id="section-6.2.6-2">EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> standard endpoints (/simpleenroll, /simplereenroll, /serverkeygen, /cacerts) on the registrar cannot be used for BRSKI-PRM.
-This is caused by the utilization of signature wrapped-objects in BRSKI-PRM.
-As EST requires to sent a raw PKCS#10 request to e.g., "/.well-known/est/simpleenroll" endpoint, this document makes an enhancement by utilizing EST but with the exception to transport a signature wrapped PKCS#10 request.
-Therefore a new endpoint for BRSKI-PRM on the registrar is defined as "/.well-known/brski/requestenroll"<a href="#section-6.2.6-2" class="pilcrow">¶</a></p>
-<p id="section-6.2.6-3">The Content-Type header of PER is: <code>application/jose+json</code>.<a href="#section-6.2.6-3" class="pilcrow">¶</a></p>
-<p id="section-6.2.6-4">This is a deviation from the Content-Type header values used in <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> and results in additional processing at the domain registrar (as EST server).
-Note, the registrar is already aware that the bootstrapping is performed in a pledge-responder-mode due to the use of the EE (RegAgt) certificate for TLS and the provided PVR as JSON-in-JWS object.<a href="#section-6.2.6-4" class="pilcrow">¶</a></p>
+<p id="section-7.3.5-1">After receiving the PVR from Registrar-Agent, the registrar <span class="bcp14">SHALL</span> perform the verification as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.3" class="relref">Section 5.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+In addition, the registrar <span class="bcp14">SHALL</span> verify the following parameters from the PVR:<a href="#section-7.3.5-1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.2.6-5.1">
-              <p id="section-6.2.6-5.1.1">If the registrar receives a PER with Content-Type header: <code>application/jose+json</code>, it <span class="bcp14">MUST</span> verify the wrapping signature using the certificate indicated in the JOSE header.<a href="#section-6.2.6-5.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.3.5-2.1">
+              <p id="section-7.3.5-2.1.1">agent-provided-proximity-registrar-cert: <span class="bcp14">MUST</span> contain registrar's own registrar LDevID certificate to ensure the registrar in proximity of the Registrar-Agent is the desired registrar for this PVR.<a href="#section-7.3.5-2.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.2.6-5.2">
-              <p id="section-6.2.6-5.2.1">The registrar verifies that the pledge's certificate (here IDevID), carried in "x5c" header field, is accepted to join the domain after successful validation of the PVR.<a href="#section-6.2.6-5.2.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-6.2.6-5.3">
-              <p id="section-6.2.6-5.3.1">If both succeed, the registrar utilizes the PKCS#10 request contained in the JWS object body as "P10" parameter of "ietf-sztp-csr:csr" for further processing of the enrollment-request with the corresponding domain CA.
-It creates a registrar-enrollment-request (RER) by utilizing the protocol expected by the domain CA.
-The domain registrar may either directly forward the provided PKCS#10 request to the CA or provide additional information about attributes to be included by the CA into the requested LDevID certificate.
-The approach of sending this information to the CA depends on the utilized certificate management protocol between the RA and the CA and is out of scope for this document.<a href="#section-6.2.6-5.3.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.3.5-2.2">
+              <p id="section-7.3.5-2.2.1">agent-signed-data: The registrar <span class="bcp14">MUST</span> verify that the Registrar-Agent provided data has been signed with the private key corresponding to the EE (RegAgt) certificate indicated in the "kid" JOSE header parameter.
+The registrar <span class="bcp14">MUST</span> verify that the LDevID(ReAgt) certificate, corresponding to the signature, is still valid.
+If the certificate is already expired, the registrar <span class="bcp14">SHALL</span> reject the request.
+Validity of used signing certificates at the time of signing the agent-signed-data is necessary to avoid that a rogue Registrar-Agent generates agent-signed-data objects to onboard arbitrary pledges at a later point in time, see also <a href="#sec_cons_reg-agt" class="auto internal xref">Section 11.3</a>.
+The registrar <span class="bcp14">MUST</span> fetch the EE (RegAgt) certificate, based on the provided SubjectKeyIdentifier (SKID) contained in the "kid" header parameter of the agent-signed-data, and perform this verification.
+This requires, that the registrar has access to the EE (RegAgt) certificate data (including intermediate CA certificates if existent) based on the SKID.
+Note, the registrar may have stored the EE (RegAgt) certificate if used during TLS establishment between Registrar-Agent and registrar or it may be provided via a repository.<a href="#section-7.3.5-2.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.2.6-6">Note while BRSKI-PRM targets the initial enrollment, re-enrollment may be supported in a similar way with the exception that the current LDevID certificate is used instead of the IDevID certificate to verify the wrapping signature of the PKCS#10 request (see also <a href="#PER-response" class="auto internal xref">Section 6.1.4</a>).<a href="#section-6.2.6-6" class="pilcrow">¶</a></p>
-<p id="section-6.2.6-7">The Registrar-Agent <span class="bcp14">SHALL</span> send the PER to the registrar by HTTP POST to the endpoint: "/.well-known/brski/requestenroll"<a href="#section-6.2.6-7" class="pilcrow">¶</a></p>
-<p id="section-6.2.6-8">The registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.<a href="#section-6.2.6-8" class="pilcrow">¶</a></p>
-<p id="section-6.2.6-9">A successful interaction with the domain CA will result in a pledge LDevID certificate, which is then forwarded by the registrar to the Registrar-Agent using the Content-Type header: <code>application/pkcs7-mime</code>.<a href="#section-6.2.6-9" class="pilcrow">¶</a></p>
+<p id="section-7.3.5-3">If the registrar is unable to validate the PVR it <span class="bcp14">SHOULD</span> respond with a HTTP 4xx/5xx error code to the Registrar-Agent.<a href="#section-7.3.5-3" class="pilcrow">¶</a></p>
+<p id="section-7.3.5-4">The following 4xx client error codes <span class="bcp14">SHOULD</span> be used:<a href="#section-7.3.5-4" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7.3.5-5.1">
+              <p id="section-7.3.5-5.1.1">403 Forbidden: if the registrar detected that one or more security related parameters are not valid.<a href="#section-7.3.5-5.1.1" class="pilcrow">¶</a></p>
+</li>
+            <li class="normal" id="section-7.3.5-5.2">
+              <p id="section-7.3.5-5.2.1">404 Not Found status code if the pledge provided information could not be used with automated allowance, as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.3" class="relref">Section 5.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.3.5-5.2.1" class="pilcrow">¶</a></p>
+</li>
+            <li class="normal" id="section-7.3.5-5.3">
+              <p id="section-7.3.5-5.3.1">406 Not Acceptable: if the Content-Type indicated by the Accept header is unknown or unsupported.<a href="#section-7.3.5-5.3.1" class="pilcrow">¶</a></p>
+</li>
+          </ul>
+<p id="section-7.3.5-6">If the validation succeeds, the registrar performs pledge authorization according to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.3" class="relref">Section 5.3</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> followed by obtaining a voucher from the pledge's MASA according to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.4" class="relref">Section 5.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with the modifications described below in <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a>.<a href="#section-7.3.5-6" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="exchanges_uc2_2_wca">
-<section id="section-6.2.7">
-          <h4 id="name-request-wrapped-ca-certific">
-<a href="#section-6.2.7" class="section-number selfRef">6.2.7. </a><a href="#name-request-wrapped-ca-certific" class="section-name selfRef">Request Wrapped-CA-certificate(s) (Registrar-Agent to Registrar)</a>
+</section>
+</div>
+<div id="per">
+<section id="section-7.4">
+        <h3 id="name-supply-per-to-registrar">
+<a href="#section-7.4" class="section-number selfRef">7.4. </a><a href="#name-supply-per-to-registrar" class="section-name selfRef">Supply PER to Registrar</a>
+        </h3>
+<p id="section-7.4-1">After receiving the voucher, the Registrar-Agent sends the PER to the registrar in the same HTTP-over-TLS connection. Which is similar to the PER processing described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.2" class="relref">Section 5.2</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+In case the PER cannot be send in the same HTTP-over-TLS connection the Registrar-Agent may send the PER in a new HTTP-over-TLS connection. The registrar is able to correlate the PVR and the PER based on the signatures and the contained product-serial-number information.
+Note, this also addresses situations in which a nonceless voucher is used and may be pre-provisioned to the pledge.<a href="#section-7.4-1" class="pilcrow">¶</a></p>
+<div id="request-artifact-pledge-enroll-request-per">
+<section id="section-7.4.1">
+          <h4 id="name-request-artifact-pledge-enro">
+<a href="#section-7.4.1" class="section-number selfRef">7.4.1. </a><a href="#name-request-artifact-pledge-enro" class="section-name selfRef">Request Artifact: Pledge Enroll-Request (PER)</a>
           </h4>
-<p id="section-6.2.7-1">As the pledge will verify it own certificate LDevID certificate when received, it also needs the corresponding CA certificates.
+<p id="section-7.4.1-1">As specified in <a href="#tper" class="auto internal xref">Section 7.2</a> deviating from BRSKI the PER is not a raw PKCS#10.
+As the Registrar-Agent is involved in the exchange, the PKCS#10 is wrapped in a JWS object by the pledge and signed with pledge's IDevID to ensure proof-of-identity as outlined in <a href="#per_example" class="auto internal xref">Figure 9</a>.<a href="#section-7.4.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.4.1-2">EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> standard endpoints (/simpleenroll, /simplereenroll, /serverkeygen, /cacerts) on the registrar cannot be used for BRSKI-PRM.
+This is caused by the utilization of signature wrapped-objects in BRSKI-PRM.
+As EST requires to sent a raw PKCS#10 request to e.g., "/.well-known/est/simpleenroll" endpoint, this document makes an enhancement by utilizing EST but with the exception to transport a signature wrapped PKCS#10 request.
+Therefore a new endpoint for BRSKI-PRM on the registrar is defined as "/.well-known/brski/requestenroll"<a href="#section-7.4.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.4.1-3">The Registrar-Agent <span class="bcp14">SHALL</span> send the PER to the registrar by HTTP POST to the endpoint: "/.well-known/brski/requestenroll"<a href="#section-7.4.1-3" class="pilcrow">¶</a></p>
+<p id="section-7.4.1-4">The Content-Type header of PER is: <code>application/jose+json</code>.<a href="#section-7.4.1-4" class="pilcrow">¶</a></p>
+<p id="section-7.4.1-5">This is a deviation from the Content-Type header values used in <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> and results in additional processing at the domain registrar (as EST server).
+Note, the registrar is already aware that the bootstrapping is performed in a pledge-responder-mode due to the use of the EE (RegAgt) certificate for TLS and the provided PVR as JSON-in-JWS object.<a href="#section-7.4.1-5" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7.4.1-6.1">
+              <p id="section-7.4.1-6.1.1">If the registrar receives a PER with Content-Type header: <code>application/jose+json</code>, it <span class="bcp14">MUST</span> verify the wrapping signature using the certificate indicated in the JOSE header.<a href="#section-7.4.1-6.1.1" class="pilcrow">¶</a></p>
+</li>
+            <li class="normal" id="section-7.4.1-6.2">
+              <p id="section-7.4.1-6.2.1">The registrar verifies that the pledge's certificate (here IDevID), carried in "x5c" header field, is accepted to join the domain after successful validation of the PVR.<a href="#section-7.4.1-6.2.1" class="pilcrow">¶</a></p>
+</li>
+          </ul>
+</section>
+</div>
+<div id="enrollment-by-domain-ca">
+<section id="section-7.4.2">
+          <h4 id="name-enrollment-by-domain-ca">
+<a href="#section-7.4.2" class="section-number selfRef">7.4.2. </a><a href="#name-enrollment-by-domain-ca" class="section-name selfRef">Enrollment by Domain CA</a>
+          </h4>
+<p id="section-7.4.2-1">If both succeed, the registrar utilizes the PKCS#10 request contained in the JWS object body as "P10" parameter of "ietf-sztp-csr:csr" for further processing of the Enroll-Request with the corresponding domain CA.
+It creates a registrar-Enroll-Request (RER) by utilizing the protocol expected by the domain CA.<a href="#section-7.4.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.4.2-2">The domain registrar may either directly forward the provided PKCS#10 request to the CA or provide additional information about attributes to be included by the CA into the requested LDevID certificate.<a href="#section-7.4.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.4.2-3">The approach of sending this information to the CA depends on the utilized certificate management protocol between the RA and the CA and is out of scope for this document.<a href="#section-7.4.2-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="response-artifact-enroll-response">
+<section id="section-7.4.3">
+          <h4 id="name-response-artifact-enroll-re">
+<a href="#section-7.4.3" class="section-number selfRef">7.4.3. </a><a href="#name-response-artifact-enroll-re" class="section-name selfRef">Response Artifact: Enroll-Response</a>
+          </h4>
+<p id="section-7.4.3-1">The registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.<a href="#section-7.4.3-1" class="pilcrow">¶</a></p>
+<p id="section-7.4.3-2">A successful interaction with the domain CA will result in a pledge LDevID certificate, which is then forwarded by the registrar to the Registrar-Agent using the Content-Type header: <code>application/pkcs7-mime</code>.<a href="#section-7.4.3-2" class="pilcrow">¶</a></p>
+<p id="section-7.4.3-3">Note while BRSKI-PRM targets the initial enrollment, re-enrollment may be supported in a similar way with the exception that the current LDevID certificate is used instead of the IDevID certificate to verify the wrapping signature of the PKCS#10 request (see also <a href="#tper" class="auto internal xref">Section 7.2</a>).<a href="#section-7.4.3-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="req_cacerts">
+<section id="section-7.5">
+        <h3 id="name-request-ca-certificates">
+<a href="#section-7.5" class="section-number selfRef">7.5. </a><a href="#name-request-ca-certificates" class="section-name selfRef">Request CA Certificates</a>
+        </h3>
+<p id="section-7.5-1">As the pledge will verify it own certificate LDevID certificate when received, it also needs the corresponding CA certificates.
 This is done in EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> using the "/.well-known/est/cacerts" endpoint, which provides the CA certificates over a TLS protected connection.
 BRSKI-PRM requires a signature wrapped CA certificate object, to avoid that the pledge can be provided with arbitrary CA certificates in an authorized way.
 The registrar signed CA certificate object will allow the pledge to verify the authorization to install the received CA certificate(s).
-As the CA certificate(s) are provided to the pledge after the voucher, the pledge has the required information (the domain certificate) to verify the wrapped CA certificate object.<a href="#section-6.2.7-1" class="pilcrow">¶</a></p>
-<p id="section-6.2.7-2">To support Registrar-Agents requesting a signature wrapped CA certificate(s) object, a new endpoint for BRSKI-PRM is defined on the registrar: "/.well-known/brski/wrappedcacerts"<a href="#section-6.2.7-2" class="pilcrow">¶</a></p>
-<p id="section-6.2.7-3">The Registrar-Agent <span class="bcp14">SHALL</span> requests the EST CA trust anchor database information (in form of CA certificates) by HTTP GET.<a href="#section-6.2.7-3" class="pilcrow">¶</a></p>
-<p id="section-6.2.7-4">The Content-Type header of the response <span class="bcp14">SHALL</span> be: <code>application/jose+json</code>.<a href="#section-6.2.7-4" class="pilcrow">¶</a></p>
-<p id="section-6.2.7-5">This is a deviation from the Content-Type header values used in EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> and results in additional processing at the domain registrar (as EST server).
+As the CA certificate(s) are provided to the pledge after the voucher, the pledge has the required information (the domain certificate) to verify the wrapped CA certificate object.<a href="#section-7.5-1" class="pilcrow">¶</a></p>
+<div id="request-artifact-cacert-req">
+<section id="section-7.5.1">
+          <h4 id="name-request-artifact-cacert-req">
+<a href="#section-7.5.1" class="section-number selfRef">7.5.1. </a><a href="#name-request-artifact-cacert-req" class="section-name selfRef">Request Artifact: cACert-Req</a>
+          </h4>
+<p id="section-7.5.1-1">To support Registrar-Agents requesting a signature wrapped CA certificate(s) object, a new endpoint for BRSKI-PRM is defined on the registrar: "/.well-known/brski/wrappedcacerts"<a href="#section-7.5.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.5.1-2">The Registrar-Agent <span class="bcp14">SHALL</span> requests the EST CA trust anchor database information (in form of CA certificates) by HTTP GET.<a href="#section-7.5.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="response-artifact-cacert-resp">
+<section id="section-7.5.2">
+          <h4 id="name-response-artifact-cacert-re">
+<a href="#section-7.5.2" class="section-number selfRef">7.5.2. </a><a href="#name-response-artifact-cacert-re" class="section-name selfRef">Response Artifact: cACert-Resp</a>
+          </h4>
+<p id="section-7.5.2-1">The Content-Type header of the response <span class="bcp14">SHALL</span> be: <code>application/jose+json</code>.<a href="#section-7.5.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.5.2-2">This is a deviation from the Content-Type header values used in EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> and results in additional processing at the domain registrar (as EST server).
 The additional processing is to sign the CA certificate(s) information using the registrar LDevID credentials.
-This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certificates are provided as base64 encoded "x5bag" (see definition in <span>[<a href="#RFC9360" class="cite xref">RFC9360</a>]</span>) in the JWS payload.<a href="#section-6.2.7-5" class="pilcrow">¶</a></p>
+This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certificates are provided as base64-encoded "x5bag" (see definition in <span>[<a href="#RFC9360" class="cite xref">RFC9360</a>]</span>) in the JWS payload.<a href="#section-7.5.2-2" class="pilcrow">¶</a></p>
 <span id="name-representation-of-ca-certif"></span><div id="PCAC">
-<figure id="figure-15">
-            <div class="alignLeft art-text artwork" id="section-6.2.7-6.1">
+<figure id="figure-13">
+            <div class="alignLeft art-text artwork" id="section-7.5.2-3.1">
 <pre>
 # The CA certificates data with registrar signature in General JWS Serialization syntax
 {
@@ -3885,7 +3940,7 @@ This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certific
 }
 </pre>
 </div>
-<figcaption><a href="#figure-15" class="selfRef">Figure 15</a>:
+<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
 <a href="#name-representation-of-ca-certif" class="selfRef">Representation of CA certificate(s) data with registrar signature</a>
             </figcaption></figure>
 </div>
@@ -3893,171 +3948,74 @@ This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certific
 </div>
 </section>
 </div>
-<div id="exchanges_uc2_3">
-<section id="section-6.3">
-        <h3 id="name-response-objects-supplied-b">
-<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-response-objects-supplied-b" class="section-name selfRef">Response Objects supplied by the Registrar-Agent to the Pledge</a>
+<div id="voucher">
+<section id="section-7.6">
+        <h3 id="name-supply-voucher-to-pledge">
+<a href="#section-7.6" class="section-number selfRef">7.6. </a><a href="#name-supply-voucher-to-pledge" class="section-name selfRef">Supply Voucher to Pledge</a>
         </h3>
-<p id="section-6.3-1">It is assumed that the Registrar-Agent already obtained the bootstrapping response objects from the domain registrar and can supply them to the pledge:<a href="#section-6.3-1" class="pilcrow">¶</a></p>
+<p id="section-7.6-1">It is assumed that the Registrar-Agent already obtained the bootstrapping response objects from the domain registrar and can supply them to the pledge:<a href="#section-7.6-1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.3-2.1">
-            <p id="section-6.3-2.1.1">voucher-response - Voucher (from MASA via Registrar)<a href="#section-6.3-2.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.6-2.1">
+            <p id="section-7.6-2.1.1">voucher-response - Voucher (from MASA via Registrar)<a href="#section-7.6-2.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="normal" id="section-6.3-2.2">
-            <p id="section-6.3-2.2.1">wrapped-CA-certificate(s)-response - CA certificates<a href="#section-6.3-2.2.1" class="pilcrow">¶</a></p>
+          <li class="normal" id="section-7.6-2.2">
+            <p id="section-7.6-2.2.1">wrapped-CA-certificate(s)-response - CA certificates<a href="#section-7.6-2.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="normal" id="section-6.3-2.3">
-            <p id="section-6.3-2.3.1">enrollment-response - LDevID (Pledge) certificate (from CA via registrar)<a href="#section-6.3-2.3.1" class="pilcrow">¶</a></p>
+          <li class="normal" id="section-7.6-2.3">
+            <p id="section-7.6-2.3.1">enrollment-response - LDevID (Pledge) certificate (from CA via registrar)<a href="#section-7.6-2.3.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-6.3-3">To deliver these response objects, the Registrar-Agent will re-connect to the pledge.
-To contact the pledge, it may either discover the pledge as described in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 5.6.2</a> or use stored information from the first contact with the pledge.<a href="#section-6.3-3" class="pilcrow">¶</a></p>
-<p id="section-6.3-4">Preconditions in addition to <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a>:<a href="#section-6.3-4" class="pilcrow">¶</a></p>
+<p id="section-7.6-3">To deliver these response objects, the Registrar-Agent will re-connect to the pledge.
+To contact the pledge, it may either discover the pledge as described in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 6.2.2</a> or use stored information from the first contact with the pledge.<a href="#section-7.6-3" class="pilcrow">¶</a></p>
+<p id="section-7.6-4">Preconditions in addition to <a href="#pvr" class="auto internal xref">Section 7.3</a>:<a href="#section-7.6-4" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.3-5.1">
-            <p id="section-6.3-5.1.1">Registrar-Agent: obtained voucher and LDevID certificate and optionally IDevID CA certificates.
-The IDevID CA certificate is necessary, when the connection between the Registrar-Agent and the pledge is established using TLS to enable the Registrar-Agent to validate the pledges' IDevID certificate during the TLS handshake as described in <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a>.<a href="#section-6.3-5.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.6-5.1">
+            <p id="section-7.6-5.1.1">Registrar-Agent: obtained voucher and LDevID certificate and optionally IDevID CA certificates.
+The IDevID CA certificate is necessary, when the connection between the Registrar-Agent and the pledge is established using TLS to enable the Registrar-Agent to validate the pledges' IDevID certificate during the TLS handshake as described in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.<a href="#section-7.6-5.1.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<span id="name-responses-and-status-handli"></span><div id="exchangesfig_uc2_3">
-<figure id="figure-16">
-          <div id="section-6.3-6.1">
-            <div class="alignLeft art-svg artwork" id="section-6.3-6.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="368" width="528" viewBox="0 0 528 368" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
-                <path d="M 8,32 L 8,96" fill="none" stroke="black"></path>
-                <path d="M 40,104 L 40,336" fill="none" stroke="black"></path>
-                <path d="M 80,32 L 80,96" fill="none" stroke="black"></path>
-                <path d="M 280,32 L 280,96" fill="none" stroke="black"></path>
-                <path d="M 328,144 L 328,336" fill="none" stroke="black"></path>
-                <path d="M 376,32 L 376,96" fill="none" stroke="black"></path>
-                <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
-                <path d="M 280,32 L 376,32" fill="none" stroke="black"></path>
-                <path d="M 8,96 L 80,96" fill="none" stroke="black"></path>
-                <path d="M 280,96 L 376,96" fill="none" stroke="black"></path>
-                <path d="M 48,160 L 88,160" fill="none" stroke="black"></path>
-                <path d="M 296,160 L 320,160" fill="none" stroke="black"></path>
-                <path d="M 48,192 L 104,192" fill="none" stroke="black"></path>
-                <path d="M 240,192 L 320,192" fill="none" stroke="black"></path>
-                <path d="M 48,224 L 112,224" fill="none" stroke="black"></path>
-                <path d="M 248,224 L 320,224" fill="none" stroke="black"></path>
-                <path d="M 48,256 L 72,256" fill="none" stroke="black"></path>
-                <path d="M 296,256 L 320,256" fill="none" stroke="black"></path>
-                <path d="M 48,288 L 72,288" fill="none" stroke="black"></path>
-                <path d="M 304,288 L 320,288" fill="none" stroke="black"></path>
-                <path d="M 48,320 L 112,320" fill="none" stroke="black"></path>
-                <path d="M 240,320 L 320,320" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="328,320 316,314.4 316,325.6" fill="black" transform="rotate(0,320,320)"></polygon>
-                <polygon class="arrowhead" points="328,224 316,218.4 316,229.6" fill="black" transform="rotate(0,320,224)"></polygon>
-                <polygon class="arrowhead" points="56,288 44,282.4 44,293.6" fill="black" transform="rotate(180,48,288)"></polygon>
-                <polygon class="arrowhead" points="56,256 44,250.4 44,261.6" fill="black" transform="rotate(180,48,256)"></polygon>
-                <polygon class="arrowhead" points="56,192 44,186.4 44,197.6" fill="black" transform="rotate(180,48,192)"></polygon>
-                <polygon class="arrowhead" points="56,160 44,154.4 44,165.6" fill="black" transform="rotate(180,48,160)"></polygon>
-                <g class="text">
-                  <text x="44" y="52">Pledge</text>
-                  <text x="332" y="52">Registrar-</text>
-                  <text x="312" y="68">Agent</text>
-                  <text x="324" y="84">(RegAgt)</text>
-                  <text x="284" y="116">[voucher</text>
-                  <text x="336" y="116">and</text>
-                  <text x="400" y="116">enrollment]</text>
-                  <text x="292" y="132">[responses</text>
-                  <text x="380" y="132">available]</text>
-                  <text x="132" y="164">optional</text>
-                  <text x="184" y="164">TLS</text>
-                  <text x="244" y="164">connection</text>
-                  <text x="140" y="196">supply</text>
-                  <text x="200" y="196">voucher</text>
-                  <text x="152" y="228">voucher</text>
-                  <text x="212" y="228">status</text>
-                  <text x="344" y="228">-</text>
-                  <text x="376" y="228">store</text>
-                  <text x="380" y="244">pledge</text>
-                  <text x="440" y="244">voucher</text>
-                  <text x="500" y="244">status</text>
-                  <text x="108" y="260">supply</text>
-                  <text x="168" y="260">CAcerts</text>
-                  <text x="244" y="260">(optional)</text>
-                  <text x="108" y="292">supply</text>
-                  <text x="216" y="292">enrollment-response</text>
-                  <text x="148" y="324">enroll</text>
-                  <text x="204" y="324">status</text>
-                  <text x="344" y="324">-</text>
-                  <text x="376" y="324">store</text>
-                  <text x="380" y="340">pledge</text>
-                  <text x="436" y="340">enroll</text>
-                  <text x="492" y="340">status</text>
-                </g>
-              </svg><a href="#section-6.3-6.1.1" class="pilcrow">¶</a>
-</div>
-</div>
-<figcaption><a href="#figure-16" class="selfRef">Figure 16</a>:
-<a href="#name-responses-and-status-handli" class="selfRef">Responses and status handling between pledge and Registrar-Agent</a>
-          </figcaption></figure>
-</div>
-<p id="section-6.3-7">The Registrar-Agent <span class="bcp14">MAY</span> optionally use TLS to protect the communication as outlined in <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a>.<a href="#section-6.3-7" class="pilcrow">¶</a></p>
-<p id="section-6.3-8">The Registrar-Agent provides the information via distinct pledge endpoints as following.<a href="#section-6.3-8" class="pilcrow">¶</a></p>
-<div id="exchanges_uc2_3a">
-<section id="section-6.3.1">
-          <h4 id="name-pledge-voucher-response-pro">
-<a href="#section-6.3.1" class="section-number selfRef">6.3.1. </a><a href="#name-pledge-voucher-response-pro" class="section-name selfRef">Pledge: Voucher-Response Processing</a>
+<p id="section-7.6-6">The Registrar-Agent <span class="bcp14">MAY</span> optionally use TLS to protect the communication as outlined in <a href="#tpvr" class="auto internal xref">Section 7.1</a>.<a href="#section-7.6-6" class="pilcrow">¶</a></p>
+<p id="section-7.6-7">The Registrar-Agent provides the information via distinct pledge endpoints as following.<a href="#section-7.6-7" class="pilcrow">¶</a></p>
+<div id="request-artifact-voucher">
+<section id="section-7.6.1">
+          <h4 id="name-request-artifact-voucher">
+<a href="#section-7.6.1" class="section-number selfRef">7.6.1. </a><a href="#name-request-artifact-voucher" class="section-name selfRef">Request Artifact: Voucher</a>
           </h4>
-<p id="section-6.3.1-1">The Registrar-Agent <span class="bcp14">SHALL</span> send the voucher-response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/svr".<a href="#section-6.3.1-1" class="pilcrow">¶</a></p>
-<p id="section-6.3.1-2">The Registrar-Agent voucher-response Content-Type header is <code>application/voucher-jws+json</code> and contains the voucher as provided by the MASA. An example is given in <a href="#MASA-vr" class="auto internal xref">Figure 13</a> for a MASA  signed voucher and in <a href="#MASA-REG-vr" class="auto internal xref">Figure 14</a> for the voucher with the additional signature of the registrar.<a href="#section-6.3.1-2" class="pilcrow">¶</a></p>
-<p id="section-6.3.1-3">A nonceless voucher may be accepted as in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> and may be allowed by a manufacture's pledge implementation.<a href="#section-6.3.1-3" class="pilcrow">¶</a></p>
-<p id="section-6.3.1-4">To perform the validation of several signatures on the voucher object, the pledge <span class="bcp14">SHALL</span> perform the signature verification in the following order:<a href="#section-6.3.1-4" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-6.3.1-5">
-<li id="section-6.3.1-5.1">
-              <p id="section-6.3.1-5.1.1">Verify MASA signature as described in Section 5.6.1 in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, against pre-installed manufacturer trust anchor (IDevID).<a href="#section-6.3.1-5.1.1" class="pilcrow">¶</a></p>
+<p id="section-7.6.1-1">The Registrar-Agent <span class="bcp14">SHALL</span> send the voucher-response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/svr".<a href="#section-7.6.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.6.1-2">The Registrar-Agent voucher-response Content-Type header is <code>application/voucher-jws+json</code> and contains the voucher as provided by the MASA. An example is given in <a href="#MASA-vr" class="auto internal xref">Figure 11</a> for a MASA  signed voucher and in <a href="#MASA-REG-vr" class="auto internal xref">Figure 12</a> for the voucher with the additional signature of the registrar.<a href="#section-7.6.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.6.1-3">A nonceless voucher may be accepted as in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> and may be allowed by a manufacture's pledge implementation.<a href="#section-7.6.1-3" class="pilcrow">¶</a></p>
+<p id="section-7.6.1-4">To perform the validation of several signatures on the voucher object, the pledge <span class="bcp14">SHALL</span> perform the signature verification in the following order:<a href="#section-7.6.1-4" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-7.6.1-5">
+<li id="section-7.6.1-5.1">
+              <p id="section-7.6.1-5.1.1">Verify MASA signature as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6.1" class="relref">Section 5.6.1</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, against pre-installed manufacturer trust anchor (IDevID).<a href="#section-7.6.1-5.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-6.3.1-5.2">
-              <p id="section-6.3.1-5.2.1">Install trust anchor contained in the voucher ("pinned-domain-cert")  provisionally<a href="#section-6.3.1-5.2.1" class="pilcrow">¶</a></p>
+            <li id="section-7.6.1-5.2">
+              <p id="section-7.6.1-5.2.1">Install trust anchor contained in the voucher ("pinned-domain-cert")  provisionally<a href="#section-7.6.1-5.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-6.3.1-5.3">
-              <p id="section-6.3.1-5.3.1">Validate the LDevID(Reg) certificate received in the agent-provided-proximity-registrar-cert in the pledge-voucher-request trigger request (in the field "agent-provided-proximity-registrar-cert")<a href="#section-6.3.1-5.3.1" class="pilcrow">¶</a></p>
+            <li id="section-7.6.1-5.3">
+              <p id="section-7.6.1-5.3.1">Validate the LDevID(Reg) certificate received in the agent-provided-proximity-registrar-cert in the Pledge-Voucher-Request trigger request (in the field "agent-provided-proximity-registrar-cert")<a href="#section-7.6.1-5.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-6.3.1-5.4">
-              <p id="section-6.3.1-5.4.1">Verify registrar signature of the voucher similar as described in Section 5.6.1 in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, but take the registrar certificate instead of the MASA certificate for the verification<a href="#section-6.3.1-5.4.1" class="pilcrow">¶</a></p>
+            <li id="section-7.6.1-5.4">
+              <p id="section-7.6.1-5.4.1">Verify registrar signature of the voucher similar as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.6.1" class="relref">Section 5.6.1</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, but take the registrar certificate instead of the MASA certificate for the verification<a href="#section-7.6.1-5.4.1" class="pilcrow">¶</a></p>
 </li>
           </ol>
-<p id="section-6.3.1-6">Step3 and step 4 have been introduced in BRSKI-PRM to enable verification of LDevID(Reg) certificate and also the proof-of-possession of the corresponding private key by the registrar, which is done in BRSKI based on the established TLS channel.
-If all steps stated above have been performed successfully, the pledge <span class="bcp14">SHALL</span> terminate the "PROVISIONAL accept" state for the domain trust anchor and the registrar LDevID certificate.<a href="#section-6.3.1-6" class="pilcrow">¶</a></p>
-<p id="section-6.3.1-7">If an error occurs during the verification and validation of the voucher, this <span class="bcp14">SHALL</span> be reported in the reason field of the pledge voucher status.<a href="#section-6.3.1-7" class="pilcrow">¶</a></p>
+<p id="section-7.6.1-6">Step3 and step 4 have been introduced in BRSKI-PRM to enable verification of LDevID(Reg) certificate and also the proof-of-possession of the corresponding private key by the registrar, which is done in BRSKI based on the established TLS channel.
+If all steps stated above have been performed successfully, the pledge <span class="bcp14">SHALL</span> terminate the "PROVISIONAL accept" state for the domain trust anchor and the registrar LDevID certificate.<a href="#section-7.6.1-6" class="pilcrow">¶</a></p>
+<p id="section-7.6.1-7">If an error occurs during the verification and validation of the voucher, this <span class="bcp14">SHALL</span> be reported in the reason field of the pledge voucher status.<a href="#section-7.6.1-7" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="exchanges_uc2_3b">
-<section id="section-6.3.2">
-          <h4 id="name-pledge-voucher-status-telem">
-<a href="#section-6.3.2" class="section-number selfRef">6.3.2. </a><a href="#name-pledge-voucher-status-telem" class="section-name selfRef">Pledge: Voucher Status Telemetry</a>
+<div id="response-artifact-vstatus">
+<section id="section-7.6.2">
+          <h4 id="name-response-artifact-vstatus">
+<a href="#section-7.6.2" class="section-number selfRef">7.6.2. </a><a href="#name-response-artifact-vstatus" class="section-name selfRef">Response Artifact: vStatus</a>
           </h4>
-<p id="section-6.3.2-1">After voucher processing the pledge <span class="bcp14">MUST</span> reply with a voucher status telemetry message as defined in Section 5.7 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
-The voucher-status is also a signed object in BRSKI-PRM and results in form of JSON-in-JWS here.
-BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> section 5.7 specifies the voucher status telemetry message with two optional fields for "reason" and "reason-context". 
-In BRSKI-PRM the optional fields are mandated to have a clear distinction between other status messages and <span class="bcp14">MUST</span> be provided therefore.
-This distinction is intended for better error handling on registrar side, as a status object could be send to a wrong status endpoint.
-The following CDDL <span>[<a href="#RFC8610" class="cite xref">RFC8610</a>]</span> defines the pledge voucher-status response structure. 
-It is similar as defined in section 5.7 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with the optional fields set as mandatory as described above.<a href="#section-6.3.2-1" class="pilcrow">¶</a></p>
-<span id="name-cddl-for-pledge-voucher-sta"></span><div id="v_stat_res_def">
-<figure id="figure-17">
-            <div class="sourcecode" id="section-6.3.2-2.1">
-<pre>&lt;CODE BEGINS&gt;
-voucherstatus-post = {
-    "version": uint,
-    "status": bool,
-    "reason": text,
-    "reason-context" : { $$arbitrary-map }
-  }
-
-&lt;CODE ENDS&gt;</pre>
-</div>
-<figcaption><a href="#figure-17" class="selfRef">Figure 17</a>:
-<a href="#name-cddl-for-pledge-voucher-sta" class="selfRef">CDDL for pledge-voucher-status response</a>
-            </figcaption></figure>
-</div>
-<p id="section-6.3.2-3">The pledge generates the voucher-status and provides it as signed JSON-in-JWS object in response to the Registrar-Agent.
-The response has the Content-Type <code>application/jose+json</code> and is signed using the IDevID of the pledge as shown in <a href="#vstat" class="auto internal xref">Figure 18</a>.<a href="#section-6.3.2-3" class="pilcrow">¶</a></p>
+<p id="section-7.6.2-1">After voucher verification and validation the pledge <span class="bcp14">MUST</span> reply with a status telemetry message as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.7" class="relref">Section 5.7</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+The pledge generates the voucher-status and provides it as signed JSON-in-JWS object in response to the Registrar-Agent.<a href="#section-7.6.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.6.2-2">The response has the Content-Type <code>application/jose+json</code> and is signed using the IDevID of the pledge as shown in <a href="#vstat" class="auto internal xref">Figure 14</a>.
+As the reason field is optional (see <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>), it <span class="bcp14">MAY</span> be omitted in case of success.<a href="#section-7.6.2-2" class="pilcrow">¶</a></p>
 <span id="name-representation-of-pledge-vo"></span><div id="vstat">
-<figure id="figure-18">
-            <div class="alignLeft art-text artwork" id="section-6.3.2-4.1">
+<figure id="figure-14">
+            <div class="alignLeft art-text artwork" id="section-7.6.2-3.1">
 <pre>
 # The "pledge-voucher-status" telemetry in general JWS
   serialization syntax
@@ -4105,73 +4063,95 @@ The response has the Content-Type <code>application/jose+json</code> and is sign
 }
 </pre>
 </div>
-<figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
+<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
 <a href="#name-representation-of-pledge-vo" class="selfRef">Representation of pledge voucher status telemetry</a>
             </figcaption></figure>
 </div>
-<p id="section-6.3.2-5">If the pledge did not did not provide voucher status telemetry information after processing the voucher, the Registrar-Agent <span class="bcp14">MAY</span> query the pledge status explicitly as described in <a href="#exchanges_uc2_5" class="auto internal xref">Section 6.4</a> and <span class="bcp14">MAY</span> resent the voucher depending on the Pledge status following the procedure described in <a href="#exchanges_uc2_3a" class="auto internal xref">Section 6.3.1</a>.<a href="#section-6.3.2-5" class="pilcrow">¶</a></p>
+<p id="section-7.6.2-4">If the pledge did not did not provide voucher status telemetry information after processing the voucher, the Registrar-Agent <span class="bcp14">MAY</span> query the pledge status explicitly as described in <a href="#query" class="auto internal xref">Section 7.11</a> and <span class="bcp14">MAY</span> resent the voucher depending on the Pledge status following the procedure described in <a href="#voucher" class="auto internal xref">Section 7.6</a>.<a href="#section-7.6.2-4" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="exchanges_uc2_3c">
-<section id="section-6.3.3">
-          <h4 id="name-pledge-wrapped-ca-certifica">
-<a href="#section-6.3.3" class="section-number selfRef">6.3.3. </a><a href="#name-pledge-wrapped-ca-certifica" class="section-name selfRef">Pledge: Wrapped-CA-Certificate(s) Processing</a>
+</section>
+</div>
+<div id="cacerts">
+<section id="section-7.7">
+        <h3 id="name-supply-ca-certificates-to-p">
+<a href="#section-7.7" class="section-number selfRef">7.7. </a><a href="#name-supply-ca-certificates-to-p" class="section-name selfRef">Supply CA certificates to Pledge</a>
+        </h3>
+<div id="request-artifact">
+<section id="section-7.7.1">
+          <h4 id="name-request-artifact">
+<a href="#section-7.7.1" class="section-number selfRef">7.7.1. </a><a href="#name-request-artifact" class="section-name selfRef">Request Artifact:</a>
           </h4>
-<p id="section-6.3.3-1">The Registrar-Agent <span class="bcp14">SHALL</span> provide the set of CA certificates requested from the registrar to the pledge by HTTP POST to the endpoint: "/.well-known/brski/scac".<a href="#section-6.3.3-1" class="pilcrow">¶</a></p>
-<p id="section-6.3.3-2">As the CA certificate provisioning is crucial from a security perspective, this provisioning <span class="bcp14">SHOULD</span> only be done, if the voucher-response has been successfully processed by pledge as reflected in the voucher status telemetry.<a href="#section-6.3.3-2" class="pilcrow">¶</a></p>
-<p id="section-6.3.3-3">The CA certificates message has the Content-Type <code>application/jose+json</code> and is signed using the credential of the registrar as shown in <a href="#PCAC" class="auto internal xref">Figure 15</a>.<a href="#section-6.3.3-3" class="pilcrow">¶</a></p>
-<p id="section-6.3.3-4">The CA certificates are provided as base64 encoded "x5bag".
-The pledge <span class="bcp14">SHALL</span> install the received CA certificates as trust anchor after successful verification of the registrar's signature.<a href="#section-6.3.3-4" class="pilcrow">¶</a></p>
-<p id="section-6.3.3-5">The verification comprises the following steps the pledge <span class="bcp14">MUST</span> perform. Maintaining the order of versification steps as indicated allows to determine, which verification has already been passed:<a href="#section-6.3.3-5" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-6.3.3-6">
-<li id="section-6.3.3-6.1">
-              <p id="section-6.3.3-6.1.1">Check content-type of the CA certificates message. If no Content-Type is contained in the HTTP header, the default Content-Type utilized in this document (JSON-in-JWS) is used. If the Content-Type of the response is in an unknown or unsupported format, the pledge <span class="bcp14">SHOULD</span> reply with a 415 Unsupported media type error code.<a href="#section-6.3.3-6.1.1" class="pilcrow">¶</a></p>
+<p id="section-7.7.1-1">The Registrar-Agent <span class="bcp14">SHALL</span> provide the set of CA certificates requested from the registrar to the pledge by HTTP POST to the endpoint: "/.well-known/brski/scac".<a href="#section-7.7.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.7.1-2">As the CA certificate provisioning is crucial from a security perspective, this provisioning <span class="bcp14">SHOULD</span> only be done, if the voucher-response has been successfully processed by pledge as reflected in the voucher status telemetry.<a href="#section-7.7.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.7.1-3">The CA certificates message has the Content-Type <code>application/jose+json</code> and is signed using the credential of the registrar as shown in <a href="#PCAC" class="auto internal xref">Figure 13</a>.<a href="#section-7.7.1-3" class="pilcrow">¶</a></p>
+<p id="section-7.7.1-4">The CA certificates are provided as base64-encoded "x5bag".
+The pledge <span class="bcp14">SHALL</span> install the received CA certificates as trust anchor after successful verification of the registrar's signature.<a href="#section-7.7.1-4" class="pilcrow">¶</a></p>
+<p id="section-7.7.1-5">The verification comprises the following steps the pledge <span class="bcp14">MUST</span> perform. Maintaining the order of versification steps as indicated allows to determine, which verification has already been passed:<a href="#section-7.7.1-5" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-7.7.1-6">
+<li id="section-7.7.1-6.1">
+              <p id="section-7.7.1-6.1.1">Check content-type of the CA certificates message. If no Content-Type is contained in the HTTP header, the default Content-Type utilized in this document (JSON-in-JWS) is used. If the Content-Type of the response is in an unknown or unsupported format, the pledge <span class="bcp14">SHOULD</span> reply with a 415 Unsupported media type error code.<a href="#section-7.7.1-6.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-6.3.3-6.2">
-              <p id="section-6.3.3-6.2.1">Check the encoding of the payload. If the pledge detects errors in the encoding of the payload, it <span class="bcp14">SHOULD</span> reply with 400 Bad Request error code.<a href="#section-6.3.3-6.2.1" class="pilcrow">¶</a></p>
+            <li id="section-7.7.1-6.2">
+              <p id="section-7.7.1-6.2.1">Check the encoding of the payload. If the pledge detects errors in the encoding of the payload, it <span class="bcp14">SHOULD</span> reply with 400 Bad Request error code.<a href="#section-7.7.1-6.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-6.3.3-6.3">
-              <p id="section-6.3.3-6.3.1">Verify that the wrapped CA certificate object is signed using the registrar certificate against the pinned-domain certificate. This <span class="bcp14">MAY</span> be done by comparing the hash that is indicating the certificate used to sign the message is that of the pinned-domain certificate. If the validation against the pinned domain-certificate fails, the client <span class="bcp14">SHOULD</span> reply with a 401 Unauthorized error code. It signals that the authentication has failed and therefore the object was not accepted.<a href="#section-6.3.3-6.3.1" class="pilcrow">¶</a></p>
+            <li id="section-7.7.1-6.3">
+              <p id="section-7.7.1-6.3.1">Verify that the wrapped CA certificate object is signed using the registrar certificate against the pinned-domain certificate. This <span class="bcp14">MAY</span> be done by comparing the hash that is indicating the certificate used to sign the message is that of the pinned-domain certificate. If the validation against the pinned domain-certificate fails, the client <span class="bcp14">SHOULD</span> reply with a 401 Unauthorized error code. It signals that the authentication has failed and therefore the object was not accepted.<a href="#section-7.7.1-6.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-6.3.3-6.4">
-              <p id="section-6.3.3-6.4.1">Verify signature of the the received wrapped CA certificate object. If the validation of the signature fails, the pledge <span class="bcp14">SHOULD</span> reply with a 406 Not Acceptable. It signals that the object has not been accepted.<a href="#section-6.3.3-6.4.1" class="pilcrow">¶</a></p>
+            <li id="section-7.7.1-6.4">
+              <p id="section-7.7.1-6.4.1">Verify signature of the the received wrapped CA certificate object. If the validation of the signature fails, the pledge <span class="bcp14">SHOULD</span> reply with a 406 Not Acceptable. It signals that the object has not been accepted.<a href="#section-7.7.1-6.4.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-6.3.3-6.5">
-              <p id="section-6.3.3-6.5.1">If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span>.<a href="#section-6.3.3-6.5.1" class="pilcrow">¶</a></p>
+            <li id="section-7.7.1-6.5">
+              <p id="section-7.7.1-6.5.1">If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span>.<a href="#section-7.7.1-6.5.1" class="pilcrow">¶</a></p>
 </li>
           </ol>
 </section>
 </div>
-<div id="pledge-enrollment-response-processing">
-<section id="section-6.3.4">
-          <h4 id="name-pledge-enrollment-response-">
-<a href="#section-6.3.4" class="section-number selfRef">6.3.4. </a><a href="#name-pledge-enrollment-response-" class="section-name selfRef">Pledge: Enrollment-Response Processing</a>
+<div id="response">
+<section id="section-7.7.2">
+          <h4 id="name-response">
+<a href="#section-7.7.2" class="section-number selfRef">7.7.2. </a><a href="#name-response" class="section-name selfRef">Response</a>
           </h4>
-<p id="section-6.3.4-1">The Registrar-Agent <span class="bcp14">SHALL</span> send the enroll-response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/ser".<a href="#section-6.3.4-1" class="pilcrow">¶</a></p>
-<p id="section-6.3.4-2">The Registrar-Agent enroll-response Content-Type header, when using EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> as enrollment protocol between the Registrar-Agent and the infrastructure is: <code>application/pkcs7-mime</code>.
-Note: It only contains the LDevID certificate for the pledge, not the certificate chain.<a href="#section-6.3.4-2" class="pilcrow">¶</a></p>
-<p id="section-6.3.4-3">Upon reception, the pledge <span class="bcp14">SHALL</span> verify the received LDevID certificate.
-The pledge <span class="bcp14">SHALL</span> generate the enroll status and provide it in the response to the Registrar-Agent.
-If the verification of the LDevID certificate succeeds, the status property <span class="bcp14">SHALL</span> be set to "status": true, otherwise to "status": false<a href="#section-6.3.4-3" class="pilcrow">¶</a></p>
+<p id="section-7.7.2-1">TODO[empty?]<a href="#section-7.7.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="exchanges_uc2_3e">
-<section id="section-6.3.5">
-          <h4 id="name-pledge-enrollment-status-te">
-<a href="#section-6.3.5" class="section-number selfRef">6.3.5. </a><a href="#name-pledge-enrollment-status-te" class="section-name selfRef">Pledge: Enrollment-Status Telemetry</a>
+</section>
+</div>
+<div id="enroll_response">
+<section id="section-7.8">
+        <h3 id="name-supply-enroll-response-to-p">
+<a href="#section-7.8" class="section-number selfRef">7.8. </a><a href="#name-supply-enroll-response-to-p" class="section-name selfRef">Supply Enroll-Response to Pledge</a>
+        </h3>
+<div id="request-artifact-enroll-response">
+<section id="section-7.8.1">
+          <h4 id="name-request-artifact-enroll-res">
+<a href="#section-7.8.1" class="section-number selfRef">7.8.1. </a><a href="#name-request-artifact-enroll-res" class="section-name selfRef">Request Artifact: Enroll-Response</a>
           </h4>
-<p id="section-6.3.5-1">After enrollment processing the pledge <span class="bcp14">MUST</span> reply with a enrollment status telemetry message as defined in Section 5.9.4 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+<p id="section-7.8.1-1">The Registrar-Agent <span class="bcp14">SHALL</span> send the Enroll-Response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/ser".<a href="#section-7.8.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.8.1-2">The Content-Type header when using EST <span>[<a href="#RFC7030" class="cite xref">RFC7030</a>]</span> as enrollment protocol between the Registrar-Agent and the infrastructure is <code>application/pkcs7-mime</code>.
+Note: It only contains the LDevID certificate for the pledge, not the certificate chain.<a href="#section-7.8.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.8.1-3">Upon reception, the pledge <span class="bcp14">SHALL</span> verify the received LDevID certificate.
+The pledge <span class="bcp14">SHALL</span> generate the enroll status and provide it in the response to the Registrar-Agent.
+If the verification of the LDevID certificate succeeds, the status property <span class="bcp14">SHALL</span> be set to "status": true, otherwise to "status": false<a href="#section-7.8.1-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="response-artifact-estatus">
+<section id="section-7.8.2">
+          <h4 id="name-response-artifact-estatus">
+<a href="#section-7.8.2" class="section-number selfRef">7.8.2. </a><a href="#name-response-artifact-estatus" class="section-name selfRef">Response Artifact: eStatus</a>
+          </h4>
+<p id="section-7.8.2-1">After enrollment processing the pledge <span class="bcp14">MUST</span> reply with a enrollment status telemetry message as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 The enroll-status is also a signed object in BRSKI-PRM and results in form of JSON-in-JWS here.
-If the pledge verified the received LDevID certificate successfully it <span class="bcp14">SHALL</span> sign the enroll-status using its new LDevID credentials as shown in <a href="#estat" class="auto internal xref">Figure 20</a>.
+If the pledge verified the received LDevID certificate successfully it <span class="bcp14">SHALL</span> sign the enroll-status using its new LDevID credentials as shown in <a href="#estat" class="auto internal xref">Figure 16</a>.
 In failure case, the pledge <span class="bcp14">SHALL</span> use its IDevID credentials.
-BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> section 5.9.4 specifies the enrollment status telemetry message with two optional fields for "reason" and "reason-context". 
+<span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> specifies the enrollment status telemetry message with two optional fields for "reason" and "reason-context". 
 In BRSKI-PRM the optional fields are mandated to have a clear distinction between other status messages and <span class="bcp14">MUST</span> be provided therefore.
-This distinction is intended for better error handling on registrar side, as a status object could be send to a wrong status endpoint.<a href="#section-6.3.5-1" class="pilcrow">¶</a></p>
-<p id="section-6.3.5-2">The following CDDL <span>[<a href="#RFC8610" class="cite xref">RFC8610</a>]</span> explains enroll-status response structure. 
-It is the version defined in Section 5.9.4 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with the optional fields set to mandatory as described above.<a href="#section-6.3.5-2" class="pilcrow">¶</a></p>
+This distinction is intended for better error handling on registrar side, as a status object could be send to a wrong status endpoint.<a href="#section-7.8.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.8.2-2">The following CDDL <span>[<a href="#RFC8610" class="cite xref">RFC8610</a>]</span> explains enroll-status response structure. 
+It is similar as defined in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> with the optional fields set to mandatory as described above.<a href="#section-7.8.2-2" class="pilcrow">¶</a></p>
 <span id="name-cddl-for-pledge-enrollment-"></span><div id="e_stat_res_def">
-<figure id="figure-19">
-            <div class="sourcecode" id="section-6.3.5-3.1">
+<figure id="figure-15">
+            <div class="sourcecode" id="section-7.8.2-3.1">
 <pre>&lt;CODE BEGINS&gt;
 enrollstatus-post = {
     "version": uint,
@@ -4182,14 +4162,14 @@ enrollstatus-post = {
 
 &lt;CODE ENDS&gt;</pre>
 </div>
-<figcaption><a href="#figure-19" class="selfRef">Figure 19</a>:
+<figcaption><a href="#figure-15" class="selfRef">Figure 15</a>:
 <a href="#name-cddl-for-pledge-enrollment-" class="selfRef">CDDL for pledge-enrollment-status response</a>
             </figcaption></figure>
 </div>
-<p id="section-6.3.5-4">The response has the Content-Type <code>application/jose+json</code>.<a href="#section-6.3.5-4" class="pilcrow">¶</a></p>
+<p id="section-7.8.2-4">The response has the Content-Type <code>application/jose+json</code>.<a href="#section-7.8.2-4" class="pilcrow">¶</a></p>
 <span id="name-representation-of-pledge-en"></span><div id="estat">
-<figure id="figure-20">
-            <div class="alignLeft art-text artwork" id="section-6.3.5-5.1">
+<figure id="figure-16">
+            <div class="alignLeft art-text artwork" id="section-7.8.2-5.1">
 <pre>
 # The "pledge-enroll-status" telemetry in General JWS Serialization
   syntax
@@ -4208,7 +4188,7 @@ enrollstatus-post = {
 {
   "version": 1,
   "status": true,
-  "reason": "Enrollment response successfully processed",
+  "reason": "Enroll-Response successfully processed",
   "reason-context": {
     "pes-details": "JSON"
   }
@@ -4219,7 +4199,7 @@ enrollstatus-post = {
 {
   "version": 1,
   "status": false,
-  "reason": "Enrollment response could not be verified.",
+  "reason": "Enroll-Response could not be verified.",
   "reason-context": {
     "pes-details": "no matching trust anchor"
   }
@@ -4236,225 +4216,255 @@ enrollstatus-post = {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-20" class="selfRef">Figure 20</a>:
+<figcaption><a href="#figure-16" class="selfRef">Figure 16</a>:
 <a href="#name-representation-of-pledge-en" class="selfRef">Representation of pledge enroll status telemetry</a>
             </figcaption></figure>
 </div>
-<p id="section-6.3.5-6">Once the Registrar-Agent has collected the information, it can connect to the registrar to provide it with the status responses.<a href="#section-6.3.5-6" class="pilcrow">¶</a></p>
+<p id="section-7.8.2-6">Once the Registrar-Agent has collected the information, it can connect to the registrar to provide it with the status responses.<a href="#section-7.8.2-6" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="exchanges_uc2_4">
-<section id="section-6.3.6">
-          <h4 id="name-telemetry-voucher-status-an">
-<a href="#section-6.3.6" class="section-number selfRef">6.3.6. </a><a href="#name-telemetry-voucher-status-an" class="section-name selfRef">Telemetry Voucher Status and Enroll Status Handling (Registrar-Agent to Domain Registrar)</a>
-          </h4>
-<p id="section-6.3.6-1">The following description requires that the Registrar-Agent has collected the status information from the pledge.
-It <span class="bcp14">SHALL</span> provide the status information to the registrar for further processing.<a href="#section-6.3.6-1" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-2">Preconditions in addition to <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a>:<a href="#section-6.3.6-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="vstatus">
+<section id="section-7.9">
+        <h3 id="name-voucher-status-telemetry">
+<a href="#section-7.9" class="section-number selfRef">7.9. </a><a href="#name-voucher-status-telemetry" class="section-name selfRef">Voucher Status Telemetry</a>
+        </h3>
+<p id="section-7.9-1">The following description requires that the Registrar-Agent has collected the status information from the pledge.
+It <span class="bcp14">SHALL</span> provide the status information to the registrar for further processing.<a href="#section-7.9-1" class="pilcrow">¶</a></p>
+<p id="section-7.9-2">Preconditions in addition to <a href="#pvr" class="auto internal xref">Section 7.3</a>:<a href="#section-7.9-2" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.3.6-3.1">
-              <p id="section-6.3.6-3.1.1">Registrar-Agent: obtained voucher status and enroll status from pledge.<a href="#section-6.3.6-3.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.9-3.1">
+            <p id="section-7.9-3.1.1">Registrar-Agent: obtained voucher status and enroll status from pledge.<a href="#section-7.9-3.1.1" class="pilcrow">¶</a></p>
 </li>
-          </ul>
+        </ul>
 <span id="name-bootstrapping-status-handli"></span><div id="exchangesfig_uc2_4">
-<figure id="figure-21">
-            <div id="section-6.3.6-4.1">
-              <div class="alignLeft art-svg artwork" id="section-6.3.6-4.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="320" width="496" viewBox="0 0 496 320" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
-                  <path d="M 8,32 L 8,96" fill="none" stroke="black"></path>
-                  <path d="M 40,160 L 40,304" fill="none" stroke="black"></path>
-                  <path d="M 104,32 L 104,96" fill="none" stroke="black"></path>
-                  <path d="M 176,32 L 176,96" fill="none" stroke="black"></path>
-                  <path d="M 224,104 L 224,240" fill="none" stroke="black"></path>
-                  <path d="M 224,272 L 224,304" fill="none" stroke="black"></path>
-                  <path d="M 272,32 L 272,96" fill="none" stroke="black"></path>
-                  <path d="M 304,32 L 304,96" fill="none" stroke="black"></path>
-                  <path d="M 344,104 L 344,208" fill="none" stroke="black"></path>
-                  <path d="M 344,272 L 344,304" fill="none" stroke="black"></path>
-                  <path d="M 376,32 L 376,96" fill="none" stroke="black"></path>
-                  <path d="M 408,32 L 408,96" fill="none" stroke="black"></path>
-                  <path d="M 448,104 L 448,240" fill="none" stroke="black"></path>
-                  <path d="M 448,272 L 448,304" fill="none" stroke="black"></path>
-                  <path d="M 488,32 L 488,96" fill="none" stroke="black"></path>
-                  <path d="M 8,32 L 104,32" fill="none" stroke="black"></path>
-                  <path d="M 176,32 L 272,32" fill="none" stroke="black"></path>
-                  <path d="M 304,32 L 376,32" fill="none" stroke="black"></path>
-                  <path d="M 408,32 L 488,32" fill="none" stroke="black"></path>
-                  <path d="M 8,96 L 104,96" fill="none" stroke="black"></path>
-                  <path d="M 176,96 L 272,96" fill="none" stroke="black"></path>
-                  <path d="M 304,96 L 376,96" fill="none" stroke="black"></path>
-                  <path d="M 408,96 L 488,96" fill="none" stroke="black"></path>
-                  <path d="M 48,176 L 104,176" fill="none" stroke="black"></path>
-                  <path d="M 160,176 L 216,176" fill="none" stroke="black"></path>
-                  <path d="M 48,208 L 64,208" fill="none" stroke="black"></path>
-                  <path d="M 200,208 L 216,208" fill="none" stroke="black"></path>
-                  <path d="M 232,224 L 248,224" fill="none" stroke="black"></path>
-                  <path d="M 424,224 L 440,224" fill="none" stroke="black"></path>
-                  <path d="M 232,240 L 264,240" fill="none" stroke="black"></path>
-                  <path d="M 416,240 L 440,240" fill="none" stroke="black"></path>
-                  <path d="M 48,288 L 64,288" fill="none" stroke="black"></path>
-                  <path d="M 192,288 L 216,288" fill="none" stroke="black"></path>
-                  <polygon class="arrowhead" points="448,224 436,218.4 436,229.6" fill="black" transform="rotate(0,440,224)"></polygon>
-                  <polygon class="arrowhead" points="240,240 228,234.4 228,245.6" fill="black" transform="rotate(180,232,240)"></polygon>
-                  <polygon class="arrowhead" points="224,288 212,282.4 212,293.6" fill="black" transform="rotate(0,216,288)"></polygon>
-                  <polygon class="arrowhead" points="224,208 212,202.4 212,213.6" fill="black" transform="rotate(0,216,208)"></polygon>
-                  <polygon class="arrowhead" points="224,176 212,170.4 212,181.6" fill="black" transform="rotate(0,216,176)"></polygon>
-                  <polygon class="arrowhead" points="56,176 44,170.4 44,181.6" fill="black" transform="rotate(180,48,176)"></polygon>
-                  <g class="text">
-                    <text x="60" y="52">Registrar-</text>
-                    <text x="212" y="52">Domain</text>
-                    <text x="340" y="52">Domain</text>
-                    <text x="444" y="52">Vendor</text>
-                    <text x="40" y="68">Agent</text>
-                    <text x="224" y="68">Registrar</text>
-                    <text x="324" y="68">CA</text>
-                    <text x="448" y="68">Service</text>
-                    <text x="52" y="84">(RegAgt)</text>
-                    <text x="216" y="84">(JRC)</text>
-                    <text x="444" y="84">(MASA)</text>
-                    <text x="40" y="116">|</text>
-                    <text x="404" y="116">Internet</text>
-                    <text x="36" y="132">[voucher</text>
-                    <text x="80" y="132">+</text>
-                    <text x="116" y="132">enroll</text>
-                    <text x="152" y="132">]</text>
-                    <text x="32" y="148">[status</text>
-                    <text x="84" y="148">info</text>
-                    <text x="148" y="148">available]</text>
-                    <text x="132" y="180">mTLS</text>
-                    <text x="104" y="212">Voucher</text>
-                    <text x="164" y="212">Status</text>
-                    <text x="300" y="228">req-device</text>
-                    <text x="368" y="228">audit</text>
-                    <text x="408" y="228">log</text>
-                    <text x="300" y="244">device</text>
-                    <text x="352" y="244">audit</text>
-                    <text x="392" y="244">log</text>
-                    <text x="184" y="260">[verify</text>
-                    <text x="240" y="260">audit</text>
-                    <text x="280" y="260">log</text>
-                    <text x="304" y="260">]</text>
-                    <text x="100" y="292">Enroll</text>
-                    <text x="156" y="292">Status</text>
-                  </g>
-                </svg><a href="#section-6.3.6-4.1.1" class="pilcrow">¶</a>
+<figure id="figure-17">
+          <div id="section-7.9-4.1">
+            <div class="alignLeft art-svg artwork" id="section-7.9-4.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="304" width="496" viewBox="0 0 496 304" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 40,144 L 40,288" fill="none" stroke="black"></path>
+                <path d="M 104,32 L 104,80" fill="none" stroke="black"></path>
+                <path d="M 176,32 L 176,80" fill="none" stroke="black"></path>
+                <path d="M 224,88 L 224,224" fill="none" stroke="black"></path>
+                <path d="M 224,256 L 224,288" fill="none" stroke="black"></path>
+                <path d="M 272,32 L 272,80" fill="none" stroke="black"></path>
+                <path d="M 304,32 L 304,80" fill="none" stroke="black"></path>
+                <path d="M 344,88 L 344,192" fill="none" stroke="black"></path>
+                <path d="M 344,256 L 344,288" fill="none" stroke="black"></path>
+                <path d="M 376,32 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 408,32 L 408,80" fill="none" stroke="black"></path>
+                <path d="M 448,88 L 448,224" fill="none" stroke="black"></path>
+                <path d="M 448,256 L 448,288" fill="none" stroke="black"></path>
+                <path d="M 488,32 L 488,80" fill="none" stroke="black"></path>
+                <path d="M 8,32 L 104,32" fill="none" stroke="black"></path>
+                <path d="M 176,32 L 272,32" fill="none" stroke="black"></path>
+                <path d="M 304,32 L 376,32" fill="none" stroke="black"></path>
+                <path d="M 408,32 L 488,32" fill="none" stroke="black"></path>
+                <path d="M 8,80 L 104,80" fill="none" stroke="black"></path>
+                <path d="M 176,80 L 272,80" fill="none" stroke="black"></path>
+                <path d="M 304,80 L 376,80" fill="none" stroke="black"></path>
+                <path d="M 408,80 L 488,80" fill="none" stroke="black"></path>
+                <path d="M 48,160 L 104,160" fill="none" stroke="black"></path>
+                <path d="M 160,160 L 216,160" fill="none" stroke="black"></path>
+                <path d="M 48,192 L 64,192" fill="none" stroke="black"></path>
+                <path d="M 200,192 L 216,192" fill="none" stroke="black"></path>
+                <path d="M 232,208 L 248,208" fill="none" stroke="black"></path>
+                <path d="M 424,208 L 440,208" fill="none" stroke="black"></path>
+                <path d="M 232,224 L 264,224" fill="none" stroke="black"></path>
+                <path d="M 416,224 L 440,224" fill="none" stroke="black"></path>
+                <path d="M 48,272 L 64,272" fill="none" stroke="black"></path>
+                <path d="M 192,272 L 216,272" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="448,208 436,202.4 436,213.6" fill="black" transform="rotate(0,440,208)"></polygon>
+                <polygon class="arrowhead" points="240,224 228,218.4 228,229.6" fill="black" transform="rotate(180,232,224)"></polygon>
+                <polygon class="arrowhead" points="224,272 212,266.4 212,277.6" fill="black" transform="rotate(0,216,272)"></polygon>
+                <polygon class="arrowhead" points="224,192 212,186.4 212,197.6" fill="black" transform="rotate(0,216,192)"></polygon>
+                <polygon class="arrowhead" points="224,160 212,154.4 212,165.6" fill="black" transform="rotate(0,216,160)"></polygon>
+                <polygon class="arrowhead" points="56,160 44,154.4 44,165.6" fill="black" transform="rotate(180,48,160)"></polygon>
+                <g class="text">
+                  <text x="60" y="52">Registrar-</text>
+                  <text x="212" y="52">Domain</text>
+                  <text x="340" y="52">Domain</text>
+                  <text x="436" y="52">MASA</text>
+                  <text x="40" y="68">Agent</text>
+                  <text x="224" y="68">Registrar</text>
+                  <text x="324" y="68">CA</text>
+                  <text x="40" y="100">|</text>
+                  <text x="404" y="100">Internet</text>
+                  <text x="36" y="116">[voucher</text>
+                  <text x="80" y="116">+</text>
+                  <text x="116" y="116">enroll</text>
+                  <text x="152" y="116">]</text>
+                  <text x="32" y="132">[status</text>
+                  <text x="84" y="132">info</text>
+                  <text x="148" y="132">available]</text>
+                  <text x="132" y="164">mTLS</text>
+                  <text x="104" y="196">Voucher</text>
+                  <text x="164" y="196">Status</text>
+                  <text x="300" y="212">req-device</text>
+                  <text x="368" y="212">audit</text>
+                  <text x="408" y="212">log</text>
+                  <text x="300" y="228">device</text>
+                  <text x="352" y="228">audit</text>
+                  <text x="392" y="228">log</text>
+                  <text x="184" y="244">[verify</text>
+                  <text x="240" y="244">audit</text>
+                  <text x="280" y="244">log</text>
+                  <text x="304" y="244">]</text>
+                  <text x="100" y="276">Enroll</text>
+                  <text x="156" y="276">Status</text>
+                </g>
+              </svg><a href="#section-7.9-4.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-21" class="selfRef">Figure 21</a>:
+<figcaption><a href="#figure-17" class="selfRef">Figure 17</a>:
 <a href="#name-bootstrapping-status-handli" class="selfRef">Bootstrapping status handling</a>
-            </figcaption></figure>
+          </figcaption></figure>
 </div>
-<p id="section-6.3.6-5">The Registrar-Agent <span class="bcp14">MUST</span> provide the collected pledge voucher status to the registrar.
-This status indicates if the pledge could process the voucher successfully or not.<a href="#section-6.3.6-5" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-6">In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a>.<a href="#section-6.3.6-6" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-7">The Registrar-Agent sends the pledge voucher status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/voucher_status". The Content-Type header is kept as <code>application/jose+json</code> as described in <a href="#exchangesfig_uc2_3" class="auto internal xref">Figure 16</a> and depicted in the example in <a href="#vstat" class="auto internal xref">Figure 18</a>.<a href="#section-6.3.6-7" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-8">The registrar <span class="bcp14">SHOULD</span> log the transaction provided for a pledge via Registrar-Agent and include the identity of the Registrar-Agent in these logs. For log analysis the following may be considered:<a href="#section-6.3.6-8" class="pilcrow">¶</a></p>
+<p id="section-7.9-5">The Registrar-Agent <span class="bcp14">MUST</span> provide the collected pledge voucher status to the registrar.
+This status indicates if the pledge could process the voucher successfully or not.<a href="#section-7.9-5" class="pilcrow">¶</a></p>
+<p id="section-7.9-6">In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-7.9-6" class="pilcrow">¶</a></p>
+<div id="request-artifact-vstatus">
+<section id="section-7.9.1">
+          <h4 id="name-request-artifact-vstatus">
+<a href="#section-7.9.1" class="section-number selfRef">7.9.1. </a><a href="#name-request-artifact-vstatus" class="section-name selfRef">Request Artifact: vStatus</a>
+          </h4>
+<p id="section-7.9.1-1">The Registrar-Agent sends the pledge voucher status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/voucher_status". The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#vstat" class="auto internal xref">Figure 14</a>.<a href="#section-7.9.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.9.1-2">The registrar <span class="bcp14">SHOULD</span> log the transaction provided for a pledge via Registrar-Agent and include the identity of the Registrar-Agent in these logs. For log analysis the following may be considered:<a href="#section-7.9.1-2" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.3.6-9.1">
-              <p id="section-6.3.6-9.1.1">The registrar knows the interacting Registrar-Agent from the authentication of the Registrar-Agent towards the registrar using LDevID (RegAgt) and can log it accordingly.<a href="#section-6.3.6-9.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.9.1-3.1">
+              <p id="section-7.9.1-3.1.1">The registrar knows the interacting Registrar-Agent from the authentication of the Registrar-Agent towards the registrar using LDevID (RegAgt) and can log it accordingly.<a href="#section-7.9.1-3.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.3.6-9.2">
-              <p id="section-6.3.6-9.2.1">The telemetry information from the pledge can be correlated to the voucher response provided from the registrar to the Registrar-Agent and further to the pledge.<a href="#section-6.3.6-9.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.9.1-3.2">
+              <p id="section-7.9.1-3.2.1">The telemetry information from the pledge can be correlated to the voucher response provided from the registrar to the Registrar-Agent and further to the pledge.<a href="#section-7.9.1-3.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.3.6-9.3">
-              <p id="section-6.3.6-9.3.1">The telemetry information, when provided to the registrar is provided via the Registrar-Agent and can thus be correlated.<a href="#section-6.3.6-9.3.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.9.1-3.3">
+              <p id="section-7.9.1-3.3.1">The telemetry information, when provided to the registrar is provided via the Registrar-Agent and can thus be correlated.<a href="#section-7.9.1-3.3.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.3.6-10">The registrar <span class="bcp14">SHALL</span> verify the signature of the pledge voucher status and validate that it belongs to an accepted device of the domain based on the contained "serial-number" in the IDevID certificate referenced in the header of the voucher status.<a href="#section-6.3.6-10" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-11">According to <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> Section 5.7, the registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
+<p id="section-7.9.1-4">The registrar <span class="bcp14">SHALL</span> verify the signature of the pledge voucher status and validate that it belongs to an accepted device of the domain based on the contained "serial-number" in the IDevID certificate referenced in the header of the voucher status.<a href="#section-7.9.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="response-1">
+<section id="section-7.9.2">
+          <h4 id="name-response-2">
+<a href="#section-7.9.2" class="section-number selfRef">7.9.2. </a><a href="#name-response-2" class="section-name selfRef">Response</a>
+          </h4>
+<p id="section-7.9.2-1">According to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.7" class="relref">Section 5.7</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
 The Registrar-Agent may use the response to signal success / failure to the service technician operating the Registrar-Agent.
-Within the server logs the server <span class="bcp14">SHOULD</span> capture this telemetry information.<a href="#section-6.3.6-11" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-12">The registrar <span class="bcp14">SHOULD</span> proceed with collecting and logging status information by requesting the MASA audit-log from the MASA service as described in Section 5.8 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-6.3.6-12" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-13">The Registrar-Agent <span class="bcp14">MUST</span> provide the pledge's enroll status to the registrar.
-The status indicates the pledge could process the enroll-response (certificate) and holds the corresponding private key.<a href="#section-6.3.6-13" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-14">The Registrar-Agent sends the pledge enroll status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/enrollstatus".
-The Content-Type header is kept as <code>application/jose+json</code> as described in <a href="#exchangesfig_uc2_3" class="auto internal xref">Figure 16</a> and depicted in the example in <a href="#estat" class="auto internal xref">Figure 20</a>.<a href="#section-6.3.6-14" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-15">The registrar <span class="bcp14">MUST</span> verify the signature of the pledge enroll status.
+Within the server logs the server <span class="bcp14">SHOULD</span> capture this telemetry information.<a href="#section-7.9.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.9.2-2">The registrar <span class="bcp14">SHOULD</span> proceed with collecting and logging status information by requesting the MASA audit-log from the MASA service as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.8" class="relref">Section 5.8</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.9.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="estatus">
+<section id="section-7.10">
+        <h3 id="name-enroll-status-telemetry">
+<a href="#section-7.10" class="section-number selfRef">7.10. </a><a href="#name-enroll-status-telemetry" class="section-name selfRef">Enroll Status Telemetry</a>
+        </h3>
+<p id="section-7.10-1">The Registrar-Agent <span class="bcp14">MUST</span> provide the pledge's enroll status to the registrar.
+The status indicates the pledge could process the Enroll-Response (certificate) and holds the corresponding private key.<a href="#section-7.10-1" class="pilcrow">¶</a></p>
+<div id="request-artifact-vstatus-1">
+<section id="section-7.10.1">
+          <h4 id="name-request-artifact-vstatus-2">
+<a href="#section-7.10.1" class="section-number selfRef">7.10.1. </a><a href="#name-request-artifact-vstatus-2" class="section-name selfRef">Request Artifact: vStatus</a>
+          </h4>
+<p id="section-7.10.1-1">The Registrar-Agent sends the pledge enroll status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/enrollstatus".
+The Content-Type header is kept as <code>application/jose+json</code> as depicted in the example in <a href="#estat" class="auto internal xref">Figure 16</a>.<a href="#section-7.10.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.10.1-2">The registrar <span class="bcp14">MUST</span> verify the signature of the pledge enroll status.
 Also, the registrar <span class="bcp14">SHALL</span> validate that the pledge is an accepted device of the domain based on the contained product-serial-number in the LDevID certificate referenced in the header of the enroll status.
 The registrar <span class="bcp14">SHOULD</span> log this event.
 In case the pledge enroll status indicates a failure, the pledge was unable to verify the received LDevID certificate and therefore signed the enroll status with its IDevID credential.
-Note that the signature verification of the status information is an addition to the described handling in Section 5.9.4 of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, and is replacing the pledges TLS client authentication by DevID credentials in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-6.3.6-15" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-16">According to <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> Section 5.9.4, the registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
+Note that the signature verification of the status information is an addition to the described handling in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, and is replacing the pledges TLS client authentication by DevID credentials in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-7.10.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="response-2">
+<section id="section-7.10.2">
+          <h4 id="name-response-3">
+<a href="#section-7.10.2" class="section-number selfRef">7.10.2. </a><a href="#name-response-3" class="section-name selfRef">Response</a>
+          </h4>
+<p id="section-7.10.2-1">According to <span><a href="https://rfc-editor.org/rfc/rfc8995#section-5.9.4" class="relref">Section 5.9.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the registrar <span class="bcp14">SHOULD</span> respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
 Based on the failure case the registrar <span class="bcp14">MAY</span> decide that for security reasons the pledge is not allowed to reside in the domain. In this case the registrar <span class="bcp14">MUST</span> revoke the certificate.
 An example case for the registrar revoking the issued LDevID for the pledge is when the pledge was not able to verify the received LDevID certificate and therefore did send a 406 (Not Acceptable) response.
-In this case the registrar may revoke the LDevID certificate as the pledge did no accepted it for installation.<a href="#section-6.3.6-16" class="pilcrow">¶</a></p>
-<p id="section-6.3.6-17">The Registrar-Agent may use the response to signal success / failure to the service technician operating the Registrar-Agent.
-Within the server log the registrar <span class="bcp14">SHOULD</span> capture this telemetry information.<a href="#section-6.3.6-17" class="pilcrow">¶</a></p>
+In this case the registrar may revoke the LDevID certificate as the pledge did no accepted it for installation.<a href="#section-7.10.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.10.2-2">The Registrar-Agent may use the response to signal success / failure to the service technician operating the Registrar-Agent.
+Within the server log the registrar <span class="bcp14">SHOULD</span> capture this telemetry information.<a href="#section-7.10.2-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
-<div id="exchanges_uc2_5">
-<section id="section-6.4">
-        <h3 id="name-request-pledge-status-by-re">
-<a href="#section-6.4" class="section-number selfRef">6.4. </a><a href="#name-request-pledge-status-by-re" class="section-name selfRef">Request Pledge-Status by Registrar-Agent from Pledge</a>
+<div id="query">
+<section id="section-7.11">
+        <h3 id="name-query-pledge-status">
+<a href="#section-7.11" class="section-number selfRef">7.11. </a><a href="#name-query-pledge-status" class="section-name selfRef">Query Pledge Status</a>
         </h3>
-<p id="section-6.4-1">The following assumes that a Registrar-Agent may need to query the status of a pledge.
+<p id="section-7.11-1">The following assumes that a Registrar-Agent may need to query the status of a pledge.
 This information may be useful to solve errors, when the pledge was not able to connect to the target domain during the bootstrapping.
-The pledge <span class="bcp14">MAY</span> provide a dedicated endpoint to accept status-requests.<a href="#section-6.4-1" class="pilcrow">¶</a></p>
-<p id="section-6.4-2">Preconditions:<a href="#section-6.4-2" class="pilcrow">¶</a></p>
+The pledge <span class="bcp14">MAY</span> provide a dedicated endpoint to accept status-requests.<a href="#section-7.11-1" class="pilcrow">¶</a></p>
+<p id="section-7.11-2">Preconditions:<a href="#section-7.11-2" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.4-3.1">
-            <p id="section-6.4-3.1.1">Registrar-Agent: possesses LDevID (RegAgt), may have a list of product-serial-number(s) of pledges to be queried and a list of corresponding manufacturer trust anchors to be able to verify signatures performed with the IDevID credential.<a href="#section-6.4-3.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.11-3.1">
+            <p id="section-7.11-3.1.1">Registrar-Agent: possesses LDevID (RegAgt), may have a list of product-serial-number(s) of pledges to be queried and a list of corresponding manufacturer trust anchors to be able to verify signatures performed with the IDevID credential.<a href="#section-7.11-3.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="normal" id="section-6.4-3.2">
-            <p id="section-6.4-3.2.1">Pledge: may already possess domain credentials and LDevID(Pledge), or may not possess one or both of these.<a href="#section-6.4-3.2.1" class="pilcrow">¶</a></p>
+          <li class="normal" id="section-7.11-3.2">
+            <p id="section-7.11-3.2.1">Pledge: may already possess domain credentials and LDevID(Pledge), or may not possess one or both of these.<a href="#section-7.11-3.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 <span id="name-pledge-status-handling-betw"></span><div id="exchangesfig_uc2_5">
-<figure id="figure-22">
-          <div id="section-6.4-4.1">
-            <div class="alignLeft art-svg artwork" id="section-6.4-4.1.1">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="192" width="360" viewBox="0 0 360 192" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
-                <path d="M 8,32 L 8,96" fill="none" stroke="black"></path>
-                <path d="M 40,104 L 40,176" fill="none" stroke="black"></path>
-                <path d="M 80,32 L 80,96" fill="none" stroke="black"></path>
-                <path d="M 256,32 L 256,96" fill="none" stroke="black"></path>
-                <path d="M 304,104 L 304,176" fill="none" stroke="black"></path>
-                <path d="M 352,32 L 352,96" fill="none" stroke="black"></path>
+<figure id="figure-18">
+          <div id="section-7.11-4.1">
+            <div class="alignLeft art-svg artwork" id="section-7.11-4.1.1">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="176" width="360" viewBox="0 0 360 176" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+                <path d="M 8,32 L 8,80" fill="none" stroke="black"></path>
+                <path d="M 40,88 L 40,160" fill="none" stroke="black"></path>
+                <path d="M 80,32 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 256,32 L 256,80" fill="none" stroke="black"></path>
+                <path d="M 304,88 L 304,160" fill="none" stroke="black"></path>
+                <path d="M 352,32 L 352,80" fill="none" stroke="black"></path>
                 <path d="M 8,32 L 80,32" fill="none" stroke="black"></path>
                 <path d="M 256,32 L 352,32" fill="none" stroke="black"></path>
-                <path d="M 8,96 L 80,96" fill="none" stroke="black"></path>
-                <path d="M 256,96 L 352,96" fill="none" stroke="black"></path>
-                <path d="M 48,128 L 72,128" fill="none" stroke="black"></path>
-                <path d="M 264,128 L 296,128" fill="none" stroke="black"></path>
-                <path d="M 48,160 L 72,160" fill="none" stroke="black"></path>
-                <path d="M 272,160 L 296,160" fill="none" stroke="black"></path>
-                <polygon class="arrowhead" points="304,160 292,154.4 292,165.6" fill="black" transform="rotate(0,296,160)"></polygon>
-                <polygon class="arrowhead" points="56,128 44,122.4 44,133.6" fill="black" transform="rotate(180,48,128)"></polygon>
+                <path d="M 8,80 L 80,80" fill="none" stroke="black"></path>
+                <path d="M 256,80 L 352,80" fill="none" stroke="black"></path>
+                <path d="M 48,112 L 72,112" fill="none" stroke="black"></path>
+                <path d="M 264,112 L 296,112" fill="none" stroke="black"></path>
+                <path d="M 48,144 L 72,144" fill="none" stroke="black"></path>
+                <path d="M 272,144 L 296,144" fill="none" stroke="black"></path>
+                <polygon class="arrowhead" points="304,144 292,138.4 292,149.6" fill="black" transform="rotate(0,296,144)"></polygon>
+                <polygon class="arrowhead" points="56,112 44,106.4 44,117.6" fill="black" transform="rotate(180,48,112)"></polygon>
                 <g class="text">
                   <text x="44" y="52">Pledge</text>
                   <text x="308" y="52">Registrar-</text>
                   <text x="288" y="68">Agent</text>
-                  <text x="300" y="84">(RegAgt)</text>
-                  <text x="136" y="132">pledge-status</text>
-                  <text x="224" y="132">request</text>
-                  <text x="136" y="164">pledge-status</text>
-                  <text x="228" y="164">response</text>
+                  <text x="136" y="116">pledge-status</text>
+                  <text x="224" y="116">request</text>
+                  <text x="136" y="148">pledge-status</text>
+                  <text x="228" y="148">response</text>
                 </g>
-              </svg><a href="#section-6.4-4.1.1" class="pilcrow">¶</a>
+              </svg><a href="#section-7.11-4.1.1" class="pilcrow">¶</a>
 </div>
 </div>
-<figcaption><a href="#figure-22" class="selfRef">Figure 22</a>:
+<figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
 <a href="#name-pledge-status-handling-betw" class="selfRef">Pledge-status handling between Registrar-Agent and pledge</a>
           </figcaption></figure>
 </div>
-<div id="exchanges_uc2_5a">
-<section id="section-6.4.1">
-          <h4 id="name-pledge-status-request-regis">
-<a href="#section-6.4.1" class="section-number selfRef">6.4.1. </a><a href="#name-pledge-status-request-regis" class="section-name selfRef">Pledge-Status - Request (Registrar-Agent to Pledge)</a>
+<div id="request-artifact-status-request">
+<section id="section-7.11.1">
+          <h4 id="name-request-artifact-status-req">
+<a href="#section-7.11.1" class="section-number selfRef">7.11.1. </a><a href="#name-request-artifact-status-req" class="section-name selfRef">Request Artifact: status-request</a>
           </h4>
-<p id="section-6.4.1-1">The Registrar-Agent requests the pledge-status via HTTP POST on the defined pledge endpoint: "/.well-known/brski/qps"<a href="#section-6.4.1-1" class="pilcrow">¶</a></p>
-<p id="section-6.4.1-2">The Registrar-Agent Content-Type header for the pledge-status request is: <code>application/jose+json</code>.
-It contains information on the requested status-type, the time and date the request is created, and the product serial-number of the pledge contacted as shown in <a href="#stat_req_def" class="auto internal xref">Figure 23</a>.
-The pledge-status request is signed by Registrar-Agent using the private key corresponding to the EE (RegAgt) certificate.<a href="#section-6.4.1-2" class="pilcrow">¶</a></p>
-<p id="section-6.4.1-3">The following Concise Data Definition Language (CDDL) <span>[<a href="#RFC8610" class="cite xref">RFC8610</a>]</span> explains the structure of the format for the pledge-status request. It is defined following the status telemetry definitions in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
+<p id="section-7.11.1-1">The Registrar-Agent requests the pledge-status via HTTP POST on the defined pledge endpoint: "/.well-known/brski/qps"<a href="#section-7.11.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.11.1-2">The Registrar-Agent Content-Type header for the pledge-status request is: <code>application/jose+json</code>.
+It contains information on the requested status-type, the time and date the request is created, and the product serial-number of the pledge contacted as shown in <a href="#stat_req_def" class="auto internal xref">Figure 19</a>.
+The pledge-status request is signed by Registrar-Agent using the private key corresponding to the EE (RegAgt) certificate.<a href="#section-7.11.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.11.1-3">The following Concise Data Definition Language (CDDL) <span>[<a href="#RFC8610" class="cite xref">RFC8610</a>]</span> explains the structure of the format for the pledge-status request. It is defined following the status telemetry definitions in BRSKI <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.
 Consequently, format and semantics of pledge-status requests below are for version 1.
 The version field is included to permit significant changes to the pledge-status request and response in the future.
-A pledge or a Registrar-Agent that receives a pledge-status request with a version larger than it knows about <span class="bcp14">SHOULD</span> log the contents and alert a human.<a href="#section-6.4.1-3" class="pilcrow">¶</a></p>
+A pledge or a Registrar-Agent that receives a pledge-status request with a version larger than it knows about <span class="bcp14">SHOULD</span> log the contents and alert a human.<a href="#section-7.11.1-3" class="pilcrow">¶</a></p>
 <span id="name-cddl-for-pledge-status-requ"></span><div id="stat_req_def">
-<figure id="figure-23">
-            <div class="sourcecode" id="section-6.4.1-4.1">
+<figure id="figure-19">
+            <div class="sourcecode" id="section-7.11.1-4.1">
 <pre>&lt;CODE BEGINS&gt;
   status-request = {
       "version": uint,
@@ -4465,23 +4475,23 @@ A pledge or a Registrar-Agent that receives a pledge-status request with a versi
 
 &lt;CODE ENDS&gt;</pre>
 </div>
-<figcaption><a href="#figure-23" class="selfRef">Figure 23</a>:
+<figcaption><a href="#figure-19" class="selfRef">Figure 19</a>:
 <a href="#name-cddl-for-pledge-status-requ" class="selfRef">CDDL for pledge-status request</a>
             </figcaption></figure>
 </div>
-<p id="section-6.4.1-5">The status-type defined for BRSKI-PRM is "bootstrap".
+<p id="section-7.11.1-5">The status-type defined for BRSKI-PRM is "bootstrap".
 This indicates the pledge to provide current status information regarding the bootstrapping status (voucher processing and enrollment of the pledge into the new domain).
 As the pledge-status request is defined generic, it may be used by other specifications to request further status information, e.g., for onboarding to get further information about enrollment of application specific LDevIDs or other parameters.
-This is out of scope for this specification.<a href="#section-6.4.1-5" class="pilcrow">¶</a></p>
-<p id="section-6.4.1-6"><a href="#stat_req" class="auto internal xref">Figure 24</a> below shows an example for querying pledge-status using status-type bootstrap.<a href="#section-6.4.1-6" class="pilcrow">¶</a></p>
+This is out of scope for this specification.<a href="#section-7.11.1-5" class="pilcrow">¶</a></p>
+<p id="section-7.11.1-6"><a href="#stat_req" class="auto internal xref">Figure 20</a> below shows an example for querying pledge-status using status-type bootstrap.<a href="#section-7.11.1-6" class="pilcrow">¶</a></p>
 <span id="name-example-of-registrar-agent-"></span><div id="stat_req">
-<figure id="figure-24">
-            <div class="alignLeft art-text artwork" id="section-6.4.1-7.1">
+<figure id="figure-20">
+            <div class="alignLeft art-text artwork" id="section-7.11.1-7.1">
 <pre>
 # The Registrar-Agent request of "pledge-status" in general JWS
   serialization syntax
 {
-  "payload": BASE64URL(status-request),
+  "payload": BASE64URL(UTF8(status-request)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -4510,23 +4520,23 @@ This is out of scope for this specification.<a href="#section-6.4.1-5" class="pi
 }
 </pre>
 </div>
-<figcaption><a href="#figure-24" class="selfRef">Figure 24</a>:
+<figcaption><a href="#figure-20" class="selfRef">Figure 20</a>:
 <a href="#name-example-of-registrar-agent-" class="selfRef">Example of Registrar-Agent request of pledge-status using status-type bootstrap</a>
             </figcaption></figure>
 </div>
 </section>
 </div>
-<div id="exchanges_uc2_5b">
-<section id="section-6.4.2">
-          <h4 id="name-pledge-status-response-pled">
-<a href="#section-6.4.2" class="section-number selfRef">6.4.2. </a><a href="#name-pledge-status-response-pled" class="section-name selfRef">Pledge-Status - Response (Pledge - Registrar-Agent)</a>
+<div id="response-artifact-status-response">
+<section id="section-7.11.2">
+          <h4 id="name-response-artifact-status-re">
+<a href="#section-7.11.2" class="section-number selfRef">7.11.2. </a><a href="#name-response-artifact-status-re" class="section-name selfRef">Response Artifact: status-response</a>
           </h4>
-<p id="section-6.4.2-1">If the pledge receives the pledge-status request with status-type "bootstrap" it <span class="bcp14">SHALL</span> react with a status response message based on the telemetry information described in <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a>.<a href="#section-6.4.2-1" class="pilcrow">¶</a></p>
-<p id="section-6.4.2-2">The pledge-status response Content-Type header is <code>application/jose+json</code>.<a href="#section-6.4.2-2" class="pilcrow">¶</a></p>
-<p id="section-6.4.2-3">The following CDDL explains the structure of the format for the status response, which is:<a href="#section-6.4.2-3" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-1">If the pledge receives the pledge-status request with status-type "bootstrap" it <span class="bcp14">SHALL</span> react with a status response message based on the telemetry information described in TODO.<a href="#section-7.11.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-2">The pledge-status response Content-Type header is <code>application/jose+json</code>.<a href="#section-7.11.2-2" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-3">The following CDDL explains the structure of the format for the status response, which is:<a href="#section-7.11.2-3" class="pilcrow">¶</a></p>
 <span id="name-cddl-for-pledge-status-resp"></span><div id="stat_res_def">
-<figure id="figure-25">
-            <div class="sourcecode" id="section-6.4.2-4.1">
+<figure id="figure-21">
+            <div class="sourcecode" id="section-7.11.2-4.1">
 <pre>&lt;CODE BEGINS&gt;
   status-response = {
     "version": uint,
@@ -4544,64 +4554,64 @@ This is out of scope for this specification.<a href="#section-6.4.1-5" class="pi
 
 &lt;CODE ENDS&gt;</pre>
 </div>
-<figcaption><a href="#figure-25" class="selfRef">Figure 25</a>:
+<figcaption><a href="#figure-21" class="selfRef">Figure 21</a>:
 <a href="#name-cddl-for-pledge-status-resp" class="selfRef">CDDL for pledge-status response</a>
             </figcaption></figure>
 </div>
-<p id="section-6.4.2-5">Different cases for pledge bootstrapping status may occur, which <span class="bcp14">SHOULD</span> be reflected using the status enumeration.
+<p id="section-7.11.2-5">Different cases for pledge bootstrapping status may occur, which <span class="bcp14">SHOULD</span> be reflected using the status enumeration.
 This document specifies the status values in the context of the bootstrapping process and credential application.
-Other documents may enhance the above enumeration to reflect further status information.<a href="#section-6.4.2-5" class="pilcrow">¶</a></p>
-<p id="section-6.4.2-6">The pledge-status response message is signed with IDevID or LDevID, depending on bootstrapping state of the pledge.<a href="#section-6.4.2-6" class="pilcrow">¶</a></p>
+Other documents may enhance the above enumeration to reflect further status information.<a href="#section-7.11.2-5" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-6">The pledge-status response message is signed with IDevID or LDevID, depending on bootstrapping state of the pledge.<a href="#section-7.11.2-6" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.4.2-7.1">
-              <p id="section-6.4.2-7.1.1">"factory-default": Pledge has not been bootstrapped.
+<li class="normal" id="section-7.11.2-7.1">
+              <p id="section-7.11.2-7.1.1">"factory-default": Pledge has not been bootstrapped.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its IDevID(Pledge).<a href="#section-6.4.2-7.1.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-7.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.4.2-7.2">
-              <p id="section-6.4.2-7.2.1">"voucher-success": Pledge processed the voucher exchange successfully.
+            <li class="normal" id="section-7.11.2-7.2">
+              <p id="section-7.11.2-7.2.1">"voucher-success": Pledge processed the voucher exchange successfully.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its IDevID(Pledge).<a href="#section-6.4.2-7.2.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-7.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.4.2-7.3">
-              <p id="section-6.4.2-7.3.1">"voucher-error": Pledge voucher processing terminated with error.
+            <li class="normal" id="section-7.11.2-7.3">
+              <p id="section-7.11.2-7.3.1">"voucher-error": Pledge voucher processing terminated with error.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its IDevID(Pledge).<a href="#section-6.4.2-7.3.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-7.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.4.2-7.4">
-              <p id="section-6.4.2-7.4.1">"enroll-success": Pledge has processed the enrollment exchange successfully.
+            <li class="normal" id="section-7.11.2-7.4">
+              <p id="section-7.11.2-7.4.1">"enroll-success": Pledge has processed the enrollment exchange successfully.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its LDevID(Pledge).<a href="#section-6.4.2-7.4.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-7.4.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.4.2-7.5">
-              <p id="section-6.4.2-7.5.1">"enroll-error": Pledge enrollment-response processing terminated with error.
+            <li class="normal" id="section-7.11.2-7.5">
+              <p id="section-7.11.2-7.5.1">"enroll-error": Pledge enrollment-response processing terminated with error.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its IDevID(Pledge).<a href="#section-6.4.2-7.5.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its IDevID(Pledge).<a href="#section-7.11.2-7.5.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.4.2-8">The reason and the reason-context <span class="bcp14">SHOULD</span> contain the telemetry information as described in <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a>.<a href="#section-6.4.2-8" class="pilcrow">¶</a></p>
-<p id="section-6.4.2-9">As the pledge is assumed to utilize its bootstrapped credentials (LDevID) in communication with other peers, additional status information is provided for the connectivity to other peers, which may be helpful in analyzing potential error cases.<a href="#section-6.4.2-9" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-8">The reason and the reason-context <span class="bcp14">SHOULD</span> contain the telemetry information as described in TODO[exchanges_uc2_3].<a href="#section-7.11.2-8" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-9">As the pledge is assumed to utilize its bootstrapped credentials (LDevID) in communication with other peers, additional status information is provided for the connectivity to other peers, which may be helpful in analyzing potential error cases.<a href="#section-7.11.2-9" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-6.4.2-10.1">
-              <p id="section-6.4.2-10.1.1">"connect-success": Pledge could successfully establish a connection to another peer.
+<li class="normal" id="section-7.11.2-10.1">
+              <p id="section-7.11.2-10.1.1">"connect-success": Pledge could successfully establish a connection to another peer.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its LDevID(Pledge).<a href="#section-6.4.2-10.1.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-10.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.4.2-10.2">
-              <p id="section-6.4.2-10.2.1">"connect-error": Pledge connection establishment terminated with error.
+            <li class="normal" id="section-7.11.2-10.2">
+              <p id="section-7.11.2-10.2.1">"connect-error": Pledge connection establishment terminated with error.
 Additional information may be provided in the reason or reason-context.
-The pledge signs the response message using its LDevID(Pledge).<a href="#section-6.4.2-10.2.1" class="pilcrow">¶</a></p>
+The pledge signs the response message using its LDevID(Pledge).<a href="#section-7.11.2-10.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.4.2-11">The pledge-status responses are cumulative in the sense that connect-success implies enroll-success, which in turn implies voucher-success.<a href="#section-6.4.2-11" class="pilcrow">¶</a></p>
-<p id="section-6.4.2-12"><a href="#stat_res" class="auto internal xref">Figure 26</a> provides an example for the bootstrapping-status information.<a href="#section-6.4.2-12" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-11">The pledge-status responses are cumulative in the sense that connect-success implies enroll-success, which in turn implies voucher-success.<a href="#section-7.11.2-11" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-12"><a href="#stat_res" class="auto internal xref">Figure 22</a> provides an example for the bootstrapping-status information.<a href="#section-7.11.2-12" class="pilcrow">¶</a></p>
 <span id="name-example-of-pledge-status-re"></span><div id="stat_res">
-<figure id="figure-26">
-            <div class="alignLeft art-text artwork" id="section-6.4.2-13.1">
+<figure id="figure-22">
+            <div class="alignLeft art-text artwork" id="section-7.11.2-13.1">
 <pre>
 # The pledge "status-response" in General JWS Serialization syntax
 {
-  "payload": BASE64URL(status-response),
+  "payload": BASE64URL(UTF8(status-response)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -4632,256 +4642,299 @@ The pledge signs the response message using its LDevID(Pledge).<a href="#section
 }
 </pre>
 </div>
-<figcaption><a href="#figure-26" class="selfRef">Figure 26</a>:
+<figcaption><a href="#figure-22" class="selfRef">Figure 22</a>:
 <a href="#name-example-of-pledge-status-re" class="selfRef">Example of pledge-status response</a>
             </figcaption></figure>
 </div>
 <ul class="normal">
-<li class="normal" id="section-6.4.2-14.1">
-              <p id="section-6.4.2-14.1.1">In case "factory-default" the pledge does not possess the domain certificate resp. the domain trust-anchor.
-It will not be able to verify the signature of the Registrar-Agent in the bootstrapping-status request.<a href="#section-6.4.2-14.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-7.11.2-14.1">
+              <p id="section-7.11.2-14.1.1">In case "factory-default" the pledge does not possess the domain certificate resp. the domain trust-anchor.
+It will not be able to verify the signature of the Registrar-Agent in the bootstrapping-status request.<a href="#section-7.11.2-14.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.4.2-14.2">
-              <p id="section-6.4.2-14.2.1">In cases "vouchered" and "enrolled" the pledge already possesses the domain certificate (has domain trust-anchor) and can therefore validate the signature of the Registrar-Agent.
-If validation of the JWS signature fails, the pledge <span class="bcp14">SHOULD</span> respond with the HTTP 403 Forbidden status code.<a href="#section-6.4.2-14.2.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-14.2">
+              <p id="section-7.11.2-14.2.1">In cases "vouchered" and "enrolled" the pledge already possesses the domain certificate (has domain trust-anchor) and can therefore validate the signature of the Registrar-Agent.
+If validation of the JWS signature fails, the pledge <span class="bcp14">SHOULD</span> respond with the HTTP 403 Forbidden status code.<a href="#section-7.11.2-14.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.4.2-14.3">
-              <p id="section-6.4.2-14.3.1">The HTTP 406 Not Acceptable status code <span class="bcp14">SHOULD</span> be used, if the Accept header in the request indicates an unknown or unsupported format.<a href="#section-6.4.2-14.3.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-14.3">
+              <p id="section-7.11.2-14.3.1">The HTTP 406 Not Acceptable status code <span class="bcp14">SHOULD</span> be used, if the Accept header in the request indicates an unknown or unsupported format.<a href="#section-7.11.2-14.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.4.2-14.4">
-              <p id="section-6.4.2-14.4.1">The HTTP 415 Unsupported Media Type status code <span class="bcp14">SHOULD</span> be used, if the Content-Type of the request is an unknown or unsupported format.<a href="#section-6.4.2-14.4.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-14.4">
+              <p id="section-7.11.2-14.4.1">The HTTP 415 Unsupported Media Type status code <span class="bcp14">SHOULD</span> be used, if the Content-Type of the request is an unknown or unsupported format.<a href="#section-7.11.2-14.4.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-6.4.2-14.5">
-              <p id="section-6.4.2-14.5.1">The HTTP 400 Bad Request status code <span class="bcp14">SHOULD</span> be used, if the Accept/Content-Type headers are correct but nevertheless the status-request cannot be correctly parsed.<a href="#section-6.4.2-14.5.1" class="pilcrow">¶</a></p>
+            <li class="normal" id="section-7.11.2-14.5">
+              <p id="section-7.11.2-14.5.1">The HTTP 400 Bad Request status code <span class="bcp14">SHOULD</span> be used, if the Accept/Content-Type headers are correct but nevertheless the status-request cannot be correctly parsed.<a href="#section-7.11.2-14.5.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
-<p id="section-6.4.2-15">The pledge <span class="bcp14">SHOULD</span> by default only respond to requests from nodes it can authenticate (such as registrar
-agent), once the pledge is enrolled with CA certificates and a matching domain certificate.<a href="#section-6.4.2-15" class="pilcrow">¶</a></p>
+<p id="section-7.11.2-15">The pledge <span class="bcp14">SHOULD</span> by default only respond to requests from nodes it can authenticate (such as registrar
+agent), once the pledge is enrolled with CA certificates and a matching domain certificate.<a href="#section-7.11.2-15" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 </section>
 </div>
-<div id="artifacts">
-<section id="section-7">
-      <h2 id="name-artifacts">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-artifacts" class="section-name selfRef">Artifacts</a>
+<div id="todo-artifacts">
+<section id="section-8">
+      <h2 id="name-todo-artifacts">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-todo-artifacts" class="section-name selfRef">TODO Artifacts</a>
       </h2>
 <div id="voucher-request-prm-yang">
-<section id="section-7.1">
+<section id="section-8.1">
         <h3 id="name-voucher-request-artifact">
-<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-voucher-request-artifact" class="section-name selfRef">Voucher-Request Artifact</a>
+<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-voucher-request-artifact" class="section-name selfRef">Voucher-Request Artifact</a>
         </h3>
-<p id="section-7.1-1"><span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> extends the voucher-request as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> to include additional fields necessary for handling bootstrapping in the pledge-responder-mode.
-These additional fields are defined in <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a> as:<a href="#section-7.1-1" class="pilcrow">¶</a></p>
+<p id="section-8.1-1"><span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> extends the voucher-request as defined in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> to include additional fields necessary for handling bootstrapping in the pledge-responder-mode.
+These additional fields are defined in <a href="#tpvr" class="auto internal xref">Section 7.1</a> as:<a href="#section-8.1-1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-7.1-2.1">
-            <p id="section-7.1-2.1.1">agent-signed-data to provide a JSON encoded artifact from the involved Registrar-Agent, which allows the registrar to verify the Registrar-Agent's involvement<a href="#section-7.1-2.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-8.1-2.1">
+            <p id="section-8.1-2.1.1">agent-signed-data to provide a JSON encoded artifact from the involved Registrar-Agent, which allows the registrar to verify the Registrar-Agent's involvement<a href="#section-8.1-2.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="normal" id="section-7.1-2.2">
-            <p id="section-7.1-2.2.1">agent-provided-proximity-registrar-cert to provide the registrar certificate visible to the Registrar-Agent, comparable to the registrar-proximity-certificate used in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span><a href="#section-7.1-2.2.1" class="pilcrow">¶</a></p>
+          <li class="normal" id="section-8.1-2.2">
+            <p id="section-8.1-2.2.1">agent-provided-proximity-registrar-cert to provide the registrar certificate visible to the Registrar-Agent, comparable to the registrar-proximity-certificate used in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span><a href="#section-8.1-2.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="normal" id="section-7.1-2.3">
-            <p id="section-7.1-2.3.1">agent-signing certificate to optionally provide the Registrar-Agent signing certificate.<a href="#section-7.1-2.3.1" class="pilcrow">¶</a></p>
+          <li class="normal" id="section-8.1-2.3">
+            <p id="section-8.1-2.3.1">TODO[where used? LDevID?] agent-signing certificate to optionally provide the Registrar-Agent signing certificate.<a href="#section-8.1-2.3.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-7.1-3">Examples for the application of these fields in the context of a PVR are provided in <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a>.<a href="#section-7.1-3" class="pilcrow">¶</a></p>
+<p id="section-8.1-3">Examples for the application of these fields in the context of a PVR are provided in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#section-8.1-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="iana-con">
-<section id="section-8">
+<section id="section-9">
       <h2 id="name-iana-considerations">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
-<p id="section-8-1">This document requires the following IANA actions.<a href="#section-8-1" class="pilcrow">¶</a></p>
+<p id="section-9-1">This document requires the following IANA actions.<a href="#section-9-1" class="pilcrow">¶</a></p>
 <div id="brski-well-known-registry">
-<section id="section-8.1">
+<section id="section-9.1">
         <h3 id="name-brski-well-known-registry">
-<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-brski-well-known-registry" class="section-name selfRef">BRSKI .well-known Registry</a>
+<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-brski-well-known-registry" class="section-name selfRef">BRSKI .well-known Registry</a>
         </h3>
-<p id="section-8.1-1">IANA is requested to enhance the Registry entitled: "BRSKI Well-Known URIs" with the following endpoints:<a href="#section-8.1-1" class="pilcrow">¶</a></p>
-<div class="alignLeft art-text artwork" id="section-8.1-2">
-<pre>
- URI                Description                       Reference
- tpvr               create pledge-voucher-request     [THISRFC]
- tper               create pledge-enrollment-request  [THISRFC]
- svr                supply voucher-response           [THISRFC]
- ser                supply enrollment-response        [THISRFC]
- scac               supply CA certificates to pledge  [THISRFC]
- qps                query pledge status               [THISRFC]
- requestenroll      supply PER to registrar           [THISRFC]
- wrappedcacerts     request wrapped CA certificates   [THISRFC]
-
-</pre><a href="#section-8.1-2" class="pilcrow">¶</a>
+<p id="section-9.1-1">IANA is requested to enhance the Registry entitled: "BRSKI Well-Known URIs" with the following endpoints:<a href="#section-9.1-1" class="pilcrow">¶</a></p>
+<span id="name-brski-well-known-uris-addit"></span><div id="iana_table">
+<table class="center" id="table-3">
+          <caption>
+<a href="#table-3" class="selfRef">Table 3</a>:
+<a href="#name-brski-well-known-uris-addit" class="selfRef">BRSKI Well-Known URIs Additions</a>
+          </caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Path Segment</th>
+              <th class="text-left" rowspan="1" colspan="1">Description</th>
+              <th class="text-left" rowspan="1" colspan="1">Reference</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">requestenroll</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply PER to registrar</td>
+              <td class="text-left" rowspan="1" colspan="1">[THISRFC]</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">wrappedcacerts</td>
+              <td class="text-left" rowspan="1" colspan="1">Request wrapped CA certificates</td>
+              <td class="text-left" rowspan="1" colspan="1">[THISRFC]</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">tpvr</td>
+              <td class="text-left" rowspan="1" colspan="1">Trigger Pledge Voucher-Request</td>
+              <td class="text-left" rowspan="1" colspan="1">[THISRFC]</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">tper</td>
+              <td class="text-left" rowspan="1" colspan="1">Trigger Pledge Enroll-Request</td>
+              <td class="text-left" rowspan="1" colspan="1">[THISRFC]</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">svr</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply Voucher to pledge</td>
+              <td class="text-left" rowspan="1" colspan="1">[THISRFC]</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">scac</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply CA certificates to pledge</td>
+              <td class="text-left" rowspan="1" colspan="1">[THISRFC]</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">ser</td>
+              <td class="text-left" rowspan="1" colspan="1">Supply Enroll-Response to pledge</td>
+              <td class="text-left" rowspan="1" colspan="1">[THISRFC]</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">qps</td>
+              <td class="text-left" rowspan="1" colspan="1">Query Pledge Status</td>
+              <td class="text-left" rowspan="1" colspan="1">[THISRFC]</td>
+            </tr>
+          </tbody>
+        </table>
 </div>
 </section>
 </div>
 <div id="dns-service-names">
-<section id="section-8.2">
+<section id="section-9.2">
         <h3 id="name-dns-service-names">
-<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-dns-service-names" class="section-name selfRef">DNS Service Names</a>
+<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-dns-service-names" class="section-name selfRef">DNS Service Names</a>
         </h3>
-<p id="section-8.2-1">IANA has registered the following service names:<a href="#section-8.2-1" class="pilcrow">¶</a></p>
-<p id="section-8.2-2"><strong>Service Name:</strong> brski-pledge<br>
+<p id="section-9.2-1">IANA has registered the following service names:<a href="#section-9.2-1" class="pilcrow">¶</a></p>
+<p id="section-9.2-2"><strong>Service Name:</strong> brski-pledge<br>
           <strong>Transport Protocol(s):</strong> tcp<br>
           <strong>Assignee:</strong> IESG <a href="mailto:iesg@ietf.org">iesg@ietf.org</a><br>
           <strong>Contact:</strong> IESG <a href="mailto:iesg@ietf.org">iesg@ietf.org</a><br>
           <strong>Description:</strong> The Bootstrapping Remote Secure Key Infrastructure Pledge<br>
-          <strong>Reference:</strong> [THISRFC]<a href="#section-8.2-2" class="pilcrow">¶</a></p>
+          <strong>Reference:</strong> [THISRFC]<a href="#section-9.2-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="privacy-considerations">
-<section id="section-9">
-      <h2 id="name-privacy-considerations">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-privacy-considerations" class="section-name selfRef">Privacy Considerations</a>
-      </h2>
-<p id="section-9-1">In general, the privacy considerations of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> apply for BRSKI-PRM also.
-Further privacy aspects need to be considered for:<a href="#section-9-1" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-9-2.1">
-          <p id="section-9-2.1.1">the introduction of the additional component Registrar-Agent<a href="#section-9-2.1.1" class="pilcrow">¶</a></p>
-</li>
-        <li class="normal" id="section-9-2.2">
-          <p id="section-9-2.2.1">potentially no transport layer security between Registrar-Agent and pledge<a href="#section-9-2.2.1" class="pilcrow">¶</a></p>
-</li>
-      </ul>
-<p id="section-9-3"><a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a> describes to optional apply TLS to protect the communication between the Registrar-Agent and the pledge.
-The following is therefore applicable to the communication without the TLS protection.<a href="#section-9-3" class="pilcrow">¶</a></p>
-<p id="section-9-4">The credential used by the Registrar-Agent to sign the data for the pledge <span class="bcp14">SHOULD NOT</span> contain any personal information.
-Therefore, it is recommended to use an LDevID certificate associated with the commissioning device instead of an LDevID certificate associated with the service technician operating the device.
-This avoids revealing potentially included personal information to Registrar and MASA.<a href="#section-9-4" class="pilcrow">¶</a></p>
-<p id="section-9-5">The communication between the pledge and the Registrar-Agent is performed over plain HTTP.
-Therefore, it is subject to disclosure by a Dolev-Yao attacker (an "oppressive observer")<span>[<a href="#onpath" class="cite xref">onpath</a>]</span>.
-Depending on the requests and responses, the following information is disclosed.<a href="#section-9-5" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-9-6.1">
-          <p id="section-9-6.1.1">the Pledge product-serial-number is contained in the trigger message for the PVR and in all responses from the pledge.
-This information reveals the identity of the devices being bootstrapped and allows deduction of which products an operator is using in their environment.
-As the communication between the pledge and the Registrar-Agent may be realized over wireless link, this information could easily be eavesdropped, if the wireless network is unencrypted.
-Even if the wireless network is encrypted, if it uses a network-wide key, then layer-2 attacks (ARP/ND spoofing) could insert an on-path observer into the path.<a href="#section-9-6.1.1" class="pilcrow">¶</a></p>
-</li>
-        <li class="normal" id="section-9-6.2">
-          <p id="section-9-6.2.1">the Timestamp data could reveal the activation time of the device.<a href="#section-9-6.2.1" class="pilcrow">¶</a></p>
-</li>
-        <li class="normal" id="section-9-6.3">
-          <p id="section-9-6.3.1">the Status data of the device could reveal information about the current state of the device in the domain network.<a href="#section-9-6.3.1" class="pilcrow">¶</a></p>
-</li>
-      </ul>
-</section>
-</div>
-<div id="sec_cons">
 <section id="section-10">
-      <h2 id="name-security-considerations">
-<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      <h2 id="name-privacy-considerations">
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-privacy-considerations" class="section-name selfRef">Privacy Considerations</a>
       </h2>
-<p id="section-10-1">In general, the security considerations of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> apply for BRSKI-PRM also.
-Further security aspects are considered here related to:<a href="#section-10-1" class="pilcrow">¶</a></p>
+<p id="section-10-1">In general, the privacy considerations of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> apply for BRSKI-PRM also.
+Further privacy aspects need to be considered for:<a href="#section-10-1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-10-2.1">
           <p id="section-10-2.1.1">the introduction of the additional component Registrar-Agent<a href="#section-10-2.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-10-2.2">
-          <p id="section-10-2.2.1">the reversal of the pledge communication direction (push mode, compared to BRSKI)<a href="#section-10-2.2.1" class="pilcrow">¶</a></p>
+          <p id="section-10-2.2.1">potentially no transport layer security between Registrar-Agent and pledge<a href="#section-10-2.2.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="normal" id="section-10-2.3">
-          <p id="section-10-2.3.1">no transport layer security between Registrar-Agent and pledge<a href="#section-10-2.3.1" class="pilcrow">¶</a></p>
+      </ul>
+<p id="section-10-3"><a href="#tpvr" class="auto internal xref">Section 7.1</a> describes to optional apply TLS to protect the communication between the Registrar-Agent and the pledge.
+The following is therefore applicable to the communication without the TLS protection.<a href="#section-10-3" class="pilcrow">¶</a></p>
+<p id="section-10-4">The credential used by the Registrar-Agent to sign the data for the pledge <span class="bcp14">SHOULD NOT</span> contain any personal information.
+Therefore, it is recommended to use an LDevID certificate associated with the commissioning device instead of an LDevID certificate associated with the service technician operating the device.
+This avoids revealing potentially included personal information to Registrar and MASA.<a href="#section-10-4" class="pilcrow">¶</a></p>
+<p id="section-10-5">The communication between the pledge and the Registrar-Agent is performed over plain HTTP.
+Therefore, it is subject to disclosure by a Dolev-Yao attacker (an "oppressive observer")<span>[<a href="#onpath" class="cite xref">onpath</a>]</span>.
+Depending on the requests and responses, the following information is disclosed.<a href="#section-10-5" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-10-6.1">
+          <p id="section-10-6.1.1">the Pledge product-serial-number is contained in the trigger message for the PVR and in all responses from the pledge.
+This information reveals the identity of the devices being bootstrapped and allows deduction of which products an operator is using in their environment.
+As the communication between the pledge and the Registrar-Agent may be realized over wireless link, this information could easily be eavesdropped, if the wireless network is unencrypted.
+Even if the wireless network is encrypted, if it uses a network-wide key, then layer-2 attacks (ARP/ND spoofing) could insert an on-path observer into the path.<a href="#section-10-6.1.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="normal" id="section-10-6.2">
+          <p id="section-10-6.2.1">the Timestamp data could reveal the activation time of the device.<a href="#section-10-6.2.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="normal" id="section-10-6.3">
+          <p id="section-10-6.3.1">the Status data of the device could reveal information about the current state of the device in the domain network.<a href="#section-10-6.3.1" class="pilcrow">¶</a></p>
+</li>
+      </ul>
+</section>
+</div>
+<div id="sec_cons">
+<section id="section-11">
+      <h2 id="name-security-considerations">
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<p id="section-11-1">In general, the security considerations of <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> apply for BRSKI-PRM also.
+Further security aspects are considered here related to:<a href="#section-11-1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-11-2.1">
+          <p id="section-11-2.1.1">the introduction of the additional component Registrar-Agent<a href="#section-11-2.1.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="normal" id="section-11-2.2">
+          <p id="section-11-2.2.1">the reversal of the pledge communication direction (push mode, compared to BRSKI)<a href="#section-11-2.2.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="normal" id="section-11-2.3">
+          <p id="section-11-2.3.1">no transport layer security between Registrar-Agent and pledge<a href="#section-11-2.3.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <div id="sec_cons-dos">
-<section id="section-10.1">
+<section id="section-11.1">
         <h3 id="name-denial-of-service-dos-attac">
-<a href="#section-10.1" class="section-number selfRef">10.1. </a><a href="#name-denial-of-service-dos-attac" class="section-name selfRef">Denial of Service (DoS) Attack on Pledge</a>
+<a href="#section-11.1" class="section-number selfRef">11.1. </a><a href="#name-denial-of-service-dos-attac" class="section-name selfRef">Denial of Service (DoS) Attack on Pledge</a>
         </h3>
-<p id="section-10.1-1">Disrupting the pledge behavior by a DoS attack may prevent the bootstrapping of the pledge to a new domain.
-Because in BRSKI-PRM, the pledge responds to requests from real or illicit Registrar-Agents, pledges are more subject to DoS attacks from Registrar-Agents in BRSKI-PRM than they are from illicit registrars in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, where pledges do initiate the connections.<a href="#section-10.1-1" class="pilcrow">¶</a></p>
-<p id="section-10.1-2">A DoS attack with a faked Registrar-Agent may block the bootstrapping of the pledge due changing state on the pledge (the pledge may produce a voucher-request, and refuse to produce another one).
+<p id="section-11.1-1">Disrupting the pledge behavior by a DoS attack may prevent the bootstrapping of the pledge to a new domain.
+Because in BRSKI-PRM, the pledge responds to requests from real or illicit Registrar-Agents, pledges are more subject to DoS attacks from Registrar-Agents in BRSKI-PRM than they are from illicit registrars in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, where pledges do initiate the connections.<a href="#section-11.1-1" class="pilcrow">¶</a></p>
+<p id="section-11.1-2">A DoS attack with a faked Registrar-Agent may block the bootstrapping of the pledge due changing state on the pledge (the pledge may produce a voucher-request, and refuse to produce another one).
 One mitigation may be that the pledge does not limited the number of voucher-requests it creates until at least one has finished.
-An alternative may be that the onboarding state may expire after a certain time, if no further interaction has happened.<a href="#section-10.1-2" class="pilcrow">¶</a></p>
-<p id="section-10.1-3">In addition, the pledge may assume that repeated triggering for PVR are the result of a communication error with the Registrar-Agent.
+An alternative may be that the onboarding state may expire after a certain time, if no further interaction has happened.<a href="#section-11.1-2" class="pilcrow">¶</a></p>
+<p id="section-11.1-3">In addition, the pledge may assume that repeated triggering for PVR are the result of a communication error with the Registrar-Agent.
 In that case the pledge <span class="bcp14">MAY</span> simply resent the PVR previously sent.
-Note that in case of resending, a contained nonce and also the contained agent-signed-data in the PVR would consequently be reused.<a href="#section-10.1-3" class="pilcrow">¶</a></p>
+Note that in case of resending, a contained nonce and also the contained agent-signed-data in the PVR would consequently be reused.<a href="#section-11.1-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="misuse-of-acquired-pvr-and-per-by-registrar-agent">
-<section id="section-10.2">
+<section id="section-11.2">
         <h3 id="name-misuse-of-acquired-pvr-and-">
-<a href="#section-10.2" class="section-number selfRef">10.2. </a><a href="#name-misuse-of-acquired-pvr-and-" class="section-name selfRef">Misuse of acquired PVR and PER by Registrar-Agent</a>
+<a href="#section-11.2" class="section-number selfRef">11.2. </a><a href="#name-misuse-of-acquired-pvr-and-" class="section-name selfRef">Misuse of acquired PVR and PER by Registrar-Agent</a>
         </h3>
-<p id="section-10.2-1">A Registrar-Agent that uses previously requested PVR and PER for domain-A, may attempt to onboard the device into domain-B.  This can be detected by the domain registrar while PVR processing.
+<p id="section-11.2-1">A Registrar-Agent that uses previously requested PVR and PER for domain-A, may attempt to onboard the device into domain-B.  This can be detected by the domain registrar while PVR processing.
 The domain registrar needs to verify that the "proximity-registrar-cert" field in the PVR matches its own registrar LDevID certificate.
 In addition, the domain registrar needs to verify the association of the pledge to its domain based on the product-serial-number contained in the PVR and in the IDevID certificate of the pledge. (This is just part of the supply chain integration).
-Moreover, the domain registrar verifies if the Registrar-Agent is authorized to interact with the pledge for voucher-requests and enroll-requests, based on the EE (RegAgt) certificate data contained in the PVR.<a href="#section-10.2-1" class="pilcrow">¶</a></p>
-<p id="section-10.2-2">Misbinding of a pledge by a faked domain registrar is countered as described in BRSKI security considerations <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> (Section 11.4).<a href="#section-10.2-2" class="pilcrow">¶</a></p>
+Moreover, the domain registrar verifies if the Registrar-Agent is authorized to interact with the pledge for voucher-requests and enroll-requests, based on the EE (RegAgt) certificate data contained in the PVR.<a href="#section-11.2-1" class="pilcrow">¶</a></p>
+<p id="section-11.2-2">Misbinding of a pledge by a faked domain registrar is countered as described in BRSKI security considerations <span><a href="https://rfc-editor.org/rfc/rfc8995#section-11.4" class="relref">Section 11.4</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>.<a href="#section-11.2-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="sec_cons_reg-agt">
-<section id="section-10.3">
+<section id="section-11.3">
         <h3 id="name-misuse-of-registrar-agent-c">
-<a href="#section-10.3" class="section-number selfRef">10.3. </a><a href="#name-misuse-of-registrar-agent-c" class="section-name selfRef">Misuse of Registrar-Agent Credentials</a>
+<a href="#section-11.3" class="section-number selfRef">11.3. </a><a href="#name-misuse-of-registrar-agent-c" class="section-name selfRef">Misuse of Registrar-Agent Credentials</a>
         </h3>
-<p id="section-10.3-1">Concerns of misusage of a Registrar-Agent with a valid EE (RegAgt) certificate may be addressed by utilizing short-lived certificates (e.g., valid for a day) to authenticate the Registrar-Agent against the domain registrar.
+<p id="section-11.3-1">Concerns of misusage of a Registrar-Agent with a valid EE (RegAgt) certificate may be addressed by utilizing short-lived certificates (e.g., valid for a day) to authenticate the Registrar-Agent against the domain registrar.
 The EE (RegAgt) certificate may have been acquired by a prior BRSKI run for the Registrar-Agent, if an IDevID is available on Registrar-Agent.
-Alternatively, the EE (RegAgt) certificate may be acquired by a service technician from the domain PKI system in an authenticated way.<a href="#section-10.3-1" class="pilcrow">¶</a></p>
-<p id="section-10.3-2">In addition it is required that the EE (RegAgt) certificate is valid for the complete bootstrapping phase.
+Alternatively, the EE (RegAgt) certificate may be acquired by a service technician from the domain PKI system in an authenticated way.<a href="#section-11.3-1" class="pilcrow">¶</a></p>
+<p id="section-11.3-2">In addition it is required that the EE (RegAgt) certificate is valid for the complete bootstrapping phase.
 This avoids that a Registrar-Agent could be misused to create arbitrary "agent-signed-data" objects to perform an authorized bootstrapping of a rogue pledge at a later point in time.
 In this misuse "agent-signed-data" could be dated after the validity time of the EE (RegAgt) certificate, due to missing trusted timestamp in the Registrar-Agents signature.
 To address this, the registrar <span class="bcp14">SHOULD</span> verify the certificate used to create the signature on "agent-signed-data".
-Furthermore the registrar also verifies the EE (RegAgt) certificate used in the TLS handshake with the Registrar-Agent. If both certificates are verified successfully, the Registrar-Agent's signature can be considered as valid.<a href="#section-10.3-2" class="pilcrow">¶</a></p>
+Furthermore the registrar also verifies the EE (RegAgt) certificate used in the TLS handshake with the Registrar-Agent. If both certificates are verified successfully, the Registrar-Agent's signature can be considered as valid.<a href="#section-11.3-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="sec_cons_mDNS">
-<section id="section-10.4">
+<section id="section-11.4">
         <h3 id="name-misuse-of-dns-sd-with-mdns-">
-<a href="#section-10.4" class="section-number selfRef">10.4. </a><a href="#name-misuse-of-dns-sd-with-mdns-" class="section-name selfRef">Misuse of DNS-SD with mDNS to obtain list of pledges</a>
+<a href="#section-11.4" class="section-number selfRef">11.4. </a><a href="#name-misuse-of-dns-sd-with-mdns-" class="section-name selfRef">Misuse of DNS-SD with mDNS to obtain list of pledges</a>
         </h3>
-<p id="section-10.4-1">To discover a specific pledge a Registrar-Agent may request the service name in combination with the product-serial-number of a specific pledge.
-The pledge reacts on this if its product-serial-number is part of the request message.<a href="#section-10.4-1" class="pilcrow">¶</a></p>
-<p id="section-10.4-2">If the Registrar-Agent performs DNS-based Service Discovery without a specific product-serial-number, all  pledges in the domain react if the functionality is supported.
+<p id="section-11.4-1">To discover a specific pledge a Registrar-Agent may request the service name in combination with the product-serial-number of a specific pledge.
+The pledge reacts on this if its product-serial-number is part of the request message.<a href="#section-11.4-1" class="pilcrow">¶</a></p>
+<p id="section-11.4-2">If the Registrar-Agent performs DNS-based Service Discovery without a specific product-serial-number, all  pledges in the domain react if the functionality is supported.
 This functionality enumerates and reveals the information of devices available in the domain.
 The information about this is provided here as a feature to support the commissioning of devices.
-A manufacturer may decide to support this feature only for devices not possessing a LDevID or to not support this feature at all, to avoid an enumeration in an operative domain.<a href="#section-10.4-2" class="pilcrow">¶</a></p>
+A manufacturer may decide to support this feature only for devices not possessing a LDevID or to not support this feature at all, to avoid an enumeration in an operative domain.<a href="#section-11.4-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="yang-module-security-considerations">
-<section id="section-10.5">
+<section id="section-11.5">
         <h3 id="name-yang-module-security-consid">
-<a href="#section-10.5" class="section-number selfRef">10.5. </a><a href="#name-yang-module-security-consid" class="section-name selfRef">YANG Module Security Considerations</a>
+<a href="#section-11.5" class="section-number selfRef">11.5. </a><a href="#name-yang-module-security-consid" class="section-name selfRef">YANG Module Security Considerations</a>
         </h3>
-<p id="section-10.5-1">The enhanced voucher-request described in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> is based on <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, but uses a different encoding based on <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
-The security considerations as described in <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> Section 11.7 (Security Considerations) apply.<a href="#section-10.5-1" class="pilcrow">¶</a></p>
-<p id="section-10.5-2">The YANG module specified in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> defines the schema for data that is subsequently encapsulated by a JOSE signed-data Content-type as described in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
-As such, all of the YANG-modeled data is protected against modification.<a href="#section-10.5-2" class="pilcrow">¶</a></p>
-<p id="section-10.5-3">The use of YANG to define data structures via the <span>[<a href="#RFC8971" class="cite xref">RFC8971</a>]</span> "structure" statement, is relatively
+<p id="section-11.5-1">The enhanced voucher-request described in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> is based on <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, but uses a different encoding based on <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
+The security considerations as described in <span><a href="https://rfc-editor.org/rfc/rfc8995#section-11.7" class="relref">Section 11.7</a> of [<a href="#RFC8995" class="cite xref">RFC8995</a>]</span> (Security Considerations) apply.<a href="#section-11.5-1" class="pilcrow">¶</a></p>
+<p id="section-11.5-2">The YANG module specified in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span> defines the schema for data that is subsequently encapsulated by a JOSE signed-data Content-type as described in <span>[<a href="#I-D.ietf-anima-jws-voucher" class="cite xref">I-D.ietf-anima-jws-voucher</a>]</span>.
+As such, all of the YANG-modeled data is protected against modification.<a href="#section-11.5-2" class="pilcrow">¶</a></p>
+<p id="section-11.5-3">The use of YANG to define data structures via the <span>[<a href="#RFC8971" class="cite xref">RFC8971</a>]</span> "structure" statement, is relatively
 new and distinct from the traditional use of YANG to define an API accessed by network management protocols such as NETCONF <span>[<a href="#RFC6241" class="cite xref">RFC6241</a>]</span> and RESTCONF <span>[<a href="#RFC8040" class="cite xref">RFC8040</a>]</span>.
-For this reason, these guidelines do not follow the template described by <span>[<a href="#RFC8407" class="cite xref">RFC8407</a>]</span> Section 3.7 (Security Considerations Section).<a href="#section-10.5-3" class="pilcrow">¶</a></p>
+For this reason, these guidelines do not follow the template described by <span><a href="https://rfc-editor.org/rfc/rfc8407#section-3.7" class="relref">Section 3.7</a> of [<a href="#RFC8407" class="cite xref">RFC8407</a>]</span> (Security Considerations).<a href="#section-11.5-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="acknowledgments">
-<section id="section-11">
+<section id="section-12">
       <h2 id="name-acknowledgments">
-<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
+<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
       </h2>
-<p id="section-11-1">We would like to thank the various reviewers, in particular Brian E. Carpenter, Charlie Kaufman (Early SECDIR review), Martin Björklund (Early YANGDOCTORS review), Marco Tiloca (Early IOTDIR review), Oskar Camenzind, Hendrik Brockhaus, and Ingo Wenda for their input and discussion on use cases and call flows.
+<p id="section-12-1">We would like to thank the various reviewers, in particular Brian E. Carpenter, Charlie Kaufman (Early SECDIR review), Martin Björklund (Early YANGDOCTORS review), Marco Tiloca (Early IOTDIR review), Oskar Camenzind, Hendrik Brockhaus, and Ingo Wenda for their input and discussion on use cases and call flows.
 Further review input was provided by Jesser Bouzid, Dominik Tacke, and Christian Spindler.
 Special thanks to Esko Dijk for the in deep review and the improving proposals.
-Support in PoC implementations and comments resulting from the implementation was provided by Hong Rui Li and He Peng Jia.<a href="#section-11-1" class="pilcrow">¶</a></p>
+Support in PoC implementations and comments resulting from the implementation was provided by Hong Rui Li and He Peng Jia.<a href="#section-12-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<section id="section-12">
+<section id="section-13">
       <h2 id="name-references">
-<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-references" class="section-name selfRef">References</a>
+<a href="#section-13" class="section-number selfRef">13. </a><a href="#name-references" class="section-name selfRef">References</a>
       </h2>
 <div id="sec-normative-references">
-<section id="section-12.1">
+<section id="section-13.1">
         <h3 id="name-normative-references">
-<a href="#section-12.1" class="section-number selfRef">12.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+<a href="#section-13.1" class="section-number selfRef">13.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
         </h3>
 <dl class="references">
 <dt id="I-D.ietf-anima-jws-voucher">[I-D.ietf-anima-jws-voucher]</dt>
@@ -4900,6 +4953,10 @@ Support in PoC implementations and comments resulting from the implementation wa
         <dd>
 <span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>&gt;</span>. </dd>
 <dd class="break"></dd>
+<dt id="RFC2986">[RFC2986]</dt>
+        <dd>
+<span class="refAuthor">Nystrom, M.</span> and <span class="refAuthor">B. Kaliski</span>, <span class="refTitle">"PKCS #10: Certification Request Syntax Specification Version 1.7"</span>, <span class="seriesInfo">RFC 2986</span>, <span class="seriesInfo">DOI 10.17487/RFC2986</span>, <time datetime="2000-11" class="refDate">November 2000</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc2986">https://www.rfc-editor.org/rfc/rfc2986</a>&gt;</span>. </dd>
+<dd class="break"></dd>
 <dt id="RFC6762">[RFC6762]</dt>
         <dd>
 <span class="refAuthor">Cheshire, S.</span> and <span class="refAuthor">M. Krochmal</span>, <span class="refTitle">"Multicast DNS"</span>, <span class="seriesInfo">RFC 6762</span>, <span class="seriesInfo">DOI 10.17487/RFC6762</span>, <time datetime="2013-02" class="refDate">February 2013</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc6762">https://www.rfc-editor.org/rfc/rfc6762</a>&gt;</span>. </dd>
@@ -4915,10 +4972,6 @@ Support in PoC implementations and comments resulting from the implementation wa
 <dt id="RFC7515">[RFC7515]</dt>
         <dd>
 <span class="refAuthor">Jones, M.</span>, <span class="refAuthor">Bradley, J.</span>, and <span class="refAuthor">N. Sakimura</span>, <span class="refTitle">"JSON Web Signature (JWS)"</span>, <span class="seriesInfo">RFC 7515</span>, <span class="seriesInfo">DOI 10.17487/RFC7515</span>, <time datetime="2015-05" class="refDate">May 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc7515">https://www.rfc-editor.org/rfc/rfc7515</a>&gt;</span>. </dd>
-<dd class="break"></dd>
-<dt id="RFC8040">[RFC8040]</dt>
-        <dd>
-<span class="refAuthor">Bierman, A.</span>, <span class="refAuthor">Bjorklund, M.</span>, and <span class="refAuthor">K. Watsen</span>, <span class="refTitle">"RESTCONF Protocol"</span>, <span class="seriesInfo">RFC 8040</span>, <span class="seriesInfo">DOI 10.17487/RFC8040</span>, <time datetime="2017-01" class="refDate">January 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc8040">https://www.rfc-editor.org/rfc/rfc8040</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC8174">[RFC8174]</dt>
         <dd>
@@ -4948,9 +5001,9 @@ Support in PoC implementations and comments resulting from the implementation wa
 </section>
 </div>
 <div id="sec-informative-references">
-<section id="section-12.2">
+<section id="section-13.2">
         <h3 id="name-informative-references">
-<a href="#section-12.2" class="section-number selfRef">12.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+<a href="#section-13.2" class="section-number selfRef">13.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
         </h3>
 <dl class="references">
 <dt id="androidnsd">[androidnsd]</dt>
@@ -4975,7 +5028,7 @@ Support in PoC implementations and comments resulting from the implementation wa
 <dd class="break"></dd>
 <dt id="I-D.irtf-t2trg-taxonomy-manufacturer-anchors">[I-D.irtf-t2trg-taxonomy-manufacturer-anchors]</dt>
         <dd>
-<span class="refAuthor">Richardson, M.</span>, <span class="refTitle">"A Taxonomy of operational security considerations for manufacturer installed keys and Trust Anchors"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-irtf-t2trg-taxonomy-manufacturer-anchors-02</span>, <time datetime="2023-08-06" class="refDate">6 August 2023</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-irtf-t2trg-taxonomy-manufacturer-anchors-02">https://datatracker.ietf.org/doc/html/draft-irtf-t2trg-taxonomy-manufacturer-anchors-02</a>&gt;</span>. </dd>
+<span class="refAuthor">Richardson, M.</span>, <span class="refTitle">"A Taxonomy of operational security considerations for manufacturer installed keys and Trust Anchors"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-irtf-t2trg-taxonomy-manufacturer-anchors-03</span>, <time datetime="2024-01-30" class="refDate">30 January 2024</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-irtf-t2trg-taxonomy-manufacturer-anchors-03">https://datatracker.ietf.org/doc/html/draft-irtf-t2trg-taxonomy-manufacturer-anchors-03</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="I-D.richardson-anima-registrar-considerations">[I-D.richardson-anima-registrar-considerations]</dt>
         <dd>
@@ -4993,17 +5046,13 @@ Support in PoC implementations and comments resulting from the implementation wa
         <dd>
 <span class="refTitle">"can an on-path attacker drop traffic?"</span>, <span>n.d.</span>, <span>&lt;<a href="https://mailarchive.ietf.org/arch/msg/saag/m1r9uo4xYznOcf85Eyk0Rhut598/">https://mailarchive.ietf.org/arch/msg/saag/m1r9uo4xYznOcf85Eyk0Rhut598/</a>&gt;</span>. </dd>
 <dd class="break"></dd>
-<dt id="RFC2986">[RFC2986]</dt>
+<dt id="RFC3629">[RFC3629]</dt>
         <dd>
-<span class="refAuthor">Nystrom, M.</span> and <span class="refAuthor">B. Kaliski</span>, <span class="refTitle">"PKCS #10: Certification Request Syntax Specification Version 1.7"</span>, <span class="seriesInfo">RFC 2986</span>, <span class="seriesInfo">DOI 10.17487/RFC2986</span>, <time datetime="2000-11" class="refDate">November 2000</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc2986">https://www.rfc-editor.org/rfc/rfc2986</a>&gt;</span>. </dd>
+<span class="refAuthor">Yergeau, F.</span>, <span class="refTitle">"UTF-8, a transformation format of ISO 10646"</span>, <span class="seriesInfo">STD 63</span>, <span class="seriesInfo">RFC 3629</span>, <span class="seriesInfo">DOI 10.17487/RFC3629</span>, <time datetime="2003-11" class="refDate">November 2003</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc3629">https://www.rfc-editor.org/rfc/rfc3629</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC5272">[RFC5272]</dt>
         <dd>
 <span class="refAuthor">Schaad, J.</span> and <span class="refAuthor">M. Myers</span>, <span class="refTitle">"Certificate Management over CMS (CMC)"</span>, <span class="seriesInfo">RFC 5272</span>, <span class="seriesInfo">DOI 10.17487/RFC5272</span>, <time datetime="2008-06" class="refDate">June 2008</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc5272">https://www.rfc-editor.org/rfc/rfc5272</a>&gt;</span>. </dd>
-<dd class="break"></dd>
-<dt id="RFC6125">[RFC6125]</dt>
-        <dd>
-<span class="refAuthor">Saint-Andre, P.</span> and <span class="refAuthor">J. Hodges</span>, <span class="refTitle">"Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS)"</span>, <span class="seriesInfo">RFC 6125</span>, <span class="seriesInfo">DOI 10.17487/RFC6125</span>, <time datetime="2011-03" class="refDate">March 2011</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc6125">https://www.rfc-editor.org/rfc/rfc6125</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC6241">[RFC6241]</dt>
         <dd>
@@ -5013,9 +5062,9 @@ Support in PoC implementations and comments resulting from the implementation wa
         <dd>
 <span class="refAuthor">Shelby, Z.</span>, <span class="refAuthor">Hartke, K.</span>, and <span class="refAuthor">C. Bormann</span>, <span class="refTitle">"The Constrained Application Protocol (CoAP)"</span>, <span class="seriesInfo">RFC 7252</span>, <span class="seriesInfo">DOI 10.17487/RFC7252</span>, <time datetime="2014-06" class="refDate">June 2014</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc7252">https://www.rfc-editor.org/rfc/rfc7252</a>&gt;</span>. </dd>
 <dd class="break"></dd>
-<dt id="RFC8152">[RFC8152]</dt>
+<dt id="RFC8040">[RFC8040]</dt>
         <dd>
-<span class="refAuthor">Schaad, J.</span>, <span class="refTitle">"CBOR Object Signing and Encryption (COSE)"</span>, <span class="seriesInfo">RFC 8152</span>, <span class="seriesInfo">DOI 10.17487/RFC8152</span>, <time datetime="2017-07" class="refDate">July 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc8152">https://www.rfc-editor.org/rfc/rfc8152</a>&gt;</span>. </dd>
+<span class="refAuthor">Bierman, A.</span>, <span class="refAuthor">Bjorklund, M.</span>, and <span class="refAuthor">K. Watsen</span>, <span class="refTitle">"RESTCONF Protocol"</span>, <span class="seriesInfo">RFC 8040</span>, <span class="seriesInfo">DOI 10.17487/RFC8040</span>, <time datetime="2017-01" class="refDate">January 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc8040">https://www.rfc-editor.org/rfc/rfc8040</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC8407">[RFC8407]</dt>
         <dd>
@@ -5037,17 +5086,17 @@ Support in PoC implementations and comments resulting from the implementation wa
         <dd>
 <span class="refAuthor">Schaad, J.</span>, <span class="refTitle">"CBOR Object Signing and Encryption (COSE): Structures and Process"</span>, <span class="seriesInfo">STD 96</span>, <span class="seriesInfo">RFC 9052</span>, <span class="seriesInfo">DOI 10.17487/RFC9052</span>, <time datetime="2022-08" class="refDate">August 2022</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc9052">https://www.rfc-editor.org/rfc/rfc9052</a>&gt;</span>. </dd>
 <dd class="break"></dd>
-<dt id="RFC9053">[RFC9053]</dt>
-        <dd>
-<span class="refAuthor">Schaad, J.</span>, <span class="refTitle">"CBOR Object Signing and Encryption (COSE): Initial Algorithms"</span>, <span class="seriesInfo">RFC 9053</span>, <span class="seriesInfo">DOI 10.17487/RFC9053</span>, <time datetime="2022-08" class="refDate">August 2022</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc9053">https://www.rfc-editor.org/rfc/rfc9053</a>&gt;</span>. </dd>
-<dd class="break"></dd>
 <dt id="RFC9110">[RFC9110]</dt>
         <dd>
 <span class="refAuthor">Fielding, R., Ed.</span>, <span class="refAuthor">Nottingham, M., Ed.</span>, and <span class="refAuthor">J. Reschke, Ed.</span>, <span class="refTitle">"HTTP Semantics"</span>, <span class="seriesInfo">STD 97</span>, <span class="seriesInfo">RFC 9110</span>, <span class="seriesInfo">DOI 10.17487/RFC9110</span>, <time datetime="2022-06" class="refDate">June 2022</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc9110">https://www.rfc-editor.org/rfc/rfc9110</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC9238">[RFC9238]</dt>
-      <dd>
+        <dd>
 <span class="refAuthor">Richardson, M.</span>, <span class="refAuthor">Latour, J.</span>, and <span class="refAuthor">H. Habibi Gharakheili</span>, <span class="refTitle">"Loading Manufacturer Usage Description (MUD) URLs from QR Codes"</span>, <span class="seriesInfo">RFC 9238</span>, <span class="seriesInfo">DOI 10.17487/RFC9238</span>, <time datetime="2022-05" class="refDate">May 2022</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc9238">https://www.rfc-editor.org/rfc/rfc9238</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9525">[RFC9525]</dt>
+      <dd>
+<span class="refAuthor">Saint-Andre, P.</span> and <span class="refAuthor">R. Salz</span>, <span class="refTitle">"Service Identity in TLS"</span>, <span class="seriesInfo">RFC 9525</span>, <span class="seriesInfo">DOI 10.17487/RFC9525</span>, <time datetime="2023-11" class="refDate">November 2023</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc9525">https://www.rfc-editor.org/rfc/rfc9525</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>
@@ -5062,12 +5111,12 @@ Support in PoC implementations and comments resulting from the implementation wa
 <div id="example-pledge-voucher-request-pvr-from-pledge-to-registrar-agent">
 <section id="appendix-A.1">
         <h3 id="name-example-pledge-voucher-requ">
-<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-example-pledge-voucher-requ" class="section-name selfRef">Example Pledge-Voucher-Request - PVR (from Pledge to Registrar-Agent)</a>
+<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-example-pledge-voucher-requ" class="section-name selfRef">Example Pledge Voucher-Request (PVR) - from Pledge to Registrar-Agent</a>
         </h3>
 <p id="appendix-A.1-1">The following is an example request sent from a Pledge to the Registrar-Agent, in "General JWS JSON Serialization".
 The message size of this PVR is: 4649 bytes<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
 <span id="name-example-pledge-voucher-reque"></span><div id="ExamplePledgeVoucherRequestfigure">
-<figure id="figure-27">
+<figure id="figure-23">
           <div class="alignLeft art-text artwork" id="appendix-A.1-2.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -5149,7 +5198,7 @@ yuXZ2aw93zZId45R7XxAK-12YKIx6qLjiPjMw"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-27" class="selfRef">Figure 27</a>:
+<figcaption><a href="#figure-23" class="selfRef">Figure 23</a>:
 <a href="#name-example-pledge-voucher-reque" class="selfRef">Example Pledge-Voucher-Request - PVR</a>
           </figcaption></figure>
 </div>
@@ -5158,7 +5207,7 @@ yuXZ2aw93zZId45R7XxAK-12YKIx6qLjiPjMw"
 <div id="example-parboiled-registrar-voucher-request-rvr-from-registrar-to-masa">
 <section id="appendix-A.2">
         <h3 id="name-example-parboiled-registrar">
-<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-example-parboiled-registrar" class="section-name selfRef">Example Parboiled Registrar-Voucher-Request - RVR (from Registrar to MASA)</a>
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-example-parboiled-registrar" class="section-name selfRef">Example Parboiled Registrar Voucher-Request (RVR) - from Registrar to MASA</a>
         </h3>
 <p id="appendix-A.2-1">The term parboiled refers to food which is partially cooked.  In <span>[<a href="#RFC8995" class="cite xref">RFC8995</a>]</span>, the term refers to a pledge-voucher-request (PVR) which has
 been received by the Registrar, and then has been processed by the Registrar ("cooked"), and is now being forwarded to the MASA.<a href="#appendix-A.2-1" class="pilcrow">¶</a></p>
@@ -5166,7 +5215,7 @@ been received by the Registrar, and then has been processed by the Registrar ("c
 Note that the previous PVR can be seen in the payload as "prior-signed-voucher-request".
 The message size of this RVR is: 13257 bytes<a href="#appendix-A.2-2" class="pilcrow">¶</a></p>
 <span id="name-example-registrar-voucher-r"></span><div id="ExampleRegistrarVoucherRequestfigure">
-<figure id="figure-28">
+<figure id="figure-24">
           <div class="alignLeft art-text artwork" id="appendix-A.2-3.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -5374,20 +5423,20 @@ yyFd3kP6YCn35YYJ7yK35d3styo_yoiPfKA"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-28" class="selfRef">Figure 28</a>:
+<figcaption><a href="#figure-24" class="selfRef">Figure 24</a>:
 <a href="#name-example-registrar-voucher-r" class="selfRef">Example Registrar-Voucher-Request - RVR</a>
           </figcaption></figure>
 </div>
 </section>
 </div>
-<div id="example-voucher-response-from-masa-to-pledge-via-registrar-and-registrar-agent">
+<div id="example-voucher-from-masa-to-pledge-via-registrar-and-registrar-agent">
 <section id="appendix-A.3">
-        <h3 id="name-example-voucher-response-fr">
-<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-example-voucher-response-fr" class="section-name selfRef">Example Voucher-Response (from MASA to Pledge, via Registrar and Registrar-Agent)</a>
+        <h3 id="name-example-voucher-from-masa-t">
+<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-example-voucher-from-masa-t" class="section-name selfRef">Example Voucher - from MASA to Pledge, via Registrar and Registrar-Agent</a>
         </h3>
 <p id="appendix-A.3-1">The following is an example voucher-response from MASA to Pledge via Registrar and Registrar-Agent, in "General JWS JSON Serialization". The message size of this Voucher is: 1916 bytes<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
-<span id="name-example-voucher-response-fro"></span><div id="ExampleVoucherResponsefigure">
-<figure id="figure-29">
+<span id="name-example-voucher-response-fr"></span><div id="ExampleVoucherResponsefigure">
+<figure id="figure-25">
           <div class="alignLeft art-text artwork" id="appendix-A.3-2.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -5427,21 +5476,21 @@ TvHMUw0wx9wdyuNVjNoAgLysNIgEvlcltBw"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-29" class="selfRef">Figure 29</a>:
-<a href="#name-example-voucher-response-fro" class="selfRef">Example Voucher-Response from MASA</a>
+<figcaption><a href="#figure-25" class="selfRef">Figure 25</a>:
+<a href="#name-example-voucher-response-fr" class="selfRef">Example Voucher-Response from MASA</a>
           </figcaption></figure>
 </div>
 </section>
 </div>
-<div id="example-voucher-response-masa-issued-voucher-with-additional-registrar-signature-from-masa-to-pledge-via-registrar-and-registrar-agent">
+<div id="example-voucher-masa-issued-voucher-with-additional-registrar-signature-from-masa-to-pledge-via-registrar-and-registrar-agent">
 <section id="appendix-A.4">
-        <h3 id="name-example-voucher-response-ma">
-<a href="#appendix-A.4" class="section-number selfRef">A.4. </a><a href="#name-example-voucher-response-ma" class="section-name selfRef">Example Voucher-Response, MASA issued Voucher with additional Registrar signature (from MASA to Pledge, via Registrar and Registrar-Agent)</a>
+        <h3 id="name-example-voucher-masa-issued">
+<a href="#appendix-A.4" class="section-number selfRef">A.4. </a><a href="#name-example-voucher-masa-issued" class="section-name selfRef">Example Voucher, MASA issued Voucher with additional Registrar signature (from MASA to Pledge, via Registrar and Registrar-Agent)</a>
         </h3>
 <p id="appendix-A.4-1">The following is an example voucher-response from MASA to Pledge via Registrar and Registrar-Agent, in "General JWS JSON Serialization".
 The message size of this Voucher is: 3006 bytes<a href="#appendix-A.4-1" class="pilcrow">¶</a></p>
-<span id="name-example-voucher-response-from"></span><div id="ExampleVoucherResponseWithRegSignfigure">
-<figure id="figure-30">
+<span id="name-example-voucher-response-fro"></span><div id="ExampleVoucherResponseWithRegSignfigure">
+<figure id="figure-26">
           <div class="alignLeft art-text artwork" id="appendix-A.4-2.1">
 <pre>
 =============== NOTE: '\' line wrapping per RFC 8792 ================
@@ -5499,8 +5548,8 @@ qhRRyjnxp80IV_Fy1RAOXIIzs3Q8CnMgBgg"
 }
 </pre>
 </div>
-<figcaption><a href="#figure-30" class="selfRef">Figure 30</a>:
-<a href="#name-example-voucher-response-from" class="selfRef">Example Voucher-Response from MASA, with additional Registrar signature</a>
+<figcaption><a href="#figure-26" class="selfRef">Figure 26</a>:
+<a href="#name-example-voucher-response-fro" class="selfRef">Example Voucher-Response from MASA, with additional Registrar signature</a>
           </figcaption></figure>
 </div>
 </section>
@@ -5521,7 +5570,7 @@ The authenticity of the onboarding and enrollment is not dependant upon the secu
           <p id="appendix-B-4.1.1">A certificate is generally required in order to do TLS.  While there are other modes of authentication including PSK, various EAP methods and raw public key, they do no help as there is no previous relationship between the Registrar-Agent.<a href="#appendix-B-4.1.1" class="pilcrow">¶</a></p>
 </li>
         <li id="appendix-B-4.2">
-          <p id="appendix-B-4.2.1">The pledge can use it's IDevID certificate to authenticate itself, but <span>[<a href="#RFC6125" class="cite xref">RFC6125</a>]</span> DNS-ID methods do not apply as the pledge does not have a FQDN.  Instead a new mechanism is required, which authenticates the X520SerialNumber DN attribute which must be present in every IDevID.<a href="#appendix-B-4.2.1" class="pilcrow">¶</a></p>
+          <p id="appendix-B-4.2.1">The pledge can use it's IDevID certificate to authenticate itself, but <span>[<a href="#RFC9525" class="cite xref">RFC9525</a>]</span> DNS-ID methods do not apply as the pledge does not have a FQDN.  Instead a new mechanism is required, which authenticates the X520SerialNumber DN attribute which must be present in every IDevID.<a href="#appendix-B-4.2.1" class="pilcrow">¶</a></p>
 </li>
       </ol>
 <p id="appendix-B-5">If the Registrar-Agent has a preconfigured list of which product-serial-number(s), from which manufacturers it expects to see, then it can attempt to match this pledge against a list of potential devices.<a href="#appendix-B-5" class="pilcrow">¶</a></p>
@@ -5529,7 +5578,7 @@ The authenticity of the onboarding and enrollment is not dependant upon the secu
 The use of scannable QRcodes may help automate this in some cases.<a href="#appendix-B-6" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-B-7">
 <li id="appendix-B-7.1">
-          <p id="appendix-B-7.1.1">The CA used to sign the IDevID will be a manufacturer private PKI as described in <span>[<a href="#I-D.irtf-t2trg-taxonomy-manufacturer-anchors" class="cite xref">I-D.irtf-t2trg-taxonomy-manufacturer-anchors</a>], <a href="https://datatracker.ietf.org/doc/html/draft-irtf-t2trg-taxonomy-manufacturer-anchors-02#section-4.1" class="relref">Section 4.1</a></span>.
+          <p id="appendix-B-7.1.1">The CA used to sign the IDevID will be a manufacturer private PKI as described in <span>[<a href="#I-D.irtf-t2trg-taxonomy-manufacturer-anchors" class="cite xref">I-D.irtf-t2trg-taxonomy-manufacturer-anchors</a>], <a href="https://datatracker.ietf.org/doc/html/draft-irtf-t2trg-taxonomy-manufacturer-anchors-03#section-4.1" class="relref">Section 4.1</a></span>.
 The anchors for this PKI will never be part of the public WebPKI anchors which are distributed with most smartphone operating systems.
 A Registrar-Agent application will need to use different APIs in order to initiate an HTTPS connection without performing WebPKI verification.
 The application will then have to do it's own certificate chain verification against a store of manufacturer trust anchors.
@@ -5559,32 +5608,20 @@ IDevID certificates are intended to be widely useable and EKU does not support t
 <li class="normal" id="appendix-C-3.1">
           <p id="appendix-C-3.1.1">Updated acknowledgements to reflect early reviews<a href="#appendix-C-3.1.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="normal" id="appendix-C-3.2">
-          <p id="appendix-C-3.2.1">Reworked examples to fit JSON syntax<a href="#appendix-C-3.2.1" class="pilcrow">¶</a></p>
-</li>
-        <li class="normal" id="appendix-C-3.3">
-          <p id="appendix-C-3.3.1">Update references to for voucher context to I-D.ietf-anima-rfc8366bis<a href="#appendix-C-3.3.1" class="pilcrow">¶</a></p>
-</li>
-        <li class="normal" id="appendix-C-3.4">
-          <p id="appendix-C-3.4.1">Renamed ietf-voucher-request-prm to ietf-voucher to refelct move of YANG module to RFC8366bis<a href="#appendix-C-3.4.1" class="pilcrow">¶</a></p>
-</li>
-        <li class="normal" id="appendix-C-3.5">
-          <p id="appendix-C-3.5.1">Updated status response member usage in <a href="#exchanges_uc2_3b" class="auto internal xref">Section 6.3.2</a> and <a href="#exchanges_uc2_3e" class="auto internal xref">Section 6.3.5</a> to always use all field in the BRSKI defined status messages<a href="#appendix-C-3.5.1" class="pilcrow">¶</a></p>
-</li>
       </ul>
 <p id="appendix-C-4">From IETF draft 10 -&gt; IETF draft 11:<a href="#appendix-C-4" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-C-5.1">
-          <p id="appendix-C-5.1.1">issue #79, clarified that BRSKI discovery in the context of BRSKI-PRM is not needed in <a href="#discovery_uc2_reg" class="auto internal xref">Section 5.6.1</a>.<a href="#appendix-C-5.1.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-5.1.1">issue #79, clarified that BRSKI discovery in the context of BRSKI-PRM is not needed in <a href="#discovery_uc2_reg" class="auto internal xref">Section 6.2.1</a>.<a href="#appendix-C-5.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-5.2">
-          <p id="appendix-C-5.2.1">issue #103, removed step 6 in verification handling for the wrapped CA certificate provisioning as only applicable after enrollment <a href="#exchanges_uc2_3c" class="auto internal xref">Section 6.3.3</a><a href="#appendix-C-5.2.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-5.2.1">issue #103, removed step 6 in verification handling for the wrapped CA certificate provisioning as only applicable after enrollment <a href="#cacerts" class="auto internal xref">Section 7.7</a><a href="#appendix-C-5.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-5.3">
           <p id="appendix-C-5.3.1">issue #128: included notation of nomadic operation of the Registrar-Agent in <a href="#architecture" class="auto internal xref">Section 5</a>, including proposed text from PR #131<a href="#appendix-C-5.3.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-5.4">
-          <p id="appendix-C-5.4.1">issue #130, introduced DNS service discovery name for brski_pledge to enable discovery by the Registrar-Agent in <a href="#iana-con" class="auto internal xref">Section 8</a><a href="#appendix-C-5.4.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-5.4.1">issue #130, introduced DNS service discovery name for brski_pledge to enable discovery by the Registrar-Agent in <a href="#iana-con" class="auto internal xref">Section 9</a><a href="#appendix-C-5.4.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-5.5">
           <p id="appendix-C-5.5.1">removed unused reference RFC 5280<a href="#appendix-C-5.5.1" class="pilcrow">¶</a></p>
@@ -5593,13 +5630,13 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-5.6.1">removed site terminology<a href="#appendix-C-5.6.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-5.7">
-          <p id="appendix-C-5.7.1">deleted duplicated text in <a href="#pledge_ep" class="auto internal xref">Section 5.5</a><a href="#appendix-C-5.7.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-5.7.1">deleted duplicated text in <a href="#pledge_ep" class="auto internal xref">Section 6.3</a><a href="#appendix-C-5.7.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-5.8">
-          <p id="appendix-C-5.8.1">clarified registrar discovery and relation to BRSKI-Discovery in <a href="#discovery_uc2_reg" class="auto internal xref">Section 5.6.1</a><a href="#appendix-C-5.8.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-5.8.1">clarified registrar discovery and relation to BRSKI-Discovery in <a href="#discovery_uc2_reg" class="auto internal xref">Section 6.2.1</a><a href="#appendix-C-5.8.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-5.9">
-          <p id="appendix-C-5.9.1">clarified discovery of pledges by the Registrar-Agent in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 5.6.2</a>, deleted reference to GRASP as handled in BRSKI-Discovery<a href="#appendix-C-5.9.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-5.9.1">clarified discovery of pledges by the Registrar-Agent in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 6.2.2</a>, deleted reference to GRASP as handled in BRSKI-Discovery<a href="#appendix-C-5.9.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-5.10">
           <p id="appendix-C-5.10.1">addressed comments from SECDIR early review<a href="#appendix-C-5.10.1" class="pilcrow">¶</a></p>
@@ -5608,34 +5645,34 @@ IDevID certificates are intended to be widely useable and EKU does not support t
 <p id="appendix-C-6">From IETF draft 09 -&gt; IETF draft 10:<a href="#appendix-C-6" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-C-7.1">
-          <p id="appendix-C-7.1.1">issue #79, clarified discovery in the context of BRSKI-PRM and included information about future discovery enhancements in a separate draft in <a href="#discovery_uc2_reg" class="auto internal xref">Section 5.6.1</a>.<a href="#appendix-C-7.1.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.1.1">issue #79, clarified discovery in the context of BRSKI-PRM and included information about future discovery enhancements in a separate draft in <a href="#discovery_uc2_reg" class="auto internal xref">Section 6.2.1</a>.<a href="#appendix-C-7.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.2">
-          <p id="appendix-C-7.2.1">issue #93, included information about conflict resolution in mDNS and GRASP in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 5.6.2</a><a href="#appendix-C-7.2.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.2.1">issue #93, included information about conflict resolution in mDNS and GRASP in <a href="#discovery_uc2_ppa" class="auto internal xref">Section 6.2.2</a><a href="#appendix-C-7.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.3">
-          <p id="appendix-C-7.3.1">issue #103, included verification handling for the wrapped CA certificate provisioning in <a href="#exchanges_uc2_3c" class="auto internal xref">Section 6.3.3</a><a href="#appendix-C-7.3.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.3.1">issue #103, included verification handling for the wrapped CA certificate provisioning in <a href="#cacerts" class="auto internal xref">Section 7.7</a><a href="#appendix-C-7.3.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.4">
-          <p id="appendix-C-7.4.1">issue #106, included additional text to elaborate more the registrar status handling in <a href="#exchanges_uc2_4" class="auto internal xref">Section 6.3.6</a><a href="#appendix-C-7.4.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.4.1">issue #106, included additional text to elaborate more the registrar status handling in <a href="#vstatus" class="auto internal xref">Section 7.9</a> and <a href="#estatus" class="auto internal xref">Section 7.10</a><a href="#appendix-C-7.4.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.5">
-          <p id="appendix-C-7.5.1">issue #116, enhanced DoS description in <a href="#sec_cons-dos" class="auto internal xref">Section 10.1</a><a href="#appendix-C-7.5.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.5.1">issue #116, enhanced DoS description in <a href="#sec_cons-dos" class="auto internal xref">Section 11.1</a><a href="#appendix-C-7.5.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.6">
-          <p id="appendix-C-7.6.1">issue #120, included statement regarding pledge host header processing in <a href="#pledge_ep" class="auto internal xref">Section 5.5</a><a href="#appendix-C-7.6.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.6.1">issue #120, included statement regarding pledge host header processing in <a href="#pledge_ep" class="auto internal xref">Section 6.3</a><a href="#appendix-C-7.6.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.7">
-          <p id="appendix-C-7.7.1">issue #122, availability of product-serial-number information on registrar agent clarified in <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a><a href="#appendix-C-7.7.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.7.1">issue #122, availability of product-serial-number information on registrar agent clarified in <a href="#tpvr" class="auto internal xref">Section 7.1</a><a href="#appendix-C-7.7.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.8">
-          <p id="appendix-C-7.8.1">issue #123, Clarified usage of alternative voucher formats in  <a href="#rvr-proc" class="auto internal xref">Section 6.2.3</a><a href="#appendix-C-7.8.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.8.1">issue #123, Clarified usage of alternative voucher formats in  <a href="#rvr-proc" class="auto internal xref">Section 7.3.2</a><a href="#appendix-C-7.8.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.9">
-          <p id="appendix-C-7.9.1">issue #124, determination of pinned domain certificate done as in RFC 8995 included in <a href="#exchanges_uc2_2_vc" class="auto internal xref">Section 6.2.4</a><a href="#appendix-C-7.9.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.9.1">issue #124, determination of pinned domain certificate done as in RFC 8995 included in <a href="#exchanges_uc2_2_vc" class="auto internal xref">Section 7.3.3</a><a href="#appendix-C-7.9.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.10">
-          <p id="appendix-C-7.10.1">issue #125, remove strength comparison of voucher assertions in <a href="#agt_prx" class="auto internal xref">Section 5.4</a> and <a href="#exchanges_uc2" class="auto internal xref">Section 6</a><a href="#appendix-C-7.10.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-7.10.1">issue #125, remove strength comparison of voucher assertions in <a href="#agt_prx" class="auto internal xref">Section 5.4</a> and <a href="#exchanges_uc2" class="auto internal xref">Section 7</a><a href="#appendix-C-7.10.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-7.11">
           <p id="appendix-C-7.11.1">issue #130, aligned the usage of site and domain throughout the document<a href="#appendix-C-7.11.1" class="pilcrow">¶</a></p>
@@ -5653,73 +5690,73 @@ IDevID certificates are intended to be widely useable and EKU does not support t
 <p id="appendix-C-8">From IETF draft 08 -&gt; IETF draft 09:<a href="#appendix-C-8" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-C-9.1">
-          <p id="appendix-C-9.1.1">issue #80, enhanced <a href="#discovery_uc2_ppa" class="auto internal xref">Section 5.6.2</a> with clarification on the product-serial-number and the inclusion of GRASP<a href="#appendix-C-9.1.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.1.1">issue #80, enhanced <a href="#discovery_uc2_ppa" class="auto internal xref">Section 6.2.2</a> with clarification on the product-serial-number and the inclusion of GRASP<a href="#appendix-C-9.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.2">
           <p id="appendix-C-9.2.1">issue #81, enhanced introduction with motivation for agent_signed_data<a href="#appendix-C-9.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.3">
-          <p id="appendix-C-9.3.1">issue #82, included optional TLS protection of the communication link between Registrar-Agent and pledge in the introduction <a href="#req-sol" class="auto internal xref">Section 4</a>, and <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a><a href="#appendix-C-9.3.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.3.1">issue #82, included optional TLS protection of the communication link between Registrar-Agent and pledge in the introduction <a href="#req-sol" class="auto internal xref">Section 4</a>, and <a href="#tpvr" class="auto internal xref">Section 7.1</a><a href="#appendix-C-9.3.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.4">
-          <p id="appendix-C-9.4.1">issue #83, enhanced <a href="#PER-response" class="auto internal xref">Section 6.1.4</a> and <a href="#exchanges_uc2_2_per" class="auto internal xref">Section 6.2.6</a> with note to re-enrollment<a href="#appendix-C-9.4.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.4.1">issue #83, enhanced <a href="#tper" class="auto internal xref">Section 7.2</a> and <a href="#pvr" class="auto internal xref">Section 7.3</a> with note to re-enrollment<a href="#appendix-C-9.4.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.5">
-          <p id="appendix-C-9.5.1">issue #87, clarified available information at the Registrar-Agent in <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a><a href="#appendix-C-9.5.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.5.1">issue #87, clarified available information at the Registrar-Agent in <a href="#tpvr" class="auto internal xref">Section 7.1</a><a href="#appendix-C-9.5.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.6">
-          <p id="appendix-C-9.6.1">issue #88, clarified, that the PVR in <a href="#pvrr" class="auto internal xref">Section 6.1.2</a> and PER in <a href="#PER-response" class="auto internal xref">Section 6.1.4</a> may contain the certificate chain. If not contained it <span class="bcp14">MUST</span> be available at the registrar.<a href="#appendix-C-9.6.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.6.1">issue #88, clarified, that the PVR in <a href="#tpvr" class="auto internal xref">Section 7.1</a> and PER in <a href="#tper" class="auto internal xref">Section 7.2</a> may contain the certificate chain. If not contained it <span class="bcp14">MUST</span> be available at the registrar.<a href="#appendix-C-9.6.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.7">
-          <p id="appendix-C-9.7.1">issue #91, clarified that a separate HTTP connection may also be used to provide the PER in <a href="#exchanges_uc2_2_per" class="auto internal xref">Section 6.2.6</a><a href="#appendix-C-9.7.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.7.1">issue #91, clarified that a separate HTTP connection may also be used to provide the PER in <a href="#per" class="auto internal xref">Section 7.4</a><a href="#appendix-C-9.7.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.8">
           <p id="appendix-C-9.8.1">resolved remaining editorial issues discovered after WGLC (responded to on the mailing list in Reply 1 and Reply 2) resulting in more consistent descriptions<a href="#appendix-C-9.8.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.9">
-          <p id="appendix-C-9.9.1">issue #92: kept separate endpoint for wrapped CSR on registrar <a href="#exchanges_uc2_2_wca" class="auto internal xref">Section 6.2.7</a><a href="#appendix-C-9.9.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.9.1">issue #92: kept separate endpoint for wrapped CSR on registrar <a href="#req_cacerts" class="auto internal xref">Section 7.5</a><a href="#appendix-C-9.9.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.10">
           <p id="appendix-C-9.10.1">issue #94: clarified terminology (possess vs. obtained)<a href="#appendix-C-9.10.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.11">
-          <p id="appendix-C-9.11.1">issue #95: clarified optional IDevID CA certificates on Registrar-Agent <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a><a href="#appendix-C-9.11.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.11.1">issue #95: clarified optional IDevID CA certificates on Registrar-Agent<a href="#appendix-C-9.11.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.12">
-          <p id="appendix-C-9.12.1">issue #96: updated <a href="#exchangesfig_uc2_3" class="auto internal xref">Figure 16</a> to correct to just one CA certificate provisioning<a href="#appendix-C-9.12.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.12.1">issue #96: updated exchangesfig_uc2_3 to correct to just one CA certificate provisioning<a href="#appendix-C-9.12.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.13">
-          <p id="appendix-C-9.13.1">issue #97: deleted format explanation in <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a> as it may be misleading<a href="#appendix-C-9.13.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.13.1">issue #97: deleted format explanation in exchanges_uc2_3 as it may be misleading<a href="#appendix-C-9.13.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.14">
-          <p id="appendix-C-9.14.1">issue #99: motivated verification of second signature on voucher in <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a><a href="#appendix-C-9.14.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.14.1">issue #99: motivated verification of second signature on voucher in <a href="#voucher" class="auto internal xref">Section 7.6</a><a href="#appendix-C-9.14.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.15">
-          <p id="appendix-C-9.15.1">issue #100: included negative example in <a href="#vstat" class="auto internal xref">Figure 18</a><a href="#appendix-C-9.15.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.15.1">issue #100: included negative example in <a href="#vstat" class="auto internal xref">Figure 14</a><a href="#appendix-C-9.15.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.16">
-          <p id="appendix-C-9.16.1">issue #101: included handling if <a href="#exchanges_uc2_3b" class="auto internal xref">Section 6.3.2</a> voucher telemetry information has not been received by the Registrar-Agent<a href="#appendix-C-9.16.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.16.1">issue #101: included handling if <a href="#voucher" class="auto internal xref">Section 7.6</a> voucher telemetry information has not been received by the Registrar-Agent<a href="#appendix-C-9.16.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.17">
-          <p id="appendix-C-9.17.1">issue #102: relaxed requirements for CA certs provisioning in <a href="#exchanges_uc2_3c" class="auto internal xref">Section 6.3.3</a><a href="#appendix-C-9.17.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.17.1">issue #102: relaxed requirements for CA certs provisioning in <a href="#cacerts" class="auto internal xref">Section 7.7</a><a href="#appendix-C-9.17.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.18">
-          <p id="appendix-C-9.18.1">issue #105: included negative example in <a href="#estat" class="auto internal xref">Figure 20</a><a href="#appendix-C-9.18.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.18.1">issue #105: included negative example in <a href="#estat" class="auto internal xref">Figure 16</a><a href="#appendix-C-9.18.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.19">
-          <p id="appendix-C-9.19.1">issue #107: included example for certificate revocation in <a href="#exchanges_uc2_4" class="auto internal xref">Section 6.3.6</a><a href="#appendix-C-9.19.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.19.1">issue #107: included example for certificate revocation in exchanges_uc2_4 TODO[N/A]<a href="#appendix-C-9.19.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.20">
-          <p id="appendix-C-9.20.1">issue #108: renamed heading to Pledge-Status Request of <a href="#exchanges_uc2_5a" class="auto internal xref">Section 6.4.1</a><a href="#appendix-C-9.20.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.20.1">issue #108: renamed heading to Pledge-Status Request of <a href="#query" class="auto internal xref">Section 7.11</a><a href="#appendix-C-9.20.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.21">
-          <p id="appendix-C-9.21.1">issue #111: included pledge-status response processing for authenticated requests in <a href="#exchanges_uc2_5b" class="auto internal xref">Section 6.4.2</a><a href="#appendix-C-9.21.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.21.1">issue #111: included pledge-status response processing for authenticated requests in <a href="#query" class="auto internal xref">Section 7.11</a><a href="#appendix-C-9.21.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.22">
-          <p id="appendix-C-9.22.1">issue #112: added "Example key word in pledge-status response in <a href="#stat_res" class="auto internal xref">Figure 26</a><a href="#appendix-C-9.22.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.22.1">issue #112: added "Example key word in pledge-status response in <a href="#stat_res" class="auto internal xref">Figure 22</a><a href="#appendix-C-9.22.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.23">
-          <p id="appendix-C-9.23.1">issue #113: enhanced description of status reply for "factory-default" in  <a href="#exchanges_uc2_5b" class="auto internal xref">Section 6.4.2</a><a href="#appendix-C-9.23.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-9.23.1">issue #113: enhanced description of status reply for "factory-default" in  <a href="#query" class="auto internal xref">Section 7.11</a><a href="#appendix-C-9.23.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-9.24">
           <p id="appendix-C-9.24.1">issue #114: Consideration of optional TLS usage in Privacy Considerations<a href="#appendix-C-9.24.1" class="pilcrow">¶</a></p>
@@ -5815,7 +5852,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-17.14.1">Added explanation of MASA requiring domain CA cert in section 5.5.1 and section 5.5.2, issue #36<a href="#appendix-C-17.14.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-17.15">
-          <p id="appendix-C-17.15.1">Defined new endpoint for pledge bootstrapping status inquiry, issue #35 in section <a href="#exchanges_uc2_5" class="auto internal xref">Section 6.4</a>, IANA considerations and section <a href="#pledge_ep" class="auto internal xref">Section 5.5</a><a href="#appendix-C-17.15.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-17.15.1">Defined new endpoint for pledge bootstrapping status inquiry, issue #35 in section <a href="#query" class="auto internal xref">Section 7.11</a>, IANA considerations and section <a href="#pledge_ep" class="auto internal xref">Section 6.3</a><a href="#appendix-C-17.15.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-17.16">
           <p id="appendix-C-17.16.1">Included examples for several objects in section <a href="#examples" class="auto internal xref">Appendix A</a> including message example sizes, issue #33<a href="#appendix-C-17.16.1" class="pilcrow">¶</a></p>
@@ -5860,7 +5897,7 @@ IDevID certificates are intended to be widely useable and EKU does not support t
           <p id="appendix-C-19.7.1">Removed join proxy in <a href="#uc2figure" class="auto internal xref">Figure 1</a> and added explanatory text, issue #20<a href="#appendix-C-19.7.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-19.8">
-          <p id="appendix-C-19.8.1">Added description of pledge-CAcerts endpoint plus further handling of providing a wrapped CA certs response to the pledge in section <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a>; also added new required registrar endpoint (section <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a> and IANA considerations) for the registrar to provide a wrapped CA certs response, issue #21<a href="#appendix-C-19.8.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-19.8.1">Added description of pledge-CAcerts endpoint plus further handling of providing a wrapped CA certs response to the pledge in section <a href="#cacerts" class="auto internal xref">Section 7.7</a>; also added new required registrar endpoint (section <a href="#pvr" class="auto internal xref">Section 7.3</a> and IANA considerations) for the registrar to provide a wrapped CA certs response, issue #21<a href="#appendix-C-19.8.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-19.9">
           <p id="appendix-C-19.9.1">utilized defined abbreviations in the document consistently, issue #22<a href="#appendix-C-19.9.1" class="pilcrow">¶</a></p>
@@ -5893,36 +5930,36 @@ IDevID certificates are intended to be widely useable and EKU does not support t
 <p id="appendix-C-22">From IETF draft 01 -&gt; IETF draft 02:<a href="#appendix-C-22" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-C-23.1">
-          <p id="appendix-C-23.1.1">Issue #15 included additional signature on voucher from registrar in section <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a> and section <a href="#agt_prx" class="auto internal xref">Section 5.4</a>
-The verification of multiple signatures is described in section <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a><a href="#appendix-C-23.1.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-23.1.1">Issue #15 included additional signature on voucher from registrar in section <a href="#pvr" class="auto internal xref">Section 7.3</a> and section <a href="#agt_prx" class="auto internal xref">Section 5.4</a>
+The verification of multiple signatures is described in section <a href="#voucher" class="auto internal xref">Section 7.6</a><a href="#appendix-C-23.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-23.2">
           <p id="appendix-C-23.2.1">Included representation for General JWS JSON Serialization for examples<a href="#appendix-C-23.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-23.3">
-          <p id="appendix-C-23.3.1">Included error responses from pledge if it is not able to create a pledge-voucher-request or an enrollment request in section <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a><a href="#appendix-C-23.3.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-23.3.1">Included error responses from pledge if it is not able to create a Pledge-Voucher-Request or an enrollment request in section <a href="#tpvr" class="auto internal xref">Section 7.1</a><a href="#appendix-C-23.3.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-23.4">
-          <p id="appendix-C-23.4.1">Removed open issue regarding handling of multiple CSRs and enrollment responses during the bootstrapping as the initial target it the provisioning of a generic LDevID certificate. The defined endpoint on the pledge may also be used for management of further certificates.<a href="#appendix-C-23.4.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-23.4.1">Removed open issue regarding handling of multiple CSRs and Enroll-Responses during the bootstrapping as the initial target it the provisioning of a generic LDevID certificate. The defined endpoint on the pledge may also be used for management of further certificates.<a href="#appendix-C-23.4.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <p id="appendix-C-24">From IETF draft 00 -&gt; IETF draft 01:<a href="#appendix-C-24" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-C-25.1">
-          <p id="appendix-C-25.1.1">Issue #15 lead to the inclusion of an option for an additional signature of the registrar on the voucher received from the MASA before forwarding to the Registrar-Agent to support verification of POP of the registrars private key in section <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a> and <a href="#exchanges_uc2_3" class="auto internal xref">Section 6.3</a>.<a href="#appendix-C-25.1.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-25.1.1">Issue #15 lead to the inclusion of an option for an additional signature of the registrar on the voucher received from the MASA before forwarding to the Registrar-Agent to support verification of POP of the registrars private key in section <a href="#pvr" class="auto internal xref">Section 7.3</a> and exchanges_uc2_3.<a href="#appendix-C-25.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.2">
           <p id="appendix-C-25.2.1">Based on issue #11, a new endpoint was defined for the registrar to enable delivery of the wrapped enrollment request from the pledge (in contrast to plain PKCS#10 in simple enroll).<a href="#appendix-C-25.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.3">
-          <p id="appendix-C-25.3.1">Decision on issue #8 to not provide an additional signature on the enrollment-response object by the registrar. As the enrollment response will only contain the generic LDevID certificate. This credential builds the base for further configuration outside the initial enrollment.<a href="#appendix-C-25.3.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-25.3.1">Decision on issue #8 to not provide an additional signature on the enrollment-response object by the registrar. As the Enroll-Response will only contain the generic LDevID certificate. This credential builds the base for further configuration outside the initial enrollment.<a href="#appendix-C-25.3.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.4">
           <p id="appendix-C-25.4.1">Decision on issue #7 to not support multiple CSRs during the bootstrapping, as based on the generic LDevID certificate the pledge may enroll for further certificates.<a href="#appendix-C-25.4.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.5">
           <p id="appendix-C-25.5.1">Closed open issue #5 regarding verification of ietf-ztp-types usage as verified
-via a proof-of-concept in section {#exchanges_uc2_1}.<a href="#appendix-C-25.5.1" class="pilcrow">¶</a></p>
+via a proof-of-concept in section <a href="#tpvr" class="auto internal xref">Section 7.1</a>.<a href="#appendix-C-25.5.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.6">
           <p id="appendix-C-25.6.1">Housekeeping: Removed already addressed open issues stated in the draft directly.<a href="#appendix-C-25.6.1" class="pilcrow">¶</a></p>
@@ -5935,10 +5972,10 @@ via a proof-of-concept in section {#exchanges_uc2_1}.<a href="#appendix-C-25.5.1
 </li>
         <li class="normal" id="appendix-C-25.9">
           <p id="appendix-C-25.9.1">Added prior-signed-voucher-request in the parameter description of the
-registrar-voucher-request in <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a>.<a href="#appendix-C-25.9.1" class="pilcrow">¶</a></p>
+registrar-voucher-request in <a href="#pvr" class="auto internal xref">Section 7.3</a>.<a href="#appendix-C-25.9.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.10">
-          <p id="appendix-C-25.10.1">Note added in <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a> if sub-CAs are used, that the
+          <p id="appendix-C-25.10.1">Note added in <a href="#pvr" class="auto internal xref">Section 7.3</a> if sub-CAs are used, that the
 corresponding information is to be provided to the MASA.<a href="#appendix-C-25.10.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.11">
@@ -5950,45 +5987,45 @@ up. Pledge is awake but Registrar-Agent is not available) (Issue #10).<a href="#
 open issues. (Issue #4)<a href="#appendix-C-25.12.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.13">
-          <p id="appendix-C-25.13.1">Included table for endpoints in <a href="#pledge_ep" class="auto internal xref">Section 5.5</a> for better readability.<a href="#appendix-C-25.13.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-25.13.1">Included table for endpoints in <a href="#pledge_ep" class="auto internal xref">Section 6.3</a> for better readability.<a href="#appendix-C-25.13.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.14">
           <p id="appendix-C-25.14.1">Included registrar authorization check for Registrar-Agent during
-TLS handshake  in section <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a>. Also enhanced figure
-<a href="#exchangesfig_uc2_2" class="auto internal xref">Figure 11</a> with the authorization step on TLS level.<a href="#appendix-C-25.14.1" class="pilcrow">¶</a></p>
+TLS handshake  in section <a href="#pvr" class="auto internal xref">Section 7.3</a>. Also enhanced figure
+<a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> with the authorization step on TLS level.<a href="#appendix-C-25.14.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.15">
           <p id="appendix-C-25.15.1">Enhanced description of registrar authorization check for Registrar-Agent
-based on the agent-signed-data in section <a href="#exchanges_uc2_2" class="auto internal xref">Section 6.2</a>. Also
-enhanced figure <a href="#exchangesfig_uc2_2" class="auto internal xref">Figure 11</a> with the authorization step
-on pledge-voucher-request level.<a href="#appendix-C-25.15.1" class="pilcrow">¶</a></p>
+based on the agent-signed-data in section <a href="#pvr" class="auto internal xref">Section 7.3</a>. Also
+enhanced figure <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> with the authorization step
+on Pledge-Voucher-Request level.<a href="#appendix-C-25.15.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.16">
           <p id="appendix-C-25.16.1">Changed agent-signed-cert to an array to allow for providing further
 certificate information like the issuing CA cert for the LDevID(RegAgt)
 certificate in case the registrar and the Registrar-Agent have different
-issuing CAs in <a href="#exchangesfig_uc2_2" class="auto internal xref">Figure 11</a> (issue #12).
+issuing CAs in <a href="#exchangesfig_uc2_all" class="auto internal xref">Figure 4</a> (issue #12).
 This also required changes in the YANG module in <span>[<a href="#I-D.ietf-anima-rfc8366bis" class="cite xref">I-D.ietf-anima-rfc8366bis</a>]</span><a href="#appendix-C-25.16.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.17">
           <p id="appendix-C-25.17.1">Addressed YANG warning (issue #1)<a href="#appendix-C-25.17.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-25.18">
-          <p id="appendix-C-25.18.1">Inclusion of examples for a trigger to create a pledge-voucher-request
-and an pledge-enrollment-request.<a href="#appendix-C-25.18.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-25.18.1">Inclusion of examples for a trigger to create a Pledge-Voucher-Request
+and an Pledge Enroll-Request.<a href="#appendix-C-25.18.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <p id="appendix-C-26">From IETF draft-ietf-anima-brski-async-enroll-03 -&gt; IETF anima-brski-prm-00:<a href="#appendix-C-26" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-C-27.1">
-          <p id="appendix-C-27.1.1">Moved UC2 related parts defining the pledge in responder mode from
+          <p id="appendix-C-27.1.1">Moved UC2 related parts defining the Pledge in Responder Mode from
 draft-ietf-anima-brski-async-enroll-03 to this document
 This required changes and adaptations in several sections to remove
 the description and references to UC1.<a href="#appendix-C-27.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-27.2">
           <p id="appendix-C-27.2.1">Addressed feedback for voucher-request enhancements from YANG doctor
-early review in <a href="#voucher-request-prm-yang" class="auto internal xref">Section 7.1</a> as well as in the
+early review in <a href="#voucher-request-prm-yang" class="auto internal xref">Section 8.1</a> as well as in the
 security considerations (formerly named ietf-async-voucher-request).<a href="#appendix-C-27.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-27.3">
@@ -6009,7 +6046,7 @@ YANG definition of csr-types into the enrollment request exchange.<a href="#appe
 <ul class="normal">
 <li class="normal" id="appendix-C-29.1">
           <p id="appendix-C-29.1.1">Housekeeping, deleted open issue regarding YANG voucher-request
-in <a href="#exchanges_uc2_1" class="auto internal xref">Section 6.1</a> as voucher-request was
+in <a href="#tpvr" class="auto internal xref">Section 7.1</a> as voucher-request was
 enhanced with additional leaf.<a href="#appendix-C-29.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-29.2">
@@ -6022,7 +6059,7 @@ value agent-proximity and csr encapsulation using SZTP sub module).<a href="#app
 <li class="normal" id="appendix-C-31.1">
           <p id="appendix-C-31.1.1">Defined call flow and objects for interactions in UC2. Object format
 based on draft for JOSE signed voucher artifacts and aligned the
-remaining objects with this approach in <a href="#exchanges_uc2" class="auto internal xref">Section 6</a>.<a href="#appendix-C-31.1.1" class="pilcrow">¶</a></p>
+remaining objects with this approach in <a href="#exchanges_uc2" class="auto internal xref">Section 7</a>.<a href="#appendix-C-31.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-31.2">
           <p id="appendix-C-31.2.1">Terminology change: issue #2 pledge-agent -&gt; Registrar-Agent to
@@ -6037,7 +6074,7 @@ and pledge-responder-mode to better address the pledge operation.<a href="#appen
 changed by removing TLS-PSK (former section TLS establishment)
 and associated references to other drafts in favor of relying on
 higher layer exchange of signed data objects. These data objects
-are included also in the pledge-voucher-request and lead to an
+are included also in the Pledge-Voucher-Request and lead to an
 extension of the YANG module for the voucher-request (issue #12).<a href="#appendix-C-31.4.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-31.5">
@@ -6056,14 +6093,14 @@ in Registrar-Agent signed data (issue #37).<a href="#appendix-C-31.7.1" class="p
         <li class="normal" id="appendix-C-31.8">
           <p id="appendix-C-31.8.1">Enhanced objects in exchanges between pledge and Registrar-Agent
 to allow the registrar to verify agent-proximity to the pledge
-(issue #1) in <a href="#exchanges_uc2" class="auto internal xref">Section 6</a>.<a href="#appendix-C-31.8.1" class="pilcrow">¶</a></p>
+(issue #1) in <a href="#exchanges_uc2" class="auto internal xref">Section 7</a>.<a href="#appendix-C-31.8.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-31.9">
           <p id="appendix-C-31.9.1">Details on trust relationship between Registrar-Agent and
 pledge (issue #5) included in <a href="#architecture" class="auto internal xref">Section 5</a>.<a href="#appendix-C-31.9.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-C-31.10">
-          <p id="appendix-C-31.10.1">Split of use case 2 call flow into sub sections in <a href="#exchanges_uc2" class="auto internal xref">Section 6</a>.<a href="#appendix-C-31.10.1" class="pilcrow">¶</a></p>
+          <p id="appendix-C-31.10.1">Split of use case 2 call flow into sub sections in <a href="#exchanges_uc2" class="auto internal xref">Section 7</a>.<a href="#appendix-C-31.10.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <p id="appendix-C-32">From IETF draft 00 -&gt; IETF draft 01:<a href="#appendix-C-32" class="pilcrow">¶</a></p>
@@ -6223,6 +6260,7 @@ boundary conditions.<a href="#appendix-C-41.5.1" class="pilcrow">¶</a></p>
 </address>
 <address class="vcard">
         <div dir="auto" class="left"><span class="fn nameRole">Matthias Kovatsch</span></div>
+<div dir="auto" class="left"><span class="org">Siemens Schweiz AG</span></div>
 <div class="email">
 <span>Email:</span>
 <a href="mailto:ietf@kovatsch.net" class="email">ietf@kovatsch.net</a>

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -204,7 +204,8 @@ CSR:
 : Certificate Signing Request.
 
 EE:
-: End entity.
+: End entity, as defined in {{?RFC9483}}.
+  Typically a device or service that owns a public-private key pair for which it manages a public key certificate.
 
 EE certificate:
 : Either IDevID certificate or LDevID certificate of the EE.

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -70,7 +70,6 @@ venue:
   anima mail: {anima@ietf.org}
   github: anima-wg/anima-brski-prm
 normative:
-  RFC2986:
   RFC6762:
   RFC6763:
   RFC7030:
@@ -84,6 +83,7 @@ normative:
   I-D.ietf-netconf-sztp-csr:
   I-D.ietf-anima-rfc8366bis:
 informative:
+  RFC2986:
   RFC3629:
   RFC5272:
   RFC9525:
@@ -241,7 +241,7 @@ RVR:
 : Registrar Voucher-Request is a request for a voucher signed by the domain registrar to the MASA.
 It may contain the PVR received from the pledge.
 
-This document uses the following encoding notations in the given JWS Voucher {{!I-D.ietf-anima-jws-voucher}} examples:
+This document uses the following encoding notations in the given JWS-signed artifact examples:
 
 BASE64URL(OCTETS):
 : Denotes the base64url encoding of OCTETS, per {{Section 2 of !RFC7515}}.
@@ -334,7 +334,7 @@ Solution examples based on existing technology are provided with the focus on ex
 * Voucher-Requests and Vouchers as used in {{!RFC8995}} already provide both, POP and POI, through a digital signature to protect the integrity of the voucher, while the corresponding signing certificate contains the identity of the signer.
 
 * Enroll-Requests are data structures containing the information from a requester for a CA to create a certificate.
-  The certification request format in BRSKI is PKCS#10 {{!RFC2986}}.
+  The certification request format in BRSKI is PKCS#10 {{?RFC2986}}.
   In PKCS#10, the structure is signed to ensure integrity protection and POP of the private key of the requester that corresponds to the contained public key.
   In the application examples, this POP alone is not sufficient.
   A POI is also required for the certification request and therefore the certification request needs to be additionally bound to the existing credential of the pledge (IDevID).
@@ -400,7 +400,7 @@ To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:
                .........................................
                             Customer Domain
 ~~~~
-{: #uc2figure title='BRSKI-PRM architecture overview using Registrar-Agent' artwork-align="left"}
+{: #uc2figure title='BRSKI-PRM architecture overview using Registrar-Agent' artwork-align="center"}
 
 {{uc2figure}} shows the relations between the following main components:
 
@@ -475,7 +475,7 @@ This is often the case in the aforementioned building automation use case ({{bui
                .........................................
                             Customer Domain
 ~~~~
-{: #uc3figure title='Registrar-Agent nomadic connectivity example' artwork-align="left"}
+{: #uc3figure title='Registrar-Agent nomadic connectivity example' artwork-align="center"}
 
 PRM enables support of this case through nomadic connectivity of the Registrar-Agent.
 To perform enrollment in this setup, multiple round trips of the Registrar-Agent between the pledge installation location and the domain registrar are required.
@@ -515,7 +515,7 @@ In {{!RFC8995}}, pledges instead need to continuously request enrollment from a 
                .........................................
                             Customer Domain
 ~~~~
-{: #uc4figure title='Registrar-Agent integrated into Domain Registrar example' artwork-align="left"}
+{: #uc4figure title='Registrar-Agent integrated into Domain Registrar example' artwork-align="center"}
 
 The benefits of BRSKI-PRM can be achieved even without the operational complexity of standalone Registrar-Agents by integrating the necessary functionality of the Registrar-Agent as a module into the domain registrar as shown in {{uc4figure}} so that it can support the BRSKI-PRM communications to the pledge.
 
@@ -554,9 +554,9 @@ These endpoints accommodate for the signature-wrapped objects used by BRSKI-PRM 
 
 |Endpoint        | Operation                  | Exchange and Artifacts  |
 |:---------------|:---------------------------|:------------------------|
-| requestenroll  | Supply PER to registrar    | {{per}} |
+| requestenroll  | Supply PER to Registrar    | {{per}} |
 |------------------------
-| wrappedcacerts | Request CA certificates | {{req_cacerts}} |
+| wrappedcacerts | Request CA Certificates    | {{req_cacerts}} |
 |===============
 {: #registrar_ep_table title='Additional Well-Known Endpoints on a BRSKI-PRM Registrar' }
 
@@ -595,8 +595,6 @@ Note that this is an additional requirement for issuing the certificate, as {{!I
 In BRSKI-PRM, the SKID is used in favor of providing the complete EE certificate of the Registrar-Agent to accommodate also constrained environments and reduce bandwidth needed for communication with the pledge.
 In addition, it follows the recommendation from BRSKI to use SKID in favor of a certificate fingerprint to avoid additional computations.
 
-
-
 In addition to the EE certificates, the Registrar-Agent is provided with the product serial number(s) of the pledge(s) to be bootstrapped.
 This is necessary to allow the discovery of pledge(s) by the Registrar-Agent using DNS-SD with mDNS (see {{discovery_uc2_ppa}}).
 The list may be provided by prior administrative means or the Registrar-Agent may get the information via an interaction with the pledge.
@@ -612,6 +610,7 @@ Further, the Registrar-Agent SHOULD have synchronized time.
 
 Finally, the Registrar-Agent MAY possess the IDevID (root or issuing) CA certificate of the pledge vendor/manufacturer to validate the IDevID certificate on returned PVR or in case of TLS usage for pledge communication.
 The distribution of IDevID CA certificates to the Registrar-Agent is out of scope of this document and may be done by a manual configuration.
+
 
 ### Discovery of the Registrar {#discovery_uc2_reg}
 
@@ -650,6 +649,7 @@ The same approach can be used by 6LoWPAN/mesh using a pre-agreed PAN ID.
 How to gain network connectivity is out of scope of this document.
 
 
+
 ## Pledge in Responder Mode {#pledge_ep}
 
 The pledge is triggered by the Registrar-Agent to create the PVR and PER.
@@ -658,19 +658,19 @@ It is also triggered for processing of the responses and the generation of statu
 To enable interaction as responder with the Registrar-Agent, pledges in responder mode MUST act as servers and MUST provide the endpoints defined in {{pledge_ep_table}} within the BRSKI-defined "/.well-known/brski/" URI path.
 The endpoints are defined with short names to also accommodate for resource-constrained devices.
 
-| Endpoint | Operation                         | Exchange and Artifacts |
-|:---------|:----------------------------------|:-----------------------|
-| tpvr     | Trigger Pledge Voucher-Request    | {{tpvr}}    |
+| Endpoint | Operation                        | Exchange and Artifacts |
+|:---------|:---------------------------------|:-----------------------|
+| tpvr     | Trigger Pledge Voucher-Request   | {{tpvr}}               |
 |------------------------
-| tper     | Trigger Pledge Enroll-Request     | {{tper}}    |
+| tper     | Trigger Pledge Enroll-Request    | {{tper}}               |
 |------------------------
-| svr      | Supply Voucher to pledge          | {{voucher}}    |
+| svr      | Supply Voucher to Pledge         | {{voucher}}            |
 |------------------------
-| scac     | Supply CA certificates to pledge  | {{cacerts}}    |
+| scac     | Supply CA Certificates to Pledge | {{cacerts}}            |
 |------------------------
-| ser      | Supply Enroll-Response to pledge  | {{enroll_response}}    |
+| ser      | Supply Enroll-Response to Pledge | {{enroll_response}}    |
 |------------------------
-| qps      | Query Pledge Status               | {{query}}    |
+| qps      | Query Pledge Status              | {{query}}              |
 |===============
 {: #pledge_ep_table title='Well-Known Endpoints on a Pledge in Responder Mode' }
 
@@ -682,6 +682,7 @@ In practice, however, the pledge often is only known by its IP address as return
 
 As BRSKI-PRM uses authenticated self-contained data objects between the pledge and the domain registrar, the binding of the pledge identity to the requests is provided by the data object signature employing the IDevID of the pledge.
 Hence, pledges MUST have an Initial Device Identifier (IDevID) installed in them at the factory.
+
 
 ### Pledge with Combined Functionality
 
@@ -695,161 +696,162 @@ Once a pledge with combined functionality has been bootstrapped, it MAY act as c
 If it still acts as server, the defined BRSKI-PRM endpoints to trigger a Pledge Enroll-Request (PER) or to provide an Enroll-Response can be used for further certificates.
 
 
+
+
 # Exchanges and Artifacts {#exchanges_uc2}
 
 The interaction of the pledge with the Registrar-Agent may be accomplished using different transports (i.e., protocols and/or network technologies).
 This specification utilizes HTTP as default transport.
 Other specifications may define alternative transports such as CoAP, Bluetooth Low Energy (BLE), or Near Field Communication (NFC).
 These transports may differ from and are independent of the ones used between the Registrar-Agent and the registrar.
+
 Transport independence is realized through data objects that are not bound to specific transport security and stay the same along the communication path from the pledge via the Registrar-Agent to the registrar.
-Therefore, authenticated self-contained objects (e.g., signature-wrapped JWS objects) are applied for data exchanges between the pledge and the registrar.
-
-The Registrar-Agent provides the domain registrar EE certificate to the pledge to be included in the PVR leaf "agent-provided-proximity-registrar-certificate".
-This enables the registrar to verify that it is the desired registrar for handling the request.
-The registrar EE certificate may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar.
-
-In addition, the Registrar-Agent provides "agent-signed-data" containing the pledge product serial number signed with the private key corresponding to the EE certificate of the Registrar-Agent, as described in {{tpvr}}.
-This enables the registrar to verify and log, which Registrar-Agent was in contact with the pledge, when verifying the PVR.
+Therefore, authenticated self-contained artifacts (e.g., JWS-signed JSON structures or COSE-signed CBOR structures) are used for the data exchanges between the pledge and the registrar via the Registrar-Agent.
 
 {{exchangesfig_uc2_all}} provides an overview of the exchanges detailed in the following subsections.
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   |   discover     |                 |              |            |
-   |    pledge      |                 |              |            |
-   | mDNS query     |                 |              |            |
-   |<---------------|                 |              |            |
-   |--------------->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (1) Trigger Pledge Voucher-Request
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<-- opt. TLS -->|                 |              |            |
-   |<---- tPVR -----|                 |              |            |
-   |----- PVR ----->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (2) Trigger Pledge Enroll-Request
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<-- opt. TLS -->|                 |              |            |
-   |<---- tPER -----|                 |              |            |
-   |----- PER ----->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (3) Supply PVR to Registrar (including backend interaction)
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |                |<---- mTLS ----->|              |            |
-   |                |         [Registrar-Agent       |            |
-   |                |    authenticated&authorized?]  |            |
-   |                |----- PVR ------>|              |            |
-   |                |         [accept device?]       |            |
-   |                |         [contact vendor]       |            |
-   |                |                 |              |            |
-   |                |                 |<---------- mTLS --------->|
-   |                |                 |------------ RVR --------->|
-   |                |                 |           [extract DomainID]
-   |                |                 |           [update audit log]
-   |                |                 |<--------- Voucher --------|
-   |                |<--- Voucher ----|              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (4) Supply PER to Registrar (including backend interaction)
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |                |<---- mTLS ----->|              |            |
-   |                |----- PER ------>|              |            |
-   |                |                 |<--- mTLS --->|            |
-   |                |                 |---- RER ---->|            |
-   |                |                 |<-Enroll Resp-|            |
-   |                |<--Enroll Resp---|              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (5) Request CA Certificates
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |                |-- cACert-Req -->|              |            |
-   |                |<-- cACert-Resp--|              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (6) Supply Voucher to Pledge
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<--opt. TLS --->|                 |              |            |
-   |<--- Voucher ---|                 |              |            |
-   |---- vStatus -->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (7) Supply CA certificates to Pledge
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<--opt. TLS --->|                 |              |            |
-   |<--- cACerts ---|                 |              |            |
-   |--- cACerts --->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (8) Supply Enroll-Response to Pledge
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<--Enroll Resp--|                 |              |            |
-   |--- eStatus --->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (9) Voucher Status Telemetry
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |                |<---- mTLS ----->|              |            |
-   |                |---- vStatus --->|              |            |
-   |                |                 |--- req device audit log-->|
-   |                |                 |<---- device audit log ----|
-   |                |           [verify audit log]
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (10) Enroll Status Telemetry
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |                |---- eStatus --->|              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
-   (11) Query Pledge Status
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<--pStatus-Req--|                 |              |            |
-   |--pStatus-Resp->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ |     discover     |                 |                 |            |
+ |      pledge      |                 |                 |            |
+ |    mDNS query    |                 |                 |            |
+ |<-----------------|                 |                 |            |
+ |----------------->|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(1) Trigger Pledge Voucher-Request
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<------tPVR-------|                 |                 |            |
+ |--------PVR------>|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(2) Trigger Pledge Enroll-Request
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<------tPER-------|                 |                 |            |
+ |--------PER------>|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(3) Supply PVR to Registrar (including backend interaction)
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |                  |<-----mTLS------>|                 |            |
+ |                  |         [Registrar-Agent          |            |
+ |                  |    authenticated&authorized?]     |            |
+ |                  |-------PVR------>|                 |            |
+ |                  |          [accept device?]         |            |
+ |                  |          [contact vendor]         |            |
+ |                  |                 |                 |            |
+ |                  |                 |<------------mTLS------------>|
+ |                  |                 |--------------RVR------------>|
+ |                  |                 |              [extract DomainID]
+ |                  |                 |              [update audit log]
+ |                  |                 |<-----------Voucher-----------|
+ |                  |<----Voucher-----|                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(4) Supply PER to Registrar (including backend interaction)
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |                  |<----(mTLS)----->|                 |            |
+ |                  |-------PER------>|                 |            |
+ |                  |                 |<-----mTLS------>|            |
+ |                  |                 |-------RER------>|            |
+ |                  |                 |<--Enroll-Resp---|            |
+ |                  |<--Enroll-Resp---|                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(5) Request CA Certificates
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |                  |<----(mTLS)----->|                 |            |
+ |                  |---cACert-Req--->|                 |            |
+ |                  |<--cACert-Resp---|                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(6) Supply Voucher to Pledge
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<-----Voucher-----|                 |                 |            |
+ |------vStatus---->|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(7) Supply CA Certificates to Pledge
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<-----cACerts-----|                 |                 |            |
+ |------cACerts---->|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(8) Supply Enroll-Response to Pledge
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<---Enroll-Resp---|                 |                 |            |
+ |-----eStatus----->|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(9) Voucher Status Telemetry (including backend interaction)
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |                  |<----(mTLS)----->|                 |            |
+ |                  |-----vStatus---->|                 |            |
+ |                  |                 |<-----------(mTLS)----------->|
+ |                  |                 |-----req device audit log---->|
+ |                  |                 |<------device audit log-------|
+ |                  |        [verify audit log]         |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(10) Enroll Status Telemetry
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |                  |<----(mTLS)----->|                 |            |
+ |                  |-----eStatus---->|                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
+(11) Query Pledge Status
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<-----qStatus-----|                 |                 |            |
+ |------pStatus---->|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_all title='Overview pledge-responder-mode exchanges' artwork-align="left"}
+{: #exchangesfig_uc2_all title='Overview pledge-responder-mode exchanges' artwork-align="center"}
 
 The following sub sections split the interactions shown in {{exchangesfig_uc2_all}} between the different components into:
 
-1. {{tpvr}} describes the request object acquisition for the Pledge Voucher-Request by the Registrar-Agent.
+1. {{tpvr}} describes the acquisition exchange for the Pledge Voucher-Request initiated by the Registrar-Agent to the pledge.
 
-2. {{tper}} describes the request object acquisition for the Pledge Enroll-Request by the Registrar-Agent.
+2. {{tper}} describes the acquisition exchange for the Pledge Enroll-Request initiated by the Registrar-Agent to the pledge.
 
-3. {{pvr}} describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA using the RVR {{rvr-proc}} including the response object processing by these entities.
+3. {{pvr}} describes the issuing exchange for the Voucher initiated by the Registrar-Agent to the registrar, including the interaction of the registrar with the MASA using the RVR {{rvr-proc}}, as well as the artifact processing by these entities.
 
-4. {{per}} describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the CA using the PER including the response object processing by these entities.
+4. {{per}} describes the enroll exchange initiated by the Registrar-Agent to the registrar including the interaction of the registrar with the CA using the PER as well as the artifact processing by these entities.
 
-5. {{req_cacerts}} describes the object acquisition for the optional CA certificate provisioning to the Pledge initiated by the Registrar-Agent to the CA. 
+5. {{req_cacerts}} describes the retrival exchange for the optional CA certificate provisioning to the pledge initiated by the Registrar-Agent to the CA. 
 
-6. {{voucher}} describes the supply of the Voucher from the Registrar-Agent to the pledge including the returned status information.
+6. {{voucher}} describes the Voucher exchange initiated by the Registrar-Agent to the pledge and the returned status information.
 
-7. {{cacerts}} describes the supply of CA certificates to the Pledge by the Registrar-Agent. 
+7. {{cacerts}} describes the certificate provisioning exchange initiated by the Registrar-Agent to the pledge. 
 
-8. {{enroll_response}} describes the supply of the Enroll Reponse (containing the LDevID (Pledge) certificate) from the Registrar-Agent to the pledge including the returned status information.
+8. {{enroll_response}} describes the Enroll-Response exchange (containing the LDevID (Pledge) certificate) initiated by the Registrar-Agent to the pledge and the returned status information.
 
-9. {{vstatus}} describes the status handling for the pledge processing of the voucher and addresses corresponding exchanges between the Registrar-Agent and the registrar as well as between the registrar and the MASA.
+9. {{vstatus}} describes the Voucher status telemetry exchange initiated by the Registrar-Agent to the registrar, including the interaction of the registrar with the MASA.
 
-10. {{estatus}} describes the status handling for the pledge processing of the enrollment response  and addresses the corresponding exchange between the Registrar-Agent and the registrar.
+10. {{estatus}} describes the Enroll Status telemetry exchange initiated by the Registrar-Agent to the registrar.
 
-11. {{query}} describes the general status handling to query information about the bootstrapping state from the pledge initiated by the Registrar-Agent.
+11. {{query}} describes the Pledge Status exchange about the general bootstrapping state initiated by the Registrar-Agent to the pledge.
    
 
 
@@ -858,38 +860,112 @@ The following sub sections split the interactions shown in {{exchangesfig_uc2_al
 This exchange assumes that the Registrar-Agent has already discovered the pledge.
 This may be done as described in {{discovery_uc2_ppa}} and {{exchangesfig_uc2_all}} based on DNS-SD or similar.
 
-TLS MAY be optionally used to provide privacy for this exchange between the Registrar-Agent and the pledge, see {{pledgehttps}}.
+Optionally, TLS MAY be used to provide privacy for this exchange between the Registrar-Agent and the pledge, see {{pledgehttps}}.
 
-{{exchangesfig_uc2_1}} shows the Pledge Voucher-Request aquisition and the following subsections describe the corresponding artifacts. 
+{{exchangesfig_uc2_1}} shows the acquisition of the Pledge Voucher-Request (PVR) and the following subsections describe the corresponding artifacts. 
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   ~                ~                 ~              ~            ~
-   (1) Trigger Pledge Voucher-Request
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<-- opt. TLS -->|                 |              |            |
-   |<---- tPVR -----|                 |              |            |
-   |----- PVR ----->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(1) Trigger Pledge Voucher-Request
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<------tPVR-------|                 |                 |            |
+ |--------PVR------>|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_1 title='PVR aquisition exchanges' artwork-align="left"}
+{: #exchangesfig_uc2_1 title="PVR acquisition exchange" artwork-align="center"}
+
+The Registrar-Agent triggers the pledge to create the PVR via HTTP POST on the well-known pledge endpoint `/.well-known/brski/tpvr`.
+The request body MUST contain the JSON-based Pledge Voucher-Request Trigger (tPVR) artifact.
+The request header MUST set the Content-Type field to `application/json`.
+
+Upon receiving a valid tPVR, the pledge MUST reply with the PVR artifact in the body of a 200 OK response.
+The response header MUST have the Content-Type field set to `application/voucher-jws+json` as defined in {{!I-D.ietf-anima-jws-voucher}}.
+
+TODO: Confirm that the media type goes into the HTTP response Content-Type header, not some JSON member inside the artifact (was unclear).
+
+If the pledge is unable to create the PVR, it SHOULD respond with an HTTP error code. The following client error responses MAY be used:
+
+* 400 Bad Request: if the pledge detected an error in the format of the request, e.g. missing field, wrong data types, etc. or if the request is not valid JSON even though the PVR media type was set to `application/json`.
+
+* 403 Forbidden: if the pledge detected that one or more security parameters from the trigger message to create the PVR were not valid.
+
+TODO: There is even a note that the pledge cannot validate any security parameters at this point (in particular the originally given LDevID (Reg) cert). When is 403 really a choice?
+
+* 406 Not Acceptable: if the Accept request header field indicates a type that is unknown or unsupported, e.g., a type other than `application/jose+json`.
+
+* 415 Unsupported Media Type: if the Content-Type request header field indicates a type that is unknown or unsupported, e.g., a type other than `application/json`.
 
 ### Request Artifact: Pledge Voucher-Request Trigger (tPVR)
 
-Triggering the pledge to create the PVR is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tpvr"
+The Pledge Voucher-Request Trigger (tPVR) artifact is an unsigned JSON structure providing the following trigger parameters:
 
-The Registrar-Agent PVR trigger Content-Type header is: `application/json`.
-Following parameters are provided in the JSON object:
+TODO: Why not CDDL here? It's a format defined here just like status-query.
 
-* agent-provided-proximity-registrar-cert: base64-encoded registrar EE TLS certificate.
+* `agent-provided-proximity-registrar-cert`: X.509 v3 certificate structure of the domain registrar EE certificate (base64-encoded value); may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar
 
-* agent-signed-data: base64-encoded JSON-in-JWS object.
+* `agent-signed-data`: base64-encoded JWS structure containing the SubjectKeyIdentifier of the EE (RegAgt) certificate and signing Data including the serial number of the pledge
+
+~~~~
+# The agent-signed-data in General JWS Serialization syntax
+{
+  "payload": BASE64URL(UTF8(Data)),
+  "signatures": [
+    {
+      "protected": BASE64URL(UTF8(JWS Protected Header)),
+      "signature": BASE64URL(JWS Signature)
+    }
+  ]
+}
+~~~~
+{: #asd title="JWS structure for the agent-sigend-data member in General JWS Serialization syntax" artwork-align="left"}
+
+TODO: ietf-voucher-request:agent-signed-data is only defined as binary in YANG! No definition of the fields! /* "ietf-voucher-request:agent-signed-data" element (defined in {{I-D.ietf-anima-rfc8366bis}}): */
+
+The Data MUST be UTF-8 encoded to become the octet-based JWS Payload defined in {{!RFC7515}}.
+The JWS Payload is further base64url-encoded to become the string value of the `payload` member as described in {{Section 3.2 of RFC7515}}.
+
+The Data MUST be a JSON object with two members (see {{asd_payload}} for an example):
+
+* `created-on`: creation date and time in yang:date-and-time format
+
+* `serial-number`: product-serial-number in the X520SerialNumber field of the IDevID certificate of the pledge as string as defined in {{Section 2.3.1 of !RFC8995}}
+
+~~~~
+TODO: Even unclearer if there is this wrapper, as this element is not defined in YANG!
+"ietf-voucher-request-prm:agent-signed-data": {
+  "created-on": "2021-04-16T00:00:01.000Z",
+  "serial-number": "callee4711"
+}
+~~~~
+{: #asd_payload title="Data example inside agent-signed-data" artwork-align="left"}
+
+The JWS Protected Header of the `agent-signed-data` JWS structure MUST contain the following parameters (see {{asd_header}} for an example):
+
+* `alg`: algorithm type used to create the signature, e.g., `ES256` as defined in {{Section 4.1.1 of RFC7515}}
+
+* `kid`: base64-encoded bytes of the SubjectKeyIdentifier (the "KeyIdentifier" OCTET STRING value) of the EE (RegAgt) certificate.
+
+~~~~
+{
+  "alg": "ES256",
+  "kid": "base64encodedvalue=="
+}
+~~~~
+{: #asd_header title="Protected Header example inside agent-signed-data" artwork-align="left"}
+
+Note that at the time of receiving the PVR trigger, the pledge cannot verify the registrar LDevID certificate and has no proof-of-possession of the corresponding private key for the certificate.
+Hence, the tPVR is an unsigned artifact and the pledge only accepts the registrar LDevID certificate provisionally until it receives the voucher as described in {{voucher}}.
+
+The pledge will also be unable to verify the agent-signed-data itself as it does not possess the EE (RegAgt) certificate and the domain trust has not been established at this point of the communication.
+Verification SHOULD be done, after the voucher has been received.
 
 The trigger for the pledge to create a PVR is depicted in the following figure:
 
@@ -901,94 +977,31 @@ The trigger for the pledge to create a PVR is depicted in the following figure:
 ~~~~
 {: #pavrt title='Representation of trigger to create PVR' artwork-align="left"}
 
-Note that at the time of receiving the PVR trigger, the pledge cannot verify the registrar LDevID certificate and has no proof-of-possession of the corresponding private key for the certificate. The pledge therefore accepts the registrar LDevID certificate provisionally until it receives the voucher as described in {{voucher}}.
-
-The pledge will also be unable to verify the agent-signed-data itself as it does not possess the EE (RegAgt) certificate and the domain trust has not been established at this point of the communication.
-Verification SHOULD be done, after the voucher has been received.
-
-The agent-signed-data is a JSON-in-JWS object and contains the following information:
-
-The header of the agent-signed-data contains:
-
-* alg: algorithm used for creating the object signature.
-
-* kid: MUST contain the base64-encoded bytes of the SubjectKeyIdentifier (the "KeyIdentifier" OCTET STRING value) of the EE (RegAgt) certificate.
-
-The body of the agent-signed-data contains an "ietf-voucher-request:agent-signed-data" element (defined in {{I-D.ietf-anima-rfc8366bis}}):
-
-* created-on: MUST contain the creation date and time in yang:date-and-time format.
-
-* serial-number: MUST contain the product serial number as type string as defined in {{Section 2.3.1 of !RFC8995}}.
-  The serial-number corresponds with the product-serial-number contained in the X520SerialNumber field of the IDevID certificate of the pledge.
-
-~~~~
-# The agent-signed-data in General JWS Serialization syntax
-{
-  "payload": "BASE64URL(ietf-voucher-request-prm:agent-signed-data)",
-  "signatures": [
-    {
-      "protected": "BASE64URL(UTF8(JWS Protected Header))",
-      "signature": BASE64URL(JWS Signature)
-    }
-  ]
-}
-
-# Example: Decoded payload representation in JSON syntax of
-  "ietf-voucher-request-prm:agent-signed-data"
-
-"ietf-voucher-request-prm:agent-signed-data": {
-  "created-on": "2021-04-16T00:00:01.000Z",
-  "serial-number": "callee4711"
-}
-
-# Example: Decoded "JWS Protected Header" representation
-  in JSON syntax
-{
-  "alg": "ES256",
-  "kid": "base64encodedvalue=="
-}
-~~~~
-{: #asd title='Representation of agent-signed-data in General JWS Serialization syntax' artwork-align="left"}
-
-
 
 ### Response Artifact: Pledge Voucher-Request (PVR)
 
-Upon receiving the voucher-request trigger, the pledge SHALL construct the body of the PVR as defined in {{!RFC8995}}.
-It will contain additional information provided by the Registrar-Agent as specified in the following.
-This PVR becomes a JSON-in-JWS object as defined in {{I-D.ietf-anima-jws-voucher}}.
-If the pledge is unable to construct the PVR it SHOULD respond with a HTTP error code to the Registrar-Agent to indicate that it is not able to create the PVR.
-
-The following client error responses MAY be used:
-
-* 400 Bad Request: if the pledge detected an error in the format of the request, e.g. missing field, wrong data types, etc. or if the request is not valid JSON even though the PVR media type was set to `application/json`.
-
-* 403 Forbidden: if the pledge detected that one or more security parameters from the trigger message to create the PVR were not valid, e.g., the LDevID (Reg) certificate.
-
-The header of the PVR SHALL contain the following parameters as defined in {{RFC7515}} to support JWS signing of the object:
-
-* alg: algorithm used for creating the object signature.
-
-* x5c: contains the base64-encoded pledge IDevID certificate.
-  It MAY optionally contain the certificate chain for this certificate. If the certificate chain is not included it MUST be available at the registrar for verification of the IDevID certificate.
+The Pledge Voucher-Request (PVR) artifact is a JWS Voucher Request as defined in {{I-D.ietf-anima-jws-voucher}}.
+Its unsigned data SHALL be constructed similar to the Voucher-Request artifact defined in {{!RFC8995}}.
+It will contain additional data provided by the Registrar-Agent as specified in the following.
 
 The payload of the PVR MUST contain the following parameters as part of the ietf-voucher-request-prm:voucher as defined in {{!RFC8995}}:
 
-* created-on: SHALL contain the current date and time in yang:date-and-time format.
+TODO: ietf-voucher-request-prm:voucher does not exist.
+
+* `created-on`: SHALL contain the current date and time in yang:date-and-time format.
   If the pledge does not have synchronized time, it SHALL use the created-on time from the agent-signed-data, received in the trigger to create a PVR.
 
-* nonce: SHALL contain a cryptographically strong pseudo-random number.
+* `nonce`: SHALL contain a cryptographically strong pseudo-random number.
 
-* serial-number: SHALL contain the pledge product-serial-number as X520SerialNumber.
+* `serial-number`: SHALL contain the pledge product-serial-number as X520SerialNumber.
 
-* assertion: SHALL contain the requested voucher assertion "agent-proximity" (different value as in RFC 8995)..
+* `assertion`: SHALL contain the requested voucher assertion "agent-proximity" (different value as in RFC 8995)..
 
+The ietf-voucher-request:voucher data is extended with two additional parameters that MUST be included:
 
-The ietf-voucher-request:voucher is extended with additional parameters:
+* `agent-provided-proximity-registrar-cert`: base64-encoded registrar EE certificate (provided in tPVR by the Registrar-Agent); enables the registrar to verify that it is the desired registrar for handling the PVR
 
-* agent-provided-proximity-registrar-cert: MUST be included and contains the base64-encoded registrar LDevID certificate (provided as PVR trigger parameter by the Registrar-Agent).
-
-* agent-signed-data: MUST contain the base64-encoded agent-signed-data (as defined in {{asd}}) and provided as a PVR trigger parameter by the Registrar-Agent.
+* `agent-signed-data`: base64-encoded agent-signed-data (provided in tPVR by the Registrar-Agent); enables the registrar to verify and log, which Registrar-Agent was in contact with the pledge, when verifying the PVR
 
 The enhancements of the YANG module for the ietf-voucher-request with these new leaves are defined in {{I-D.ietf-anima-rfc8366bis}}.
 
@@ -1030,105 +1043,104 @@ The PVR is signed using the pledge's IDevID credential contained as x5c paramete
 ~~~~
 {: #pvr_example title='Representation of PVR' artwork-align="left"}
 
-The PVR Media-Type is defined in {{!I-D.ietf-anima-jws-voucher}} as `application/voucher-jws+json`.
-
-The pledge MUST include this Media-Type header field indicating the included media type for the PVR.
-The PVR is included by the registrar in its RVR as described in {{pvr}}.
 
 
 ## Trigger Pledge Enroll-Request {#tper}
-{{exchangesfig_uc2_2}} shows the the aquisition of the Pledge Enroll-Request aquisition and the following subsections describe the corresponding artifacts. 
+
+Once the Registrar-Agent has received the PVR it can trigger the pledge to generate a Pledge Enroll-Request (PER).
+
+Optionally, TLS MAY be used to provide privacy for this exchange between the Registrar-Agent and the pledge, see {{pledgehttps}}.
+
+{{exchangesfig_uc2_2}} shows the the acquisition of the PER and the following subsections describe the corresponding artifacts. 
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-  ~                ~                 ~              ~            ~
-   (2) Trigger Pledge Enroll-Request
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<-- opt. TLS -->|                 |              |            |
-   |<---- tPER -----|                 |              |            |
-   |----- PER ----->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(2) Trigger Pledge Enroll-Request
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<------tPER-------|                 |                 |            |
+ |--------PER------>|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_2 title='PER aquisition exchanges' artwork-align="left"}
+{: #exchangesfig_uc2_2 title="PER acquisition exchange" artwork-align="center"}
+
+The Registrar-Agent triggers the pledge to create the PER via HTTP POST on the well-known pledge endpoint `/.well-known/brski/tper`.
+As the initial enrollment aims to request a generic certificate, no certificate attributes are provided to the pledge.
+Hence, by default, the request body is empty, no artifact is provided.
+
+Upon receiving a valid tPER, the pledge MUST reply with the PER artifact in the body of a 200 OK response.
+The response header MUST have the Content-Type field set to `application/jose+json`.
+
+If the pledge is unable to create the PER, it SHOULD respond with an HTTP error code. The following 4xx client error codes MAY be used:
+
+* 400 Bad Request: if the pledge detected an error in the format of the request.
+
+* 403 Forbidden: if the pledge detected that one or more security parameters (if provided) from the trigger message to create the PER are not valid.
+
+TODO: Can this make sense? (empty body, note that it cannot validate)
+
+* 406 Not Acceptable: if the Accept request header field indicates a type that is unknown or unsupported. For example, a type other than `application/jose+json`.
+
+* 415 Unsupported Media Type: if the Content-Type request header field indicates a type that is unknown or unsupported, e.g., a type other than `application/json`.
 
 ### Request Artifact: Pledge Enroll-Request Trigger (tPER)
 
-Once the Registrar-Agent has received the PVR it can trigger the pledge to generate a PER.
-As in BRSKI the PER contains a PKCS#10, but additionally signed using the pledge's IDevID.
-Note, as the initial enrollment aims to request a generic certificate, no certificate attributes are provided to the pledge.
-
-Triggering the pledge to create the Enroll-Request is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tper"
-
-The Registrar-Agent PER trigger Content-Type header is: `application/json` with an empty body by default.
-Note that using HTTP POST allows for an empty body, but also to provide additional data, like CSR attributes or information about the enroll type "enroll-generic-cert" or "re-enroll-generic-cert".
-The "enroll-generic-cert" case is shown in {{raer}}.
-
-~~~~
-{
-  "enroll-type" : "enroll-generic-cert"
-}
-~~~~
-{: #raer title='Example of trigger to create a PER' artwork-align="left"}
-
-This document specifies the request of a generic certificate with no CSR attributes provided to the pledge.
+This document specifies the trigger for a generic certificate with no CSR attributes provided to the pledge.
 If specific attributes in the certificate are required, they have to be inserted by the issuing RA/CA.
-How the HTTP POST can be used to provide CSR attributes is out of scope for this specification.
 
+TODO: Unclear if JSON with { "enroll-type" : "enroll-generic-cert" } could be used alternatively to an empty body (i.e., is the assumed default enroll-type). Must update/remove response codes if there is no alternative to empty body.
 
-
-
-In the following the enrollment is described as initial enrollment with an empty HTTP POST body.
+The Pledge Enroll-Request Trigger (tPER) artifact MAY be used to provide additional data, like CSR attributes or information about the enroll type.
+How to provide and use such additional data is out of scope for this specification.
 
 ### Response Artifact: Pledge Enroll-Request (PER)
 
-Upon receiving the PER trigger, the pledge SHALL construct the PER as authenticated self-contained object.
+The Pledge Enroll-Request (PER) artifact is a JWS-signed PKCS#10 Certificate Signing Request (CSR) utilizing the csr-grouping of the `ietf-ztp-types` YANG module as defined in {{!I-D.ietf-netconf-sztp-csr}}.
 The CSR already assures POP of the private key corresponding to the contained public key.
 In addition, based on the PER signature using the IDevID, POI is provided.
-Here, a JOSE object is being created in which the body utilizes the YANG module ietf-ztp-types with the grouping for csr-grouping for the CSR as defined in {{!I-D.ietf-netconf-sztp-csr}}.
+
+TODO: What is the next paragraph saying? That PRM could also just use a plain PKCS#10? That it could use some other enrollment protocol? That CMP is also okay?
 
 Depending on the capability of the pledge, it constructs the Pledge Enroll-Request (PER) as plain PKCS#10.
-Note, the focus in this use case is placed on PKCS#10 as PKCS#10 can be transmitted in different enrollment protocols in the infrastructure like EST, CMP, CMS, and SCEP.
+Note, the focus in this use case is placed on PKCS#10, as PKCS#10 can be transmitted in different enrollment protocols in the infrastructure like EST, CMP, CMS, and SCEP.
 If the pledge has already implemented an enrollment protocol, it may leverage that functionality for the creation of the CSR.
 Note, {{!I-D.ietf-netconf-sztp-csr}} also allows for inclusion of certification requests in different formats used by CMP or CMC.
 
 The pledge MUST construct the PER as PKCS#10.
 In BRSKI-PRM it MUST sign it additionally with its IDevID credentials to provide proof-of-identity bound to the PKCS#10 as described below.
 
-If the pledge is unable to construct the PER it SHOULD respond with a HTTP 4xx/5xx error code to the Registrar-Agent to indicate that it is not able to create the PER.
-
-The following 4xx client error codes MAY be used:
-
-* 400 Bad Request: if the pledge detected an error in the format of the request or detected invalid JSON even though the PER media type was set to `application/json`.
-
-* 403 Forbidden: if the pledge detected that one or more security parameters (if provided) from the trigger message to create the PER are not valid.
-
-* 406 Not Acceptable: if the request's Accept header indicates a type that is unknown or unsupported. For example, a type other than `application/jose+json`.
-
-* 415 Unsupported Media Type: if the request's Content-Type header indicates a type that is unknown or unsupported. For example, a type other than 'application/json'.
+TODO: Why is the following information given here?
 
 A successful enrollment will result in a generic LDevID certificate for the pledge in the new domain, which can be used to request further (application specific) LDevID certificates if necessary for operation.
 The Registrar-Agent SHALL use the endpoints specified in this document.
 
+TODO: What endpointS? My guess would be use ./tper with a request body to do specific cert enrollment, yes?
+
+TODO: Why is the confusing information even repeated? It does not clarify anything.
+
 {{I-D.ietf-netconf-sztp-csr}} considers PKCS#10 but also CMP and CMC as certification request format.
 Note that the wrapping of the PER signature is only necessary for plain PKCS#10 as other request formats like CMP and CMS support the signature wrapping as part of their own certificate request format.
 
-The Registrar-Agent Enroll-Request Content-Type header for a signature-wrapped PKCS#10 is: `application/jose+json`
+The JWS Protected Header of the PER MUST contain the following parameters as defined in {{RFC7515}}:
 
-The header of the Pledge Enroll-Request SHALL contain the following parameter as defined in {{RFC7515}}:
+* `alg`: algorithm type used to create the signature, e.g., `ES256` as defined in {{Section 4.1.1 of RFC7515}}
 
-* alg: algorithm used for creating the object signature.
+* `x5c`: base64-encoded pledge IDevID certificate;
+  it MAY optionally contain the certificate chain for this certificate; if the certificate chain is not included, it MUST be available at the registrar for verification of the IDevID certificate
 
-* x5c: contains the base64-encoded pledge IDevID certificate.
-  It MAY optionally contain the certificate chain for this certificate. If the certificate chain is not included it MUST be available at the registrar for verification of the IDevID certificate.
-The body of the Pledge Enroll-Request SHOULD contain a P10 parameter (for PKCS#10) as defined for ietf-ztp-types:p10-csr in {{I-D.ietf-netconf-sztp-csr}}
+The body of the Pledge Enroll-Request SHOULD contain a P10 parameter (for PKCS#10) as defined for ietf-ztp-types:p10-csr in {{I-D.ietf-netconf-sztp-csr}}:
 
-* P10: contains the base64-encoded PKCS#10 of the pledge.
+* `p10`: base64-encoded PKCS#10 of the pledge.
+
+TODO: Confirm lowercase p (not "P10")
+TODO: We contain the full CSR that is already in the payload again in the header?!
 
 The JOSE object is signed using the pledge's IDevID credential, which corresponds to the certificate signaled in the JOSE header.
 
@@ -1179,9 +1191,7 @@ This allows bulk bootstrapping of several pledges using the same connection betw
 
 
 
-
-
-## Supply Voucher Request to Registrar (including backend interaction) {#pvr}
+## Supply PVR to Registrar (including backend interaction) {#pvr}
 
 Similar to BRSKI "requestvoucher" endpoint in {{Section 5.2 of !RFC8995}}.
 
@@ -1205,46 +1215,50 @@ In {{!RFC8995}}, the pledge generates PVR as CMS-signed JSON and PER as PKCS#10 
 {{exchangesfig_uc2_3}} shows the exchanges for the Voucher Request processing and the following subsections describe the corresponding artifacts. 
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   ~                ~                 ~              ~            ~
-   (3) Supply PVR to Registrar (including backend interaction)
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |                |<---- mTLS ----->|              |            |
-   |                |         [Registrar-Agent       |            |
-   |                |    authenticated&authorized?]  |            |
-   |                |----- PVR ------>|              |            |
-   |                |         [accept device?]       |            |
-   |                |         [contact vendor]       |            |
-   |                |                 |              |            |
-   |                |                 |<---------- mTLS --------->|
-   |                |                 |------------ RVR --------->|
-   |                |                 |           [extract DomainID]
-   |                |                 |           [update audit log]
-   |                |                 |<--------- Voucher --------|
-   |                |<--- Voucher ----|              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(3) Supply PVR to Registrar (including backend interaction)
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |                  |<-----mTLS------>|                 |            |
+ |                  |         [Registrar-Agent          |            |
+ |                  |    authenticated&authorized?]     |            |
+ |                  |-------PVR------>|                 |            |
+ |                  |          [accept device?]         |            |
+ |                  |          [contact vendor]         |            |
+ |                  |                 |                 |            |
+ |                  |                 |<------------mTLS------------>|
+ |                  |                 |--------------RVR------------>|
+ |                  |                 |              [extract DomainID]
+ |                  |                 |              [update audit log]
+ |                  |                 |<-----------Voucher-----------|
+ |                  |<----Voucher-----|                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_3 title='Voucher Request processing' artwork-align="left"}
+{: #exchangesfig_uc2_3 title="Voucher issuing exchange" artwork-align="center"}
 
-### Request Artifact: PVR
+
+### Request Artifact: Pledge Voucher-Request (PVR)
 
 For BRSKI-PRM, the Registrar-Agent sends the PVR by HTTP POST to the same registrar endpoint as introduced by BRSKI: "/.well-
 known/brski/requestvoucher", but with a Content-Type header field for JSON-in-JWS"
 
 The Content-Type header field for JSON-in-JWS PVR is: `application/voucher-jws+json` (see {{tpvr}} for the content definition), as defined in {{I-D.ietf-anima-jws-voucher}}.
 
-The Registrar-Agent sets the Accept field in the request-header indicating the acceptable Content-Type for the voucher-response.
+The Registrar-Agent sets the Accept field in the request-header indicating the acceptable Content-Type for the Voucher.
+
 The voucher-response Content-Type header field is set to `application/voucher-jws+json` as defined in {{I-D.ietf-anima-jws-voucher}}.
 
+TODO: conflict with content negotiation (Accept). So you mean "by default"?
 
+### Supply RVR to MASA (backend interaction) {#rvr-proc}
 
-### Registrar Voucher-Request (RVR) Processing (Registrar to MASA) {#rvr-proc}
+The registrar needs to convert the PVR to an RVR and supply it to the MASA.
 
 If the MASA address/URI is learned from the IDevID MASA URI extension ({{Section 2.3 of !RFC8995}}), then the MASA on that URI MUST support the procedures defined in this document if the PVR used JSON-JWS encoding.
 If the MASA is only configured on the registrar, then a registrar supporting BRKSI-PRM and other voucher encoding formats (such as those in {{!RFC8995}}) SHOULD support per-message-format MASA address/URI configuration for the same IDevID trust anchor."
@@ -1360,7 +1374,7 @@ The HTTP error status codes are kept the same as defined in {{Section 5.6 of !RF
 
 The registrar provides the EE certificate of the Registrar-Agent identified by the SubjectKeyIdentifier (SKID) in the header of the "agent-signed-data" from the PVR in its RVR (see also {{rvr-proc}}).
 
-The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-certificate" leaf and may assert the PVR as "verified" or "logged".
+The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-cert" leaf and may assert the PVR as "verified" or "logged".
 
 In addition, the MASA may issue the assertion "agent-proximity" as follows:
 The MASA verifies the signature of the "agent-signed-data" contained in the "prior-signed-voucher-request", based on the provided EE certificate of the Registrar-Agent in the "agent-sign-cert" leaf of the RVR.
@@ -1371,7 +1385,7 @@ Note that the different assertions do not provide a metric of strength as the se
 Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx response status codes as described in {{Section 5.6 of !RFC8995}}.
 When successful, the Voucher will then be supplied via the registrar to the Registrar-Agent.
 
-### Voucher Issuance by MASA {#exchanges_uc2_2_vc}
+### Issue Voucher by MASA (backend interaction) {#exchanges_uc2_2_vc}
 
 The MASA creates a voucher with Media-Type of `application/voucher-jws+json` as defined in {{I-D.ietf-anima-jws-voucher}}.
 If the MASA detects that the Accept header of the PVR does not match `application/voucher-jws+json` it SHOULD respond with the HTTP status code "406 Not Acceptable" as the pledge will not be able to parse the response.
@@ -1382,7 +1396,7 @@ The voucher is according to {{I-D.ietf-anima-rfc8366bis}} but uses the new asser
 ~~~~
 # The MASA issued voucher in General JWS Serialization syntax
 {
-  "payload": BASE64URL(ietf-voucher:voucher),
+  "payload": BASE64URL(UTF8(ietf-voucher:voucher)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -1418,12 +1432,10 @@ The pinned-domain certificate to be put into the voucher is determined by the MA
 The MASA returns the voucher-response (voucher) to the registrar.
 
 
-### MASA issued Voucher Processing by Registrar {#exchanges_uc2_2_vs}
+### Supply Voucher to Registrar (backend interaction) {#exchanges_uc2_2_vs}
 
 After receiving the voucher the registrar SHOULD evaluate it for transparency and logging purposes as outlined in {{Section 5.6 of !RFC8995}}.
 The registrar MUST add an additional signature to the MASA provided voucher using its registrar EE credentials.
-
-
 
 The signature is created by signing the original "JWS Payload" produced by MASA and the registrar added "JWS Protected Header" using the registrar EE credentials (see {{RFC7515}}, Section 5.2 point 8.
 The x5c component of the "JWS Protected Header" MUST contain the registrar EE certificate as well as potential subordinate CA certificates up to (but not including) the pinned domain certificate.
@@ -1499,7 +1511,6 @@ Depending on the security policy of the operator, this signature can also be int
 The registrar sends the voucher to the Registrar-Agent.
 
 
-
 ### Response Artifact: Voucher
 
 After receiving the PVR from Registrar-Agent, the registrar SHALL perform the verification as defined in {{Section 5.3 of RFC8995}}.
@@ -1515,19 +1526,19 @@ In addition, the registrar SHALL verify the following parameters from the PVR:
   This requires, that the registrar has access to the EE (RegAgt) certificate data (including intermediate CA certificates if existent) based on the SKID.
   Note, the registrar may have stored the EE (RegAgt) certificate if used during TLS establishment between Registrar-Agent and registrar or it may be provided via a repository.
 
-If the registrar is unable to validate the PVR it SHOULD respond with a HTTP 4xx/5xx error code to the Registrar-Agent.
+If the registrar is unable to validate the PVR, it SHOULD respond with a HTTP 4xx/5xx error code to the Registrar-Agent.
 
 The following 4xx client error codes SHOULD be used:
 
 * 403 Forbidden: if the registrar detected that one or more security related parameters are not valid.
 
-* 404 Not Found status code if the pledge provided information could not be used with automated allowance, as described in {{Section 5.3 of RFC8995}}.
+* 404 Not Found: if the pledge provided information could not be used with automated allowance, as described in {{Section 5.3 of RFC8995}}.
+
+TODO: From EST or BRSKI? Otherwise should be 422 Unprocessable Content, as the resource endpoint must exist and cannot be 404.
 
 * 406 Not Acceptable: if the Content-Type indicated by the Accept header is unknown or unsupported.
 
 If the validation succeeds, the registrar performs pledge authorization according to {{Section 5.3 of !RFC8995}} followed by obtaining a voucher from the pledge's MASA according to {{Section 5.4 of !RFC8995}} with the modifications described below in {{rvr-proc}}.
-
-
 
 
 
@@ -1540,25 +1551,27 @@ Note, this also addresses situations in which a nonceless voucher is used and ma
 {{exchangesfig_uc2_4}} depicts exchanges for the PER request handling and the following subsections describe the corresponding artifacts. 
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   ~                ~                 ~              ~            ~
-   (4) Supply PER to Registrar (including backend interaction)
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |                |<---- mTLS ----->|              |            |
-   |                |----- PER ------>|              |            |
-   |                |                 |<--- mTLS --->|            |
-   |                |                 |---- RER ---->|            |
-   |                |                 |<-Enroll Resp-|            |
-   |                |<--Enroll Resp---|              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(4) Supply PER to Registrar (including backend interaction)
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |                  |<----(mTLS)----->|                 |            |
+ |                  |-------PER------>|                 |            |
+ |                  |                 |<-----mTLS------>|            |
+ |                  |                 |-------RER------>|            |
+ |                  |                 |<--Enroll-Resp---|            |
+ |                  |<--Enroll-Resp---|                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_4 title='Pledge Enroll-Request processing' artwork-align="left"}
+{: #exchangesfig_uc2_4 title="Enroll exchange" artwork-align="center"}
+
+In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in {{pvr}}.
 
 ### Request Artifact: Pledge Enroll-Request (PER)
 
@@ -1581,23 +1594,25 @@ Note, the registrar is already aware that the bootstrapping is performed in a pl
 
 * The registrar verifies that the pledge's certificate (here IDevID), carried in "x5c" header field, is accepted to join the domain after successful validation of the PVR.
 
-### Enrollment by Domain CA
+
+### Enroll Pledge by Domain CA (backend interaction)
 
 If both succeed, the registrar utilizes the PKCS#10 request contained in the JWS object body as "P10" parameter of "ietf-sztp-csr:csr" for further processing of the Enroll-Request with the corresponding domain CA.
-It creates a registrar-Enroll-Request (RER) by utilizing the protocol expected by the domain CA.
+It creates a Registrar Enroll-Request (RER) by utilizing the protocol expected by the domain CA.
 
 The domain registrar may either directly forward the provided PKCS#10 request to the CA or provide additional information about attributes to be included by the CA into the requested LDevID certificate.
 
 The approach of sending this information to the CA depends on the utilized certificate management protocol between the RA and the CA and is out of scope for this document.
 
-### Response Artifact: Enroll-Response
+
+### Response Artifact: Enroll-Response (Enroll-Resp)
 
 The registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
 
 A successful interaction with the domain CA will result in a pledge LDevID certificate, which is then forwarded by the registrar to the Registrar-Agent using the Content-Type header: `application/pkcs7-mime`.
 
-
 Note while BRSKI-PRM targets the initial enrollment, re-enrollment may be supported in a similar way with the exception that the current LDevID certificate is used instead of the IDevID certificate to verify the wrapping signature of the PKCS#10 request (see also {{tper}}).
+
 
 
 ## Request CA Certificates {#req_cacerts}
@@ -1612,29 +1627,34 @@ As the CA certificate(s) are provided to the pledge after the voucher, the pledg
 The following subsections describe the corresponding artifacts. 
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   ~                ~                 ~              ~            ~
-   (5) Request CA Certificates
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |                |-- cACert-Req -->|              |            |
-   |                |<-- cACert-Resp--|              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(5) Request CA Certificates
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |                  |<----(mTLS)----->|                 |            |
+ |                  |---cACert-Req--->|                 |            |
+ |                  |<--cACert-Resp---|                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_5 title='CA certificate retrival' artwork-align="left"}
+{: #exchangesfig_uc2_5 title="CA certificates retrival exchange" artwork-align="center"}
 
-### Request Artifact: cACert-Req
+In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in {{pvr}}.
+
+
+### Request Artifact: cACert-Request (cACert-Req)
 
 To support Registrar-Agents requesting a signature wrapped CA certificate(s) object, a new endpoint for BRSKI-PRM is defined on the registrar: "/.well-known/brski/wrappedcacerts"
 
 The Registrar-Agent SHALL requests the EST CA trust anchor database information (in form of CA certificates) by HTTP GET.
 
-### Response Artifact: cACert-Resp
+
+### Response Artifact: cACert-Response (cACert-Resp)
 
 The Content-Type header of the response SHALL be: `application/jose+json`.
 
@@ -1677,10 +1697,7 @@ This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certific
 
 
 
-
-
 ## Supply Voucher to Pledge {#voucher}
-
 
 It is assumed that the Registrar-Agent already obtained the bootstrapping response objects from the domain registrar and can supply them to the pledge:
 
@@ -1703,22 +1720,22 @@ The Registrar-Agent provides the information via distinct pledge endpoints as fo
 The following subsections describe the corresponding artifacts. 
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   ~                ~                 ~              ~            ~
-   (6) Supply Voucher to Pledge
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<--opt. TLS --->|                 |              |            |
-   |<--- Voucher ---|                 |              |            |
-   |---- vStatus -->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(6) Supply Voucher to Pledge
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<-----Voucher-----|                 |                 |            |
+ |------vStatus---->|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_6 title='Supply voucher to pledge' artwork-align="left"}
+{: #exchangesfig_uc2_6 title="Voucher exchange" artwork-align="center"}
 
 ### Request Artifact: Voucher
 
@@ -1800,27 +1817,31 @@ As the reason field is optional (see {{!RFC8995}}), it MAY be omitted in case of
 If the pledge did not did not provide voucher status telemetry information after processing the voucher, the Registrar-Agent MAY query the pledge status explicitly as described in {{query}} and MAY resent the voucher depending on the Pledge status following the procedure described in {{voucher}}.
 
 
-## Supply CA certificates to Pledge {#cacerts}
+
+## Supply CA Certificates to Pledge {#cacerts}
+
 {{exchangesfig_uc2_7}} shows the provisioning of the CA certificates aquired by the pledge-agent to the pledge. 
 The following subsections describe the corresponding artifacts. 
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   ~                ~                 ~              ~            ~
-   (7) Supply CA certificates to Pledge
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<--opt. TLS --->|                 |              |            |
-   |<--- cACerts ---|                 |              |            |
-   |--- cACerts --->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(7) Supply CA Certificates to Pledge
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<-----cACerts-----|                 |                 |            |
+TODO: certs sent back in response?
+ |------cACerts---->|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_7 title='Supply CA certificates to pledge' artwork-align="left"}
+{: #exchangesfig_uc2_7 title="Certificate provisioning exchange" artwork-align="center"}
+
 
 ### Request Artifact:
 
@@ -1833,41 +1854,49 @@ The CA certificates message has the Content-Type `application/jose+json` and is 
 The CA certificates are provided as base64-encoded "x5bag".
 The pledge SHALL install the received CA certificates as trust anchor after successful verification of the registrar's signature.
 
-### Response
+
+### Response (no artifact)
 
 The verification comprises the following steps the pledge MUST perform. Maintaining the order of versification steps as indicated allows to determine, which verification has already been passed:
 
-  1. Check content-type of the CA certificates message. If no Content-Type is contained in the HTTP header, the default Content-Type utilized in this document (JSON-in-JWS) is used. If the Content-Type of the response is in an unknown or unsupported format, the pledge SHOULD reply with a 415 Unsupported media type error code.
-  2. Check the encoding of the payload. If the pledge detects errors in the encoding of the payload, it SHOULD reply with 400 Bad Request error code.
-  3. Verify that the wrapped CA certificate object is signed using the registrar certificate against the pinned-domain certificate. This MAY be done by comparing the hash that is indicating the certificate used to sign the message is that of the pinned-domain certificate. If the validation against the pinned domain-certificate fails, the client SHOULD reply with a 401 Unauthorized error code. It signals that the authentication has failed and therefore the object was not accepted.
-  4. Verify signature of the the received wrapped CA certificate object. If the validation of the signature fails, the pledge SHOULD reply with a 406 Not Acceptable. It signals that the object has not been accepted.
-  5. If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of [RFC7030].
+1. Check content-type of the CA certificates message. If no Content-Type is contained in the HTTP header, the default Content-Type utilized in this document (JSON-in-JWS) is used. If the Content-Type of the response is in an unknown or unsupported format, the pledge SHOULD reply with a 415 Unsupported media type error code.
+2. Check the encoding of the payload. If the pledge detects errors in the encoding of the payload, it SHOULD reply with 400 Bad Request error code.
+3. Verify that the wrapped CA certificate object is signed using the registrar certificate against the pinned-domain certificate. This MAY be done by comparing the hash that is indicating the certificate used to sign the message is that of the pinned-domain certificate. If the validation against the pinned domain-certificate fails, the client SHOULD reply with a 401 Unauthorized error code. It signals that the authentication has failed and therefore the object was not accepted.
+4. Verify signature of the the received wrapped CA certificate object [TODO: against what?]. If the validation of the signature fails, the pledge SHOULD reply with a TODO [406 Not Acceptable --> 409 Conflict? 422 Unprocessable Content?; Acceptable code is for Accept header]. It signals that the object has not been TODO accepted.
+5. If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of [RFC7030].
+
+TODO: Not clear what the success response code and what the response payload should be. Figure illustrates sending back the same certs, which does not make sense.
+
 
 
 ## Supply Enroll-Response to Pledge {#enroll_response}
+
 {{exchangesfig_uc2_8}} shows the supply of the Enroll-Response to the pledge.
 The following subsections describe the corresponding artifacts. 
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   ~                ~                 ~              ~            ~
-   (8) Supply Enroll-Response to Pledge
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<--Enroll Resp--|                 |              |            |
-   |--- eStatus --->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(8) Supply Enroll-Response to Pledge
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<---Enroll-Resp---|                 |                 |            |
+ |-----eStatus----->|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_8 title='Supply Enroll-Response to pledge' artwork-align="left"}
+{: #exchangesfig_uc2_8 title="Enroll-Response exchange" artwork-align="center"}
 
-### Request Artifact: Enroll-Response
+### Request Artifact: Enroll-Response (Enroll-Resp)
 
-The Registrar-Agent SHALL send the Enroll-Response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/ser".
+The Registrar-Agent SHALL send the Enroll-Response to the pledge by HTTP(S) POST to the endpoint: "/.well-known/brski/ser".
+
+TODO: Confirm "opt. TLS", which was missing.
 
 The Content-Type header when using EST {{RFC7030}} as enrollment protocol between the Registrar-Agent and the infrastructure is `application/pkcs7-mime`.
 Note: It only contains the LDevID certificate for the pledge, not the certificate chain.
@@ -1875,6 +1904,7 @@ Note: It only contains the LDevID certificate for the pledge, not the certificat
 Upon reception, the pledge SHALL verify the received LDevID certificate.
 The pledge SHALL generate the enroll status and provide it in the response to the Registrar-Agent.
 If the verification of the LDevID certificate succeeds, the status property SHALL be set to "status": true, otherwise to "status": false
+
 
 ### Response Artifact: Enroll Status (eStatus)
 
@@ -1953,7 +1983,8 @@ The response has the Content-Type `application/jose+json`.
 Once the Registrar-Agent has collected the information, it can connect to the registrar to provide it with the status responses.
 
 
-## Voucher Status Telemetry {#vstatus}
+
+## Voucher Status Telemetry (including backend interaction) {#vstatus}
 
 The following description requires that the Registrar-Agent has collected the status information from the pledge.
 It SHALL provide the status information to the registrar for further processing.
@@ -1963,29 +1994,30 @@ Preconditions in addition to {{pvr}}:
 * Registrar-Agent: obtained voucher status (vStatus) and enroll status (eStatus) from pledge.
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   ~                ~                 ~              ~            ~
-   (9) Voucher Status Telemetry
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |                |<---- mTLS ----->|              |            |
-   |                |---- vStatus --->|              |            |
-   |                |                 |--- req device audit log-->|
-   |                |                 |<---- device audit log ----|
-   |                |           [verify audit log]
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(9) Voucher Status Telemetry (including backend interaction)
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |                  |<----(mTLS)----->|                 |            |
+ |                  |-----vStatus---->|                 |            |
+ |                  |                 |<-----------(mTLS)----------->|
+ |                  |                 |-----req device audit log---->|
+ |                  |                 |<------device audit log-------|
+ |                  |        [verify audit log]         |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_9 title='Voucher Status tekemetry handling' artwork-align="left"}~~~~ aasvg
+{: #exchangesfig_uc2_9 title="Voucher Status telemetry exchange" artwork-align="center"}~~~~ aasvg
+
+In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in {{pvr}}.
 
 The Registrar-Agent MUST provide the collected pledge voucher status to the registrar.
 This status indicates if the pledge could process the voucher successfully or not.
-
-In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in {{pvr}}.
 
 ### Request Artifact: Voucher Status (vStatus)
 
@@ -1999,13 +2031,17 @@ The registrar SHOULD log the transaction provided for a pledge via Registrar-Age
 
 The registrar SHALL verify the signature of the pledge voucher status and validate that it belongs to an accepted device of the domain based on the contained "serial-number" in the IDevID certificate referenced in the header of the voucher status.
 
-### Response
+### Response (no artifact)
 
-According to {{Section 5.7 of !RFC8995}}, the registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
-The Registrar-Agent may use the response to signal success / failure to the service technician operating the Registrar-Agent.
+TODO: Clarify if diagnostic payload (and what representation format) may be included "to signal success/failure to the service technician. 200 OK should have payload, otherwise 204 No Content...
+
+According to {{Section 5.7 of !RFC8995}}, the registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes.
+The Registrar-Agent may use the response to signal success/failure to the service technician operating the Registrar-Agent.
 Within the server logs the server SHOULD capture this telemetry information.
 
 The registrar SHOULD proceed with collecting and logging status information by requesting the MASA audit-log from the MASA service as described in {{Section 5.8 of !RFC8995}}.
+
+
 
 ## Enroll Status Telemetry {#estatus}
 
@@ -2013,20 +2049,23 @@ The Registrar-Agent MUST provide the pledge's enroll status to the registrar.
 The status indicates the pledge could process the Enroll-Response (certificate) and holds the corresponding private key.
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   ~                ~                 ~              ~            ~
-   (10) Enroll Status Telemetry
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |                |---- eStatus --->|              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(10) Enroll Status Telemetry
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |                  |<----(mTLS)----->|                 |            |
+ |                  |-----eStatus---->|                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_10 title='Enroll-Status provisioning to domain registrar' artwork-align="left"}
+{: #exchangesfig_uc2_10 title="Enroll Status telemetry exchange" artwork-align="center"}
+
+In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in {{pvr}}.
 
 ### Request Artifact: Enroll Status (eStatus)
 
@@ -2039,9 +2078,11 @@ The registrar SHOULD log this event.
 In case the pledge enroll status indicates a failure, the pledge was unable to verify the received LDevID certificate and therefore signed the enroll status with its IDevID credential.
 Note that the signature verification of the status information is an addition to the described handling in {{Section 5.9.4 of !RFC8995}}, and is replacing the pledges TLS client authentication by DevID credentials in {{!RFC8995}}.
 
-### Response
 
-According to {{Section 5.9.4 of !RFC8995}}, the registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
+### Response (no artifact)
+
+According to {{Section 5.9.4 of !RFC8995}}, the registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes.
+
 Based on the failure case the registrar MAY decide that for security reasons the pledge is not allowed to reside in the domain. In this case the registrar MUST revoke the certificate.
 An example case for the registrar revoking the issued LDevID for the pledge is when the pledge was not able to verify the received LDevID certificate and therefore did send a 406 (Not Acceptable) response.
 In this case the registrar may revoke the LDevID certificate as the pledge did no accepted it for installation.
@@ -2054,62 +2095,84 @@ Within the server log the registrar SHOULD capture this telemetry information.
 
 The following assumes that a Registrar-Agent may need to query the status of a pledge.
 This information may be useful to solve errors, when the pledge was not able to connect to the target domain during the bootstrapping.
-The pledge MAY provide a dedicated endpoint to accept status-requests.
+The pledge MAY provide the dedicated endpoint for the Query Pledge Status operation.
 
 ~~~~ aasvg
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
-|        |   | Agent     |   | Registrar |    | CA     |  |         |
-+--------+   +-----------+   +-----------+    +--------+  +---------+
-   |                |                 |              |   Internet |
-   ~                ~                 ~              ~            ~
-   (11) Query Pledge Status
-   ~                ~                 ~              ~            ~
-   |                |                 |              |            |
-   |<--pStatus-Req--|                 |              |            |
-   |--pStatus-Resp->|                 |              |            |
-   |                |                 |              |            |
-   ~                ~                 ~              ~            ~
++--------+    +------------+    +-----------+    +--------+    +------+
+| Pledge |    | Registrar- |    |  Domain   |    | Domain |    | MASA |
+|        |    |   Agent    |    | Registrar |    |   CA   |    |      |
++--------+    +------------+    +-----------+    +--------+    +------+
+ |                  |                 |                 |   Internet |
+ ~                  ~                 ~                 ~            ~
+(11) Query Pledge Status
+ ~                  ~                 ~                 ~            ~
+ |                  |                 |                 |            |
+ |<----opt. TLS---->|                 |                 |            |
+ |<-----qStatus-----|                 |                 |            |
+ |------pStatus---->|                 |                 |            |
+ |                  |                 |                 |            |
+ ~                  ~                 ~                 ~            ~
 ~~~~
-{: #exchangesfig_uc2_11 title='Pledge-status handling between Registrar-Agent and pledge' artwork-align="left"}
+{: #exchangesfig_uc2_11 title="Pledge Status exchange" artwork-align="center"}
 
-### Request Artifact: Pledge Status Request (pStatus-Req)
+The Registrar-Agent queries the Pledge Status via HTTP POST request on the well-known pledge endpoint `/.well-known/brski/qps`.
+The request body MUST contain the JWS-signed Status Query (qStatus) artifact.
+The request header MUST set the Content-Type field `application/jose+json`.
 
-The Registrar-Agent requests the pledge-status via HTTP POST on the defined pledge endpoint: "/.well-known/brski/qps"
+If the pledge provides the Query Pledge Status endpoint, it MUST reply to this request with the Pledge Status (pStatus) artifact in the body of a 200 OK response.
+The response header MUST have the Content-Type field set to `application/jose+json`.
 
-The Registrar-Agent Content-Type header for the pledge-status request is: `application/jose+json`.
-It contains information on the requested status-type, the time and date the request is created, and the product serial-number of the pledge contacted as shown in {{stat_req_def}}.
-The pledge-status request is signed by Registrar-Agent using the private key corresponding to the EE (RegAgt) certificate.
+### Request Artifact: Status Query (qStatus)
 
-The following Concise Data Definition Language (CDDL) {{RFC8610}} explains the structure of the format for the pledge-status request. It is defined following the status telemetry definitions in BRSKI {{!RFC8995}}.
-Consequently, format and semantics of pledge-status requests below are for version 1.
-The version field is included to permit significant changes to the pledge-status request and response in the future.
-A pledge or a Registrar-Agent that receives a pledge-status request with a version larger than it knows about SHOULD log the contents and alert a human.
+The Status Query artifact is a JWS structure signing information on the requested status-type, the time and date the request is created, and the product serial-number of the pledge contacted as shown in {{stat_req_def}}.
+The following Concise Data Definition Language (CDDL) {{RFC8610}} defines the structure of the unsigned Status Query data (i.e., JWS payload):
 
 ~~~~
 <CODE BEGINS>
-  status-request = {
+  status-query = {
       "version": uint,
       "created-on": tdate ttime,
+TODO: Not sure if "ttime" exists. tdate is already a string with CBOR tag 0, i.e., a full datatime string
       "serial-number": text,
       "status-type": text
   }
 <CODE ENDS>
 ~~~~
-{: #stat_req_def title='CDDL for pledge-status request' artwork-align="left"}
+{: #stat_req_def title="CDDL for unsigned Status Query data (status-query)" artwork-align="left"}
 
-The status-type defined for BRSKI-PRM is "bootstrap".
+The `version` field is included to permit significant changes to the pledge status artifacts in the future.
+The format and semantics in this document follow the status telemetry definitions of {{!RFC8995}}.
+Hence, the version MUST be set to `1`.
+A pledge (or Registrar-Agent) that receives a version larger than it knows about SHOULD log the contents and alert a human.
+
+The `created-on` field contains a standard date/time string following {{!RFC3339}}.
+
+The `serial-number` field takes the product-serial-number corresponding to the X520SerialNumber field of the IDevID certificate of the pledge.
+
+The `status-type` value defined for BRSKI-PRM Status Query is `bootstrap`.
 This indicates the pledge to provide current status information regarding the bootstrapping status (voucher processing and enrollment of the pledge into the new domain).
-As the pledge-status request is defined generic, it may be used by other specifications to request further status information, e.g., for onboarding to get further information about enrollment of application specific LDevIDs or other parameters.
+
+As the Status Query artifact is defined generic, it may be used by other specifications to request further status information using other status types, e.g., for onboarding to get further information about enrollment of application specific LDevIDs or other parameters.
 This is out of scope for this specification.
 
-{{stat_req}} below shows an example for querying pledge-status using status-type bootstrap.
+{{stat_req_data}} below shows an example for unsigned Status Query data in JSON syntax using status-type `bootstrap`.
 
 ~~~~
-# The Registrar-Agent request of "pledge-status" in general JWS
-  serialization syntax
 {
-  "payload": BASE64URL(UTF8(status-request)),
+  "version": 1,
+  "created-on": "2022-08-12T02:37:39.235Z",
+  "serial-number": "pledge-callee4711",
+  "status-type": "bootstrap"
+}
+~~~~
+{: #stat_req_data title="Example of unsigned Status Query data in JSON syntax using status-type bootstrap for the Status Query artifact" artwork-align="left"}
+
+The Status Query data MUST be signed by the Registrar-Agent using its private key corresponding to the EE (RegAgt) certificate.
+When using a JWS signature, the Status Query artifact looks as shown in {{stat_req}} and the Content-Type response header MUST be set to `application/jose+json`:
+
+~~~~
+{
+  "payload": BASE64URL(UTF8(status-query)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -2117,40 +2180,24 @@ This is out of scope for this specification.
     }
   ]
 }
-
-# Example: Decoded payload "status-request" representation
-  in JSON syntax
-{
-  "version": 1,
-  "created-on": "2022-08-12T02:37:39.235Z",
-  "serial-number": "pledge-callee4711",
-  "status-type": "bootstrap"
-}
-
-# Example: Decoded "JWS Protected Header" representation
-  in JSON syntax
-{
-  "alg": "ES256",
-  "x5c": [
-    "base64encodedvalue==",
-    "base64encodedvalue=="
-  ]
-}
 ~~~~
-{: #stat_req title='Example of Registrar-Agent request of pledge-status using status-type bootstrap' artwork-align="left"}
+{: #stat_req title="Status Query Representation in General JWS JSON Serialization Syntax" artwork-align="left"}
+
+For details on `JWS Protected Header` and `JWS Signature` see {{!I-D.ietf-anima-jws-voucher}} or {{!RFC7515}}.
 
 
-### Response Artifact: Pledge Status Response (pStatus-Resp)
+### Response Artifact: Pledge Status (pStatus)
 
-If the pledge receives the pledge-status request with status-type "bootstrap" it SHALL react with a status response message based on previously collected telemetry information (see {{vstatus}} and {{estatus}}) in a single status-response artifact.
+When the pledge receives a Status Query with status-type `bootstrap` it SHALL respond with previously collected telemetry information (see {{vstatus}} and {{estatus}}) in a single Pledge Status artifact.
 
-The pledge-status response Content-Type header is `application/jose+json`.
 
-The following CDDL explains the structure of the format for the status response, which is:
+The pledge-status response message is signed with IDevID or LDevID, depending on bootstrapping state of the pledge.
+
+The following CDDL defines the structure of the Pledge Status (pStatus) data:
 
 ~~~~
 <CODE BEGINS>
-  status-response = {
+  pledgestatus = {
     "version": uint,
     "status":
       "factory-default" /
@@ -2165,13 +2212,13 @@ The following CDDL explains the structure of the format for the status response,
   }
 <CODE ENDS>
 ~~~~
-{: #stat_res_def title='CDDL for pledge-status response' artwork-align="left"}
+{: #stat_res_def title='CDDL for unsigned Pledge Status data (pledgestatus)' artwork-align="left"}
 
 Different cases for pledge bootstrapping status may occur, which SHOULD be reflected using the status enumeration.
 This document specifies the status values in the context of the bootstrapping process and credential application.
 Other documents may enhance the above enumeration to reflect further status information.
 
-The pledge-status response message is signed with IDevID or LDevID, depending on bootstrapping state of the pledge.
+
 
 * "factory-default": Pledge has not been bootstrapped.
   Additional information may be provided in the reason or reason-context.
@@ -2201,6 +2248,11 @@ As the pledge is assumed to utilize its bootstrapped credentials (LDevID) in com
 The pledge-status responses are cumulative in the sense that connect-success implies enroll-success, which in turn implies voucher-success.
 
 {{stat_res}} provides an example for the bootstrapping-status information.
+
+
+
+
+
 
 ~~~~
 # The pledge "status-response" in General JWS Serialization syntax
@@ -2252,9 +2304,12 @@ agent), once the pledge is enrolled with CA certificates and a matching domain c
 
 
 
+
 # IANA Considerations {#iana-con}
 
 This document requires the following IANA actions.
+
+
 
 ##  BRSKI .well-known Registry
 
@@ -2273,6 +2328,8 @@ IANA is requested to enhance the Registry entitled: "BRSKI Well-Known URIs" with
 |=========
 {: #iana_table title='BRSKI Well-Known URIs Additions' }
 
+
+
 ##  DNS Service Names
 
 IANA has registered the following service names:
@@ -2283,6 +2340,9 @@ IANA has registered the following service names:
 **Contact:** IESG <iesg@ietf.org><br>
 **Description:** The Bootstrapping Remote Secure Key Infrastructure Pledge<br>
 **Reference:** [THISRFC]
+
+
+
 
 # Privacy Considerations
 
@@ -2311,6 +2371,8 @@ Depending on the requests and responses, the following information is disclosed.
 * the Status data of the device could reveal information about the current state of the device in the domain network.
 
 
+
+
 # Security Considerations {#sec_cons}
 
 In general, the security considerations of {{!RFC8995}} apply for BRSKI-PRM also.
@@ -2319,6 +2381,7 @@ Further security aspects are considered here related to:
 * the introduction of the additional component Registrar-Agent
 * the reversal of the pledge communication direction (push mode, compared to BRSKI)
 * no transport layer security between Registrar-Agent and pledge
+
 
 
 ## Denial of Service (DoS) Attack on Pledge {#sec_cons-dos}
@@ -2346,6 +2409,7 @@ Moreover, the domain registrar verifies if the Registrar-Agent is authorized to 
 Misbinding of a pledge by a faked domain registrar is countered as described in BRSKI security considerations {{Section 11.4 of !RFC8995}}.
 
 
+
 ## Misuse of Registrar-Agent Credentials {#sec_cons_reg-agt}
 
 Concerns of misusage of a Registrar-Agent with a valid EE (RegAgt) certificate may be addressed by utilizing short-lived certificates (e.g., valid for a day) to authenticate the Registrar-Agent against the domain registrar.
@@ -2359,6 +2423,7 @@ To address this, the registrar SHOULD verify the certificate used to create the 
 Furthermore the registrar also verifies the EE (RegAgt) certificate used in the TLS handshake with the Registrar-Agent. If both certificates are verified successfully, the Registrar-Agent's signature can be considered as valid.
 
 
+
 ## Misuse of DNS-SD with mDNS to obtain list of pledges {#sec_cons_mDNS}
 
 To discover a specific pledge a Registrar-Agent may request the service name in combination with the product-serial-number of a specific pledge.
@@ -2368,6 +2433,7 @@ If the Registrar-Agent performs DNS-based Service Discovery without a specific p
 This functionality enumerates and reveals the information of devices available in the domain.
 The information about this is provided here as a feature to support the commissioning of devices.
 A manufacturer may decide to support this feature only for devices not possessing a LDevID or to not support this feature at all, to avoid an enumeration in an operative domain.
+
 
 
 ## YANG Module Security Considerations
@@ -2383,6 +2449,8 @@ new and distinct from the traditional use of YANG to define an API accessed by n
 For this reason, these guidelines do not follow the template described by {{Section 3.7 of ?RFC8407}} (Security Considerations).
 
 
+
+
 # Acknowledgments
 
 We would like to thank the various reviewers, in particular Brian E. Carpenter, Charlie Kaufman (Early SECDIR review), Martin Björklund (Early YANGDOCTORS review), Marco Tiloca (Early IOTDIR review), Oskar Camenzind, Hendrik Brockhaus, and Ingo Wenda for their input and discussion on use cases and call flows.
@@ -2391,11 +2459,17 @@ Special thanks to Esko Dijk for the in deep review and the improving proposals.
 Support in PoC implementations and comments resulting from the implementation was provided by Hong Rui Li and He Peng Jia.
 
 
+
+
 --- back
+
+
+
 
 # Examples {#examples}
 
 These examples are folded according to {{RFC8792}} Single Backslash rule.
+
 
 
 ## Example Pledge Voucher-Request (PVR) - from Pledge to Registrar-Agent

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -536,9 +536,6 @@ In a similar fashion, the pledge MUST accept the Registrar-Agent EE certificate 
 See also {{Section 5 of !RFC8995}} on "provisional state".
 
 For agent-proximity, the EE certificate of the Registrar-Agent MUST be an LDevID certificate signed by the domain owner.
-TODO[always in agent-signed-data] Further, the Registrar-Agent MUST include its LDevID certificate in the PVR trigger message and, in turn, the pledge MUST include it in the Pledge Voucher Request (PVR).
-TODO[no other field, right?] The corresponding fields are defined in {{tpvr}}.
-
 Akin to the proximity assertion in the BRSKI case, the agent-proximity provides pledge proximity evidence to the MASA.
 But additionally, agent-proximity allows the domain registrar to be sure that the PVR collected by the Registrar-Agent was in fact collected by the Registrar-Agent, to which the registrar is connected to.
 

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -1141,27 +1141,14 @@ The Pledge Enroll-Request (PER) artifact is a JWS-signed PKCS#10 Certificate Sig
 The CSR already assures POP of the private key corresponding to the contained public key.
 In addition, based on the PER signature using the IDevID, POI is provided.
 
-TODO: What is the next paragraph saying? That PRM could also just use a plain PKCS#10? That it could use some other enrollment protocol? That CMP is also okay?
-
-Depending on the capability of the pledge, it constructs the Pledge Enroll-Request (PER) as plain PKCS#10.
-Note, the focus in this use case is placed on PKCS#10, as PKCS#10 can be transmitted in different enrollment protocols in the infrastructure like EST, CMP, CMS, and SCEP.
-If the pledge has already implemented an enrollment protocol, it may leverage that functionality for the creation of the CSR.
+The pledge constructs the Pledge Enroll-Request (PER) artifact as a JWS structure containing the PKCS#10 request wrapped in ietf-ztp-types YANG structrue as JWS payload.
 Note, {{!I-D.ietf-netconf-sztp-csr}} also allows for inclusion of certification requests in different formats used by CMP or CMC.
 
-The pledge MUST construct the PER as PKCS#10.
-In BRSKI-PRM it MUST sign it additionally with its IDevID credentials to provide proof-of-identity bound to the PKCS#10 as described below.
+The pledge MUST construct the PER as PKCS#10 and MUST sign it additionally with its IDevID credentials to provide proof-of-identity bound to the PKCS#10 as described below.
 
-TODO: Why is the following information given here?
-
-A successful enrollment will result in a generic LDevID certificate for the pledge in the new domain, which can be used to request further (application specific) LDevID certificates if necessary for operation.
-The Registrar-Agent SHALL use the endpoints specified in this document.
-
-TODO: What endpointS? My guess would be use ./tper with a request body to do specific cert enrollment, yes?
-
-TODO: Why is the confusing information even repeated? It does not clarify anything.
-
-{{I-D.ietf-netconf-sztp-csr}} considers PKCS#10 but also CMP and CMC as certification request format.
-Note that the wrapping of the PER signature is only necessary for plain PKCS#10 as other request formats like CMP and CMS support the signature wrapping as part of their own certificate request format.
+A successful enrollment will result in a generic LDevID certificate for the pledge in the new domain.
+This generic LDevID certificate can be used to request further (application specific) LDevID certificates if necessary for operation.
+The Registrar-Agent SHALL use the enrollment endpoint `requestenroll` specified in this document to provide the Pledge Enroll-Request artifact to the Registrar.
 
 The JWS Protected Header of the PER MUST contain the following parameters as defined in {{RFC7515}}:
 
@@ -1172,10 +1159,7 @@ The JWS Protected Header of the PER MUST contain the following parameters as def
 
 The body of the Pledge Enroll-Request SHOULD contain a P10 parameter (for PKCS#10) as defined for ietf-ztp-types:p10-csr in {{I-D.ietf-netconf-sztp-csr}}:
 
-* `p10`: base64-encoded PKCS#10 of the pledge.
-
-TODO: Confirm lowercase p (not "P10")
-TODO: We contain the full CSR that is already in the payload again in the header?!
+* `p10-csr`: base64-encoded PKCS#10 of the pledge.
 
 The JOSE object is signed using the pledge's IDevID credential, which corresponds to the certificate signaled in the JOSE header.
 
@@ -1196,8 +1180,10 @@ Note that in this case the current LDevID credential is used instead of the IDev
 
 # Example: Decoded Payload "ietf-ztp-types" Representation
   in JSON Syntax
-"ietf-ztp-types": {
-  "p10-csr": "base64encodedvalue=="
+{
+  "ietf-ztp-types": {
+     "p10-csr": "base64encodedvalue=="
+   }
 }
 
 # Example: Decoded "JWS Protected Header" Representation
@@ -1348,17 +1334,19 @@ The object is signed using the registrar LDevID credentials, which corresponds t
 
 # Example: Decoded payload "ietf-voucher-request:voucher"
   representation in JSON syntax
-"ietf-voucher-request:voucher": {
-   "created-on": "2022-01-04T02:37:39.235Z",
-   "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
-   "serial-number": "callee4711",
-   "assertion": "agent-proximity",
-   "prior-signed-voucher-request": "base64encodedvalue==",
-   "agent-sign-cert": [
-     "base64encodedvalue==",
-     "base64encodedvalue==",
-     "..."
-   ]
+{
+  "ietf-voucher-request:voucher": {
+     "created-on": "2022-01-04T02:37:39.235Z",
+     "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
+     "serial-number": "callee4711",
+     "assertion": "agent-proximity",
+     "prior-signed-voucher-request": "base64encodedvalue==",
+     "agent-sign-cert": [
+       "base64encodedvalue==",
+       "base64encodedvalue==",
+       "..."
+     ]
+  }
 }
 
 # Example: Decoded "JWS Protected Header" representation
@@ -1442,12 +1430,14 @@ The voucher is according to {{I-D.ietf-anima-rfc8366bis}} but uses the new asser
 
 # Example: Decoded payload "ietf-voucher:voucher" representation
   in JSON syntax
-"ietf-voucher:voucher": {
-  "assertion": "agent-proximity",
-  "serial-number": "callee4711",
-  "nonce": "base64encodedvalue==",
-  "created-on": "2022-01-04T00:00:02.000Z",
-  "pinned-domain-cert": "base64encodedvalue=="
+{
+  "ietf-voucher:voucher": {
+    "assertion": "agent-proximity",
+    "serial-number": "callee4711",
+    "nonce": "base64encodedvalue==",
+    "created-on": "2022-01-04T00:00:02.000Z",
+    "pinned-domain-cert": "base64encodedvalue=="
+  }
 }
 
 # Example: Decoded "JWS Protected Header" representation
@@ -1511,12 +1501,14 @@ This ensures that the same registrar EE certificate can be used to verify the si
 
 # Example: Decoded payload "ietf-voucher:voucher" representation in
   JSON syntax
-"ietf-voucher:voucher": {
-   "assertion": "agent-proximity",
-   "serial-number": "callee4711",
-   "nonce": "base64encodedvalue==",
-   "created-on": "2022-01-04T00:00:02.000Z",
-   "pinned-domain-cert": "base64encodedvalue=="
+{
+  "ietf-voucher:voucher": {
+     "assertion": "agent-proximity",
+     "serial-number": "callee4711",
+     "nonce": "base64encodedvalue==",
+     "created-on": "2022-01-04T00:00:02.000Z",
+     "pinned-domain-cert": "base64encodedvalue=="
+  }
 }
 
 # Example: Decoded "JWS Protected Header (MASA)" representation
@@ -1897,10 +1889,10 @@ The verification comprises the following steps the pledge MUST perform. Maintain
 1. Check content-type of the CA certificates message. If no Content-Type is contained in the HTTP header, the default Content-Type utilized in this document (JSON-in-JWS) is used. If the Content-Type of the response is in an unknown or unsupported format, the pledge SHOULD reply with a 415 Unsupported media type error code.
 2. Check the encoding of the payload. If the pledge detects errors in the encoding of the payload, it SHOULD reply with 400 Bad Request error code.
 3. Verify that the wrapped CA certificate object is signed using the registrar certificate against the pinned-domain certificate. This MAY be done by comparing the hash that is indicating the certificate used to sign the message is that of the pinned-domain certificate. If the validation against the pinned domain-certificate fails, the client SHOULD reply with a 401 Unauthorized error code. It signals that the authentication has failed and therefore the object was not accepted.
-4. Verify signature of the the received wrapped CA certificate object [TODO: against what?]. If the validation of the signature fails, the pledge SHOULD reply with a TODO [406 Not Acceptable --> 409 Conflict? 422 Unprocessable Content?; Acceptable code is for Accept header]. It signals that the object has not been TODO accepted.
-5. If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of [RFC7030].
+4. Verify signature of the received wrapped CA certificate object using the domain certificate contained in the voucher. If the validation of the signature fails, the pledge SHOULD reply with a 406 Not Acceptable. It signals that the object could not be verified and has not been accepted.
+5. If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of {{RFC7030}}.
 
-TODO: Not clear what the success response code and what the response payload should be. Figure illustrates sending back the same certs, which does not make sense.
+In case of success, the pledge SHOULD reply with 200 OK.
 
 
 
@@ -1930,8 +1922,6 @@ The following subsections describe the corresponding artifacts.
 ### Request Artifact: Enroll-Response (Enroll-Resp)
 
 The Registrar-Agent SHALL send the Enroll-Response to the pledge by HTTP(S) POST to the endpoint: "/.well-known/brski/ser".
-
-TODO: Confirm "opt. TLS", which was missing.
 
 The Content-Type header when using EST {{RFC7030}} as enrollment protocol between the Registrar-Agent and the infrastructure is `application/pkcs7-mime`.
 Note: It only contains the LDevID certificate for the pledge, not the certificate chain.

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -742,7 +742,7 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
    |----- PER ----->|                 |              |            |
    |                |                 |              |            |
    ~                ~                 ~              ~            ~
-   (3) Request PVR to Registrar incl. backend interaction
+   (3) Supply PVR to Registrar (including backend interaction)
    ~                ~                 ~              ~            ~
    |                |                 |              |            |
    |                |<---- mTLS ----->|              |            |
@@ -760,7 +760,7 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
    |                |<--- Voucher ----|              |            |
    |                |                 |              |            |
    ~                ~                 ~              ~            ~
-   (4) Supply PER to Registrar incl. backend interaction
+   (4) Supply PER to Registrar (including backend interaction)
    ~                ~                 ~              ~            ~
    |                |                 |              |            |
    |                |<---- mTLS ----->|              |            |
@@ -1142,7 +1142,7 @@ This allows bulk bootstrapping of several pledges using the same connection betw
 
 
 
-## Request Voucher from the Registrar {#pvr}
+## Supply Voucher Request to Registrar (including backend interaction) {#pvr}
 
 Similar to BRSKI "requestvoucher" endpoint in {{Section 5.2 of !RFC8995}}.
 
@@ -1462,7 +1462,7 @@ If the validation succeeds, the registrar performs pledge authorization accordin
 
 
 
-## Supply PER to Registrar {#per}
+## Supply PER to Registrar (including backend interaction) {#per}
 
 After receiving the voucher, the Registrar-Agent sends the PER to the registrar in the same HTTP-over-TLS connection. Which is similar to the PER processing described in {{Section 5.2 of !RFC8995}}.
 In case the PER cannot be send in the same HTTP-over-TLS connection the Registrar-Agent may send the PER in a new HTTP-over-TLS connection. The registrar is able to correlate the PVR and the PER based on the signatures and the contained product-serial-number information.
@@ -1610,7 +1610,7 @@ If all steps stated above have been performed successfully, the pledge SHALL ter
 If an error occurs during the verification and validation of the voucher, this SHALL be reported in the reason field of the pledge voucher status.
 
 
-### Response Artifact: vStatus
+### Response Artifact: Voucher Status (vStatus)
 
 After voucher verification and validation the pledge MUST reply with a status telemetry message as defined in {{Section 5.7 of !RFC8995}}.
 The pledge generates the voucher-status and provides it as signed JSON-in-JWS object in response to the Registrar-Agent.
@@ -1706,7 +1706,7 @@ Upon reception, the pledge SHALL verify the received LDevID certificate.
 The pledge SHALL generate the enroll status and provide it in the response to the Registrar-Agent.
 If the verification of the LDevID certificate succeeds, the status property SHALL be set to "status": true, otherwise to "status": false
 
-### Response Artifact: eStatus
+### Response Artifact: Enroll Status (eStatus)
 
 After enrollment processing the pledge MUST reply with a enrollment status telemetry message as defined in {{Section 5.9.4 of !RFC8995}}.
 The enroll-status is also a signed object in BRSKI-PRM and results in form of JSON-in-JWS here.
@@ -1818,7 +1818,7 @@ This status indicates if the pledge could process the voucher successfully or no
 
 In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in {{pvr}}.
 
-### Request Artifact: vStatus
+### Request Artifact: Voucher Status (vStatus)
 
 The Registrar-Agent sends the pledge voucher status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/voucher_status". The Content-Type header is kept as `application/jose+json` as depicted in the example in {{vstat}}.
 
@@ -1843,7 +1843,7 @@ The registrar SHOULD proceed with collecting and logging status information by r
 The Registrar-Agent MUST provide the pledge's enroll status to the registrar.
 The status indicates the pledge could process the Enroll-Response (certificate) and holds the corresponding private key.
 
-### Request Artifact: eStatus
+### Request Artifact: Enroll Status (eStatus)
 
 The Registrar-Agent sends the pledge enroll status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/enrollstatus".
 The Content-Type header is kept as `application/jose+json` as depicted in the example in {{estat}}.
@@ -1884,7 +1884,7 @@ The pledge MAY provide a dedicated endpoint to accept status-requests.
 ~~~~
 {: #exchangesfig_uc2_5 title='Pledge-status handling between Registrar-Agent and pledge' artwork-align="left"}
 
-### Request Artifact: pStatus-Req
+### Request Artifact: Pledge Status Request (pStatus-Req)
 
 The Registrar-Agent requests the pledge-status via HTTP POST on the defined pledge endpoint: "/.well-known/brski/qps"
 
@@ -1951,7 +1951,7 @@ This is out of scope for this specification.
 {: #stat_req title='Example of Registrar-Agent request of pledge-status using status-type bootstrap' artwork-align="left"}
 
 
-### Response Artifact: pStatus-Resp
+### Response Artifact: Pledge Status Response (pStatus-Resp)
 
 If the pledge receives the pledge-status request with status-type "bootstrap" it SHALL react with a status response message based on previously collected telemetry information (see {{vstatus}} and {{estatus}}) in a single status-response artifact.
 

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -2864,8 +2864,7 @@ From IETF draft-ietf-anima-brski-async-enroll-03 -> IETF anima-brski-prm-00:
   the description and references to UC1.
 
 * Addressed feedback for voucher-request enhancements from YANG doctor
-  early review in {{voucher-request-prm-yang}} as well as in the
-  security considerations (formerly named ietf-async-voucher-request).
+  early review, meanwhile moved to {{I-D.ietf-anima-rfc8366bis}} as well as in the security considerations (formerly named ietf-async-voucher-request).
 
 * Renamed ietf-async-voucher-request to IETF-voucher-request-prm to
   to allow better listing of voucher related extensions; aligned with

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -61,18 +61,20 @@ contributor:
 - name: Toerless Eckert
   org: Futurewei
   email: tte@cs.fau.de
-- name: Matthias Kovatsch
+- ins: M. Kovatsch
+  name: Matthias Kovatsch
+  org: Siemens Schweiz AG
   email: ietf@kovatsch.net
 venue:
   group: ANIMA
   anima mail: {anima@ietf.org}
   github: anima-wg/anima-brski-prm
 normative:
+  RFC2986:
   RFC6762:
   RFC6763:
   RFC7030:
   RFC7515:
-  RFC8040:
   RFC8366:
   RFC8610:
   RFC8615:
@@ -82,17 +84,16 @@ normative:
   I-D.ietf-netconf-sztp-csr:
   I-D.ietf-anima-rfc8366bis:
 informative:
-  RFC2986:
+  RFC3629:
   RFC5272:
-  RFC6125:
+  RFC9525:
   RFC6241:
   RFC7252:
-  RFC8152:
+  RFC8040:
   RFC8407:
   RFC8792:
   RFC8990:
   RFC9052:
-  RFC9053:
   RFC9110:
   RFC9238:
   I-D.ietf-anima-brski-ae:
@@ -104,7 +105,7 @@ informative:
     - org: Institute of Electrical and Electronics Engineers
     date: 2018-06
     seriesinfo:
-      IEEE: '802.1AR '
+      IEEE: '802.1AR'
   BRSKI-PRM-abstract:
     title: 'Abstract BRSKI-PRM Protocol Overview'
     date: March 2022
@@ -139,25 +140,24 @@ The approach defined here is agnostic to the enrollment protocol that connects t
 
 # Introduction
 
-BRSKI as defined in {{RFC8995}} specifies a solution for secure zero-touch (automated) bootstrapping of devices (pledges) in a (customer site) domain.
+BRSKI as defined in {{!RFC8995}} specifies a solution for secure zero-touch (automated) bootstrapping of devices (pledges) in a customer domain, which may be associated to a specific installation location.
 This includes the discovery of the BRSKI registrar in the customer domain and the exchange of security information necessary to establish trust between a pledge and the domain.
 
-Security information about the customer domain, specifically the customer domain certificate, are exchanged and authenticated utilizing voucher-request and voucher-response artifacts as defined in {{RFC8995}}.
-Vouchers are signed objects from the Manufacturer's Authorized Signing Authority (MASA).
+Security information about the customer domain, specifically the customer domain certificate, are exchanged and authenticated utilizing voucher-request and voucher-response artifacts as defined in {{!RFC8995}}.
+Vouchers are signed objects from the Manufacturer Authorized Signing Authority (MASA).
 The MASA issues the voucher and provides it via the domain registrar to the pledge.
-{{RFC8366}} specifies the format of the voucher artifacts.
-{{I-D.ietf-anima-rfc8366bis}} further enhances the format of the voucher artifacts and also the voucher-request.
+{{I-D.ietf-anima-rfc8366bis}} specifies the format of the voucher artifacts including the voucher-request.
 
-For the certificate enrollment of devices, BRSKI relies on EST {{RFC7030}} to request and distribute customer domain specific device certificates.
+For the certificate enrollment of devices, BRSKI relies on EST {{!RFC7030}} to request and distribute customer domain specific device certificates.
 EST in turn relies for the authentication and authorization of the certification request on the credentials used by the underlying TLS between the EST client and the EST server.
 
 BRSKI addresses scenarios in which the pledge initiates the bootstrapping acting as client (referred to as initiator mode by this document).
-BRSKI with pledge in responder mode (BRSKI-PRM) defined in this document allows the pledge to act as server, so that it can be triggered to generate bootstrapping requests in the customer domain.
+BRSKI with Pledge in Responder Mode (BRSKI-PRM) defined in this document allows the pledge to act as server, so that it can be triggered externally and at a specific time to generate bootstrapping requests in the customer domain.
 For this approach, this document:
 
 * introduces the Registrar-Agent as new component to facilitate the communication between the pledge and the domain registrar.
-The Registrar-Agent may be implemented as an integrated functionality of a commissioning tool or be co-located with the registrar itself.
-BRSKI-PRM supports the identification of the Registrar-Agent that was performing the bootstrapping allowing for accountability of the pledges installation, when the Registrar-Agent is a component used by an installer and not co-located with the registrar.
+  The Registrar-Agent may be implemented as an integrated functionality of a commissioning tool or be co-located with the domain registrar itself.
+  BRSKI-PRM supports the identification of the Registrar-Agent that was performing the bootstrapping allowing for accountability of the pledges installation, when the Registrar-Agent is a component used by an installer and not co-located with the domain registrar.
 
 * specifies the interaction (data exchange and data objects) between a pledge acting as server, the Registrar-Agent acting as client, and the domain registrar.
 
@@ -167,31 +167,31 @@ BRSKI-PRM supports the identification of the Registrar-Agent that was performing
 
 The term endpoint used in the context of this document is equivalent to resource in HTTP {{RFC9110}} and CoAP {{RFC7252}}; it is not used to describe a device.
 Endpoints are accessible via Well-Known URIs {{RFC8615}}.
-For the interaction with the domain registrar, the Registrar-Agent will use existing BRSKI {{RFC8995}} endpoints as well as additional endpoints defined in this document.
+For the interaction with the domain registrar, the Registrar-Agent will use existing BRSKI {{!RFC8995}} endpoints as well as additional endpoints defined in this document.
 To utilize the EST server endpoints on the domain registrar, the Registrar-Agent will act as client toward the registrar.
 
-The Registrar-Agent also acts as a client when communicating with a pledge in responder mode.
+The Registrar-Agent also acts as a client when communicating with a pledge that is in responder mode.
 Here, TLS with server-side, certificate-based authentication is only optionally supported.
-If TLS is optionally used between the Registrar-Agent and the pledge, the Registrar-Agent needs to identify the pledge based on its product-serial-number rather than the hostname as this is not set in an IDevID certificate.
+If TLS is optionally used between the Registrar-Agent and the pledge, the Registrar-Agent needs to identify the pledge based on its product-serial-number rather than the hostname, as the latter is not set in an IDevID certificate.
 
 BRSKI-PRM is designed to rely on object security to support also for alternative transports for which TLS may not be available, e.g., Bluetooth or NFC.
 This is achieved through an additional signature wrapping of the exchanged data objects involving the Registrar-Agent for transport.
 
-To utilize EST {{RFC7030}} for enrollment, the domain registrar must perform the pre-processing of this wrapping signature before actually using EST as defined in {{RFC7030}}.
+To utilize EST {{!RFC7030}} for enrollment, the domain registrar performs pre-processing of the wrapping signature before actually using EST as defined in {{!RFC7030}}.
 
-There may be pledges which can support both modes, initiator and responder mode.
-In these cases BRSKI-PRM can be combined with BRSKI as defined in {{RFC8995}} or BRSKI-AE {{I-D.ietf-anima-brski-ae}} to allow for more bootstrapping flexibility.
+There may be pledges that can support both modes, initiator and responder mode.
+In these cases BRSKI-PRM can be combined with BRSKI as defined in {{!RFC8995}} or BRSKI-AE {{I-D.ietf-anima-brski-ae}} to allow for more bootstrapping flexibility.
 
 
 # Terminology
 
 {::boilerplate bcp14-tagged}
 
-This document relies on the terminology defined in {{RFC8995}}, section 1.2.
-The following terms are defined additionally:
+This document relies on the terminology defined in {{Section 1.2 of !RFC8995}}.
+The following terms are defined in addition:
 
 authenticated self-contained object:
-: Describes an object, which is cryptographically bound to the end entity (EE) certificate (IDevID certificate or LDEVID certificate).
+: Describes an object, which is cryptographically bound to the end entity (EE) certificate.
   The binding is assumed to be provided through a digital signature of the actual object using the corresponding private key of the certificate.
 
 CA:
@@ -204,53 +204,53 @@ CSR:
 : Certificate Signing Request.
 
 EE:
-: End Entity.
+: End entity.
+
+EE certificate:
+: Either IDevID certificate or LDevID certificate of the EE.
 
 endpoint:
-: term equivalent to resource in HTTP {{RFC9110}} and CoAP {{RFC7252}}.
-Endpoints are accessible via .well-known URIs.
+: Term equivalent to resource in HTTP {{RFC9110}} and CoAP {{RFC7252}}.
+  Endpoints are accessible via Well-Known URIs {{RFC8615}}.
 
 mTLS:
 : mutual Transport Layer Security.
 
-on-site:
-: Describes a component or service or functionality available in the customer domain.
-
-off-site:
-: Describes a component or service or functionality not available on-site.
-It may be at a central site or an internet resident "cloud" service.
-The on-site to off-site connection may also be temporary and, e.g., only available at times when workers are present on a construction side, for instance.
-
 PER:
-: Pledge-Enrollment-Request is a signature wrapped CSR, signed by the pledge that requests enrollment to a domain.
-
-POP:
-: Proof-of-Possession (of a private key), as defined in {{RFC5272}}.
+: Pledge Enroll-Request is a signature wrapped CSR, signed by the pledge that requests enrollment to a domain.
 
 POI:
 : Proof-of-Identity, as defined in {{RFC5272}}.
 
+POP:
+: Proof-of-Possession (of a private key), as defined in {{RFC5272}}.
+
 PVR:
-: Pledge-Voucher-Request is a request for a voucher sent to the domain registrar.
+: Pledge Voucher-Request is a request for a voucher sent to the domain registrar.
 The PVR is signed by the Pledge.
 
 RA:
 : Registration Authority, an optional system component to which a CA delegates certificate management functions such as authorization checks.
-In BRSKI-PRM this is a functionality of the domain registrar, as in BRSKI {{RFC8995}}.
+In BRSKI-PRM this is a functionality of the domain registrar, as in BRSKI {{!RFC8995}}.
 
 RER:
-: Registrar-Enrollment-Request is the CSR of a PER sent to the CA by the domain registrar (in its role as PKI RA).
+: Registrar Enroll-Request is the CSR of a PER sent to the CA by the domain registrar (in its role as PKI RA).
 
 RVR:
-: Registrar-Voucher-Request is a request for a voucher signed by the domain registrar to the MASA.
+: Registrar Voucher-Request is a request for a voucher signed by the domain registrar to the MASA.
 It may contain the PVR received from the pledge.
 
-This document includes many examples that would contain many long sequences of base64 encoded objects with no content directly comprehensible to a human reader.
+This document uses the following encoding notations in the given JWS Voucher {{!I-D.ietf-anima-jws-voucher}} examples:
+
+BASE64URL(OCTETS):
+: Denotes the base64url encoding of OCTETS, per {{Section 2 of !RFC7515}}.
+
+UTF8(STRING):
+: Denotes the octets of the UTF-8 {{?RFC3629}} representation of STRING, per {{Section 1 of !RFC7515}}.
+
+This document includes many examples that would contain many long sequences of base64-encoded objects with no content directly comprehensible to a human reader.
 In order to keep those examples short, they use the token "base64encodedvalue==" as a placeholder for base64 data.
 The full base64 data is included in the appendices of this document.
-
-This protocol unavoidably has a mix of both base64 encoded data (as is normal for many JSON encoded protocols), and also BASE64URL encoded data, as specified by JWS.
-The latter is indicated by a string like "BASE64URL(content-name)".
 
 
 # Scope of Solution
@@ -311,7 +311,7 @@ Based on the intended target environment described in {{sup-env}}, the following
   This requires the definition of pledge endpoints to allow interaction with the Registrar-Agent.
 
 * The security of communication between the Registrar-Agent and the pledge must not rely on Transport Layer Security (TLS) to enable application of BRSKI-PRM in environments, in which the communication between the Registrar-Agent and the pledge is done over other technologies like BTLE or NFC, which may not support TLS protected communication.
-  In addition, the pledge does not have a certificate that can easily be verified by {{RFC6125}} methods.
+  In addition, the pledge does not have a certificate that can easily be verified by {{?RFC9525}} methods.
 
 * The use of authenticated self-contained objects addresses both, the TLS challenges and the technology stack challenge.
 
@@ -319,21 +319,21 @@ Based on the intended target environment described in {{sup-env}}, the following
   In addition the registrar must be able to verify, which Registrar-Agent was in direct contact with the pledge.
 
 * It would be inaccurate for the voucher-request and voucher-response to use an assertion with value "proximity" in the voucher, as the pledge was not in direct contact with the registrar for bootstrapping.
-  Therefore, a new "agent-proximity" assertion value is necessary for distinguishing assertions the MASA can state.
+  Therefore, a new Agent-Proximity Assertion value {#agt_prx} is necessary for distinguishing assertions the MASA can state.
 
 At least the following properties are required for the voucher and enrollment processing:
 
-* POI: provides data-origin authentication of a data object, e.g., a voucher-request or an enrollment-request, utilizing an existing IDevID.
+* POI: provides data-origin authentication of a data object, e.g., a voucher-request or an Enroll-Request, utilizing an existing IDevID.
   Certificate updates may utilize the certificate that is to be updated.
 
 * POP: proves that an entity possesses and controls the private key corresponding to the public key contained in the certification request, typically by adding a signature computed using the private key to the certification request.
 
 Solution examples based on existing technology are provided with the focus on existing IETF RFCs:
 
-* Voucher-requests and -responses as used in {{RFC8995}} already provide both, POP and POI, through a digital signature to protect the integrity of the voucher, while the corresponding signing certificate contains the identity of the signer.
+* Voucher-requests and -responses as used in {{!RFC8995}} already provide both, POP and POI, through a digital signature to protect the integrity of the voucher, while the corresponding signing certificate contains the identity of the signer.
 
 * Certification requests are data structures containing the information from a requester for a CA to create a certificate.
-  The certification request format in BRSKI is PKCS#10 {{RFC2986}}.
+  The certification request format in BRSKI is PKCS#10 {{!RFC2986}}.
   In PKCS#10, the structure is signed to ensure integrity protection and POP of the private key of the requester that corresponds to the contained public key.
   In the application examples, this POP alone is not sufficient.
   A POI is also required for the certification request and therefore the certification request needs to be additionally bound to the existing credential of the pledge (IDevID).
@@ -345,12 +345,12 @@ Solution examples based on existing technology are provided with the focus on ex
 
 ## Overview
 
-For BRSKI with pledge in responder mode, the base system architecture defined in BRSKI {{RFC8995}} is enhanced to facilitate new use cases in which the pledge acts as server.
+For BRSKI with Pledge in Responder Mode (BRSKI-PRM), the base system architecture defined in BRSKI {{!RFC8995}} is enhanced to facilitate new use cases in which the pledge acts as server.
 The responder mode allows delegated bootstrapping using a Registrar-Agent instead of a direct connection between the pledge and the domain registrar.
 
 Necessary enhancements to support authenticated self-contained objects for certificate enrollment are kept at a minimum to enable reuse of already defined architecture elements and interactions.
-The format of the bootstrapping objects produced or consumed by the pledge is based on JOSE {{RFC7515}} and further specified in {{exchanges_uc2}} to address the requirements stated in {{req-sol}} above.
-In constrained environments it may be provided based on COSE {{RFC9052}} and {{RFC9053}}.
+The format of the bootstrapping objects produced or consumed by the pledge is usually based on JSON Web Signature (JWS) {{!RFC7515}} and further specified in {{exchanges_uc2}} to address the requirements stated in {{req-sol}} above.
+In constrained environments, it may be based on COSE {{?RFC9052}}.
 
 An abstract overview of the BRSKI-PRM protocol can be found on slide 8 of {{BRSKI-PRM-abstract}}.
 
@@ -358,12 +358,12 @@ To support mutual trust establishment between the domain registrar and pledges n
 
 This leads to extensions of the logical components in the BRSKI architecture as shown in {{uc2figure}}.
 
-Note that the Join Proxy is not shown in the figure, having been replaced by Registrar-Agent.
+Note that the Join Proxy is not shown in the figure.
 In certain situations the Join Proxy may still be present and could be used by the Registrar-Agent to connect to the Registrar.
-For example, a Registrar-Agent application on a smartphone often can connect to local wifi without giving up their LTE connection {{androidnsd}}, but only can make link-local connections.
+For example, a Registrar-Agent application on a smartphone often can connect to local Wi-Fi without giving up their cellular network connection {{androidnsd}}, but only can make link-local connections.
 
 The Registrar-Agent interacts with the pledge to transfer the required data objects for bootstrapping, which are then also exchanged between the Registrar-Agent and the domain registrar.
-The addition of the Registrar-Agent influences the sequences of the data exchange between the pledge and the domain registrar described in {{RFC8995}}.
+The addition of the Registrar-Agent influences the sequences of the data exchange between the pledge and the domain registrar described in {{!RFC8995}}.
 To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:
 
 * uses existing endpoints where the required functionality is provided.
@@ -372,7 +372,7 @@ To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:
 
 ~~~~ aasvg
                          +---------------------------+
-    ..... Drop Ship .....| Vendor Service            |
+    ..... Drop Ship .....| Vendor Services           |
     :                    +---------------+-----------+
     :                    | M anufacturer |           |
     :                    | A uthorized   | Ownership |
@@ -389,7 +389,7 @@ To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:
 | Pledge | BRSKI- | Registrar- | BRSKI- | Domain    |  .
 |        |  PRM   | Agent      |  PRM   | Registrar |  .
 |        |<------>|            |<------>| (PKI RA)  |  .
-|        |     .  |     LDevID |        |           |  .
+|        |     .  |    EE cert |        |           |  .
 |        |     .  +------------+        +-----+-----+  .
 | IDevID |     .                              |        .
 |        |     .           +------------------+-----+  .
@@ -397,61 +397,55 @@ To enable reuse of BRSKI defined functionality as much as possible, BRSKI-PRM:
                .           | (e.g., PKI CA)         |  .
                .           +------------------------+  .
                .........................................
-                         "Domain" Components
+                            Customer Domain
 ~~~~
 {: #uc2figure title='BRSKI-PRM architecture overview using Registrar-Agent' artwork-align="left"}
 
 {{uc2figure}} shows the relations between the following main components:
 
-* Pledge: The pledge is expected to respond with the necessary data objects for bootstrapping to the Registrar-Agent.
+* Pledge: Is expected to respond with the necessary data objects for bootstrapping to the Registrar-Agent.
   The protocol used between the pledge and the Registrar-Agent is assumed to be HTTP in the context of this document.
   Any other protocols (including HTTPS) can be used as long as they support the exchange of the necessary data objects.
   This includes CoAP or protocol to be used over Bluetooth or NFC connections
-  A pledge acting as a server during bootstrapping leads to some differences for BRSKI:
-
-  * Discovery of the pledge by the Registrar-Agent MUST be possible.
-
-  * As the Registrar-Agent MUST be able to request data objects for bootstrapping of the pledge, the pledge MUST offer corresponding endpoints as defined in {{pledge_ep}}.
-
-  * The Registrar-Agent MUST provide additional data to the pledge in the context of the voucher-request trigger, which the pledge MUST include into the PVR as defined in {{pvrt}} and {{pvrr}}.
+  A pledge acting as a server during bootstrapping leads to the following differences compared to BRSKI:
+  
+  * The pledge is discovered by the Registrar-Agent as defined in {#discovery_uc2_ppa}.
+  * The pledge offers additional endpoints as defined in {{pledge_ep}}, so that the Registrar-Agent can request data required for bootstrapping the pledge.
+  * The pledge includes additional data in the PVR, which is provided by the Registrar-Agent in the voucher-request trigger as defined in {{tpvr}}.
     This allows the registrar to identify, with which Registrar-Agent the pledge was in contact.
-
-  * The order of exchanges in the BRSKI-PRM call flow is different those in BRSKI {{RFC8995}}, as the PVR and PER are collected at once and provided to the registrar.
+  * The order of exchanges in the BRSKI-PRM call flow is different from those in BRSKI {{!RFC8995}}, as the PVR and PER are collected simultaneously and provided to the registrar.
     This enables bulk bootstrapping of several devices.
-
   * The data objects utilized for the data exchange between the pledge and the registrar are self-contained authenticated objects (signature-wrapped objects).
 
-* Registrar-Agent: provides a store and forward communication path to exchange data objects between the pledge and the domain registrar.
+* Registrar-Agent: Provides a store and forward communication path to exchange data objects between the pledge and the domain registrar.
   The Registrar-Agent acts as a broker in situations in which the domain registrar is not directly reachable by the pledge.
   This may be due to a different technology stack or due to missing connectivity.
-  The Registrar-Agent triggers a pledge to create bootstrapping artifacts such as the voucher-request and the enrollment-request on one or multiple pledges.
-  It can then perform a (bulk) bootstrapping based on the collected data.
-  The Registrar-Agent is expected to possess information about the domain registrar: the registrar EE certificate, LDevID(CA) certificate, IP address, either by configuration or by using the discovery mechanism defined in {{RFC8995}}.
-  There is no trust assumption between the pledge and the Registrar-Agent as only authenticated self-contained objects are used, which are transported via the Registrar-Agent and provided either by the pledge or the registrar.
-  The trust assumption between the Registrar-Agent and the registrar is based on the LDevID of the Registrar-Agent, provided by the PKI responsible for the domain.
-  This allows the Registrar-Agent to authenticate towards the registrar, e.g., in a TLS handshake.
-  Based on this, the registrar is able to distinguish a pledge from a Registrar-Agent during the TLS session establishment and also to verify that this Registrar-Agent is authorized to perform the bootstrapping of the distinct pledge.
-  The Registrar-Agent may be realized as stand-alone component supporting nomadic activities of a service technician moving between different installation sites.
-  Contrary, the Registrar-Agent may also be realized as co-located functionality for a registrar, to support pledges in pledge-responder-mode.
 
-* Join Proxy (not shown): same functionality as described in {{RFC8995}} if needed.
-  Note that a Registrar-Agent may use a join proxy to facilitate the TLS connection to the registrar, in the same way that a BRSKI pledge would use a join proxy. This is useful in cases where the Registrar-Agent does not have full IP connectivity via the domain network, or cases where it has no other means to locate the registrar on the network.
+  * The Registrar-Agent triggers one or more pledges to create bootstrapping artifacts such as the voucher-request and the Enroll-Request.
+    It can then perform a (bulk) bootstrapping based on the collected data.
+  * The Registrar-Agent is expected to possess information about the domain registrar: the registrar EE certificate, LDevID(CA) certificate, and IP address, either by configuration or by using the discovery mechanism defined in {{!RFC8995}}.
+  * There is no trust assumption between the pledge and the Registrar-Agent as only authenticated self-contained objects are used, which are transported via the Registrar-Agent and provided either by the pledge or the domain registrar.
+  * The trust assumption between the Registrar-Agent and the domain registrar may be based on an LDevID, which is provided by the PKI responsible for the customer domain.
+  * The Registrar-Agent may be realized as stand-alone component supporting nomadic activities of a service technician moving between different installation sites.
+  * Alternatively, the Registrar-Agent may also be realized as co-located functionality for a registrar, to support pledges in responder mode.
 
-* Domain Registrar: In general, the domain registrar fulfills the same functionality regarding the bootstrapping of the pledge in a (customer site) domain by facilitating the communication of the pledge with the MASA service and the domain PKI service.
-  In contrast to {{RFC8995}}, the domain registrar does not interact with a pledge directly but through the Registrar-Agent.
-  A registrar with combined functionality of BRSKI and BRSKI-PRM detects if the bootstrapping is performed by the pledge directly (BRSKI case) or by the Registrar-Agent (BRSKI-PRM case) based on the utilized credential for authentication (either pledge’s IDevID or LDevID from Registrar-Agent), see also {{exchanges_uc2_2}}.
+* Join Proxy (not shown): Has the same functionality as described in {{!RFC8995}} if needed.
+  Note that a Registrar-Agent may use a join proxy to facilitate the TLS connection to the registrar in the same way that a BRSKI pledge would use a join proxy. This is useful in cases where the Registrar-Agent does not have full IP connectivity via the domain network or cases where it has no other means to locate the registrar on the network.
 
-* The manufacturer provided components/services (MASA and Ownership tracker) are used as defined in {{RFC8995}}.
-  A MASA is able to support enrollment via Registrar-Agent without changes unless it checks the vouchers proximity indication, in which case it would need to be enhanced to support BRSKI-PRM to also accept the agent-proximity.
+* Domain Registrar: In general fulfills the same functionality regarding the bootstrapping of the pledge in a customer domain by facilitating the communication of the pledge with the MASA service and the domain key infrastructure (PKI).
+  In contrast to {{!RFC8995}}, a BRSKI-PRM domain registrar does not interact with a pledge directly, but through the Registrar-Agent.
 
-## Nomadic connectivity {#arch_nomadic}
+* Vendor Services: Encompass MASA and Ownership Tracker and are used as defined in {{!RFC8995}}.
+  A MASA is able to support enrollment via Registrar-Agent without changes unless it checks the vouchers proximity indication, in which case it would need to be enhanced to support BRSKI-PRM to also accept the Agent-Proximity Assertion {#agt_prx}.
+
+## Nomadic Connectivity {#arch_nomadic}
 
 In one example instance of the PRM architecture as shown in {{uc3figure}}, there is no connectivity between the location in which the pledge is installed and the location of the domain registrar.
 This is often the case in the aforementioned building automation use case ({{building-automation}}).
 
 ~~~~ aasvg
                          +---------------------------+
-    ..... Drop Ship .....| Vendor Service            |
+    ..... Drop Ship .....| Vendor Services           |
     :                    +---------------------------+
     :                                         ^
 ........................................      |
@@ -462,8 +456,8 @@ This is often the case in the aforementioned building automation use case ({{bui
 . +--------+ L2 or L3  :-.-.-.-.-.-.-: .      |
 .          connectivity   ^            .      |
 ..........................!.............      |
-   Pledge install         !                   |
-   location               ! Nomadic           |
+   Pledge Installation    !                   |
+   Location               ! Nomadic           |
                           ! connectivity      |
                           !                   |
                ...........!...................|.........
@@ -478,26 +472,26 @@ This is often the case in the aforementioned building automation use case ({{bui
                .           | (e.g., PKI CA)         |  .
                .           +------------------------+  .
                .........................................
-                         "Domain" Components
+                            Customer Domain
 ~~~~
 {: #uc3figure title='Registrar-Agent nomadic connectivity example' artwork-align="left"}
 
 PRM enables support of this case through nomadic connectivity of the Registrar-Agent.
-To perform enrollment in this setup, multiple round trips of the Registrar-Agent between the pledge install location and the domain registrar are required.
+To perform enrollment in this setup, multiple round trips of the Registrar-Agent between the pledge installation location and the domain registrar are required.
 
 1.  Connectivity to domain registrar: preparation tasks for pledge bootstrapping not part of the BRSKI-PRM protocol definition, like retrieval of list of pledges to enroll.
-2.  Connectivity to pledge install location: retrieve information about available pledges (IDevID), collect request objects like voucher-requests and enrollment-requests using the BRSKI-PRM approach described in {{exchanges_uc2_1}}.
-3.  Connectivity to domain registrar, submit collected pledges' request information, retrieve response objects as voucher and enrollment information using the BRSKI-PRM approach described in {{exchanges_uc2_2}}.
-4.  Connectivity to pledge install location, provide retrieved objects to the pledge to enroll pledges and collect status using the BRSKI-PRM approach described in {{exchanges_uc2_3}}.
-5.  Connectivity to domain registrar, submit voucher status and enrollment status using the BRSKI-PRM approach described in {{exchanges_uc2_4}}.
+2.  Connectivity to pledge installation location: retrieve information about available pledges (IDevID), collect request objects (i.e., Pledge Voucher-Requests and Pledge Enroll-Requests using the BRSKI-PRM approach described in {{tpvr}} and {{tper}}.
+3.  Connectivity to domain registrar, submit collected request information of pledges, retrieve response objects (i.e., Voucher and Enroll-Response) using the BRSKI-PRM approach described in {{pvr}} and {{per}}.
+4.  Connectivity to pledge installation location, provide retrieved objects to the pledges to enroll pledges and collect status using the BRSKI-PRM approach described in {{voucher}}, {{cacerts}}, and {{enroll_response}}.
+5.  Connectivity to domain registrar, submit Voucher Status and Enrollment Status using the BRSKI-PRM approach described in {{vstatus}} and {{estatus}}.
 
 Variations of this setup include cases where the Registrar-Agent uses for example WiFi to connect to the pledge installation network, and mobile network connectivity to connect to the domain registrar.
-Both connections may also be possible in a single location at the same time, based on installation building conditions.,
+Both connections may also be possible in a single location at the same time, based on installation building conditions.
 
-## Registrar-Agent co-located with registrar
+## Co-located Registrar-Agent and Domain Registrar
 
-Compared to {{RFC8995}} BRSKI, pledges supporting BRSKI-PRM can be completely passive and only need to react when being requested to react by a Registrar-Agent.
-In {{RFC8995}}, pledges instead need to continuously request enrollment from a domain registrar, which may result in undesirable communications pattern and possible overload of a domain registrar.
+Compared to {{!RFC8995}} BRSKI, pledges supporting BRSKI-PRM can be completely passive and only need to react when being requested to react by a Registrar-Agent.
+In {{!RFC8995}}, pledges instead need to continuously request enrollment from a domain registrar, which may result in undesirable communications pattern and possible overload of a domain registrar.
 
 ~~~~ aasvg
                          +---------------------------+
@@ -508,17 +502,17 @@ In {{RFC8995}}, pledges instead need to continuously request enrollment from a d
     :          ...............................|.........
     :          .                              v        .
     v          .          +-------------------------+  .
- +--------+    .          |..............           |  .
+ +--------+    .          |..............           |  .   
  |        |    .          |. Registrar- . Domain    |  .
  | Pledge |<------------->|. Agent      . Registrar |  .
- +--------+ L2 or L3      |..............           |  .
+ +--------+ L2 or L3      |..............           |  .   
             connectivity  +-------------------+-----+  .
                .                              |        .
                .           +------------------+-----+  .
                .           | Key Infrastructure     |  .
                .           +------------------------+  .
                .........................................
-                         "Domain" Components
+                            Customer Domain
 ~~~~
 {: #uc4figure title='Registrar-Agent integrated into Domain Registrar example' artwork-align="left"}
 
@@ -528,140 +522,117 @@ The benefits of BRSKI-PRM can be achieved even without the operational complexit
 ## Agent-Proximity Assertion {#agt_prx}
 
 "Agent-proximity" is a statement in the PVR and in the voucher, that the registrar certificate was provided via the Registrar-Agent as defined in {{exchanges_uc2}} and not directly to the pledge.
-"Agent-proximity" is therefore a different assertion then "proximity", which is defined in section 4 of {{RFC8366}}.
-"Agent-proximity" is defined as additional assertion type in {{I-D.ietf-anima-rfc8366bis}}.
-This can be verified by the registrar and also by the MASA during the voucher-request processing.
+Agent-proximity is therefore a different assertion than "proximity", which is defined in {{Section 4 of RFC8366}}.
+Agent-proximity is defined as additional assertion type in {{I-D.ietf-anima-rfc8366bis}}.
+This assertion can be verified by the registrar and also by the MASA during the voucher-request processing.
 
 In BRSKI, the pledge verifies POP of the registrar via the TLS handshake and pins that public key as the "proximity-registrar-cert" into the voucher request.
 This allows the MASA to verify the proximity of the pledge and registrar, facilitating a decision to assign the pledge to that domain owner.
 In BRSKI, the TLS connection is considered provisional until the pledge receives the voucher.
 
-In contrast, in BRSKI-PRM, the pledge has no direct connection to the registrar and must take the Registrar-Agent LDevID provisionally.
-The Registrar-Agent has included its LDevID, a certificate signed by the domain owner, into the PVR trigger message.
-The Registrar-Agent identity is therefore included into the Pledge Voucher Request (PVR).
+In contrast, in BRSKI-PRM, the pledge has no direct connection to the registrar and MUST accept the registrar certificate provisionally until it receives the voucher as described in {{voucher}}.
+In a similar fashion, the pledge MUST accept the Registrar-Agent EE certificate provisionally.
+See also {{Section 5 of !RFC8995}} on "provisional state".
 
-Akin to the BRSKI case, the pledge has provided proximity evidence to the MASA.
-But additionally, this allows the Registrar to be sure that the PVR collected by the Registrar-Agent was in fact collected by the Registrar-Agent to which the Registrar is connected to.
+For agent-proximity, the EE certificate of the Registrar-Agent MUST be an LDevID certificate signed by the domain owner.
+TODO[always in agent-signed-data] Further, the Registrar-Agent MUST include its LDevID certificate in the PVR trigger message and, in turn, the pledge MUST include it in the Pledge Voucher Request (PVR).
+TODO[no other field, right?] The corresponding fields are defined in {{tpvr}}.
 
-In a similar fashion, the pledge accepts the registrar certificate provisionally until it receives the voucher as described in {{exchanges_uc2_3}}.
-See also section 5 of {{RFC8995}} on "PROVISIONAL accept of server cert".
+Akin to the proximity assertion in the BRSKI case, the agent-proximity provides pledge proximity evidence to the MASA.
+But additionally, agent-proximity allows the domain registrar to be sure that the PVR collected by the Registrar-Agent was in fact collected by the Registrar-Agent, to which the registrar is connected to.
 
-
-## Behavior of Pledge in Pledge-Responder-Mode {#pledge_ep}
-
-The pledge is triggered by the Registrar-Agent to generate the PVR and PER.
-It will also be triggered for processing of the responses and the generation of status information once the Registrar-Agent has received the responses from the registrar later in the process.
-Due to the use of the Registrar-Agent, the interaction with the domain registrar is changed as shown in {{exchangesfig_uc2_1}}.
-To enable interaction as responder with the Registrar-Agent, the pledge provides endpoints using the BRSKI defined endpoints based on the "/.well-known/brski" URI tree.
-
-When the Registrar-Agent reaches out to a pledge, for instance with an example URI path "http://pledge.example/.well-known/brski/tpvr", it will in fact send a Host: header of "pledge.example", with a relative path of "/.well-known/brski/tpbr".
-However in practice the pledge will often be known only by its IP address as returned by a discovery protocol, and that is what will be present in the Host: header.
-
-The pledge MUST respond to all queries regardless of what Host: header is provided by the client.
-{{?RFC9110, section 7.2}} makes the Host: header mandatory, so it will always be present.
-
-The following operations are defined for the *pledge* in this document, describing their endpoints and their corresponding URIs.
-The endpoints are defined with short names to also accommodate for the constraint case.
-
-
-| Operation                  | Endpoint                   | Details |
-|:---------------------------|:---------------------------|:--------|
-| Trigger pledge-voucher-request creation - Returns PVR| /tpvr| {{exchanges_uc2_1}}  |
-|------------------------
-| Trigger pledge-enrollment-request - Returns PER | /tper | {{exchanges_uc2_1}} |
-|------------------------
-| Supply voucher to pledge - Returns pledge voucher-status | /svr | {{exchanges_uc2_3}} |
-|------------------------
-| Supply enrollment-response to pledge - Returns pledge enrollment-status | /ser | {{exchanges_uc2_3}}   |
-|------------------------
-| Supply CA certs to pledge | /scac | {{exchanges_uc2_3}} |
-|------------------------
-| Query status of pledge - Returns pledge-status  | /qps   | {{exchanges_uc2_5}} |
-|===============
-{: #eppfigure1 title='Endpoints on the pledge' }
-
-
-## Behavior of Registrar-Agent
-
-The Registrar-Agent as a new component provides a message passing service between the pledge and the domain registrar.
-It facilitates the exchange of data between the pledge and the domain registrar, which are the voucher-request/response, the enrollment-request/response, as well as related telemetry and status information.
-
-For the communication with the pledge the Registrar-Agent utilizes communication endpoints provided by the pledge.
-The transport in this specification is based on HTTP but may also be done using other transport mechanisms.
-
-The communication between the Registrar-Agent and the pledge MAY be protected using TLS as outlined in {{exchanges_uc2_1}}.
-The details of doing TLS validation are {{pledgehttps}}.
-
-For the communication with the registrar, the Registrar-Agent uses the endpoints of the domain registrar side already specified in {{RFC8995}} (derived from EST {{RFC7030}}) where suitable.
-These endpoints do not expect signature wrapped-objects, which are used b BRSKI-PRM.
-This specifically applies for the enrollment-request and the provisioning of CA certificates.
-To accommodate the use of signature-wrapped object, the following additional endpoints are defined for the *registrar*.
-Operations and their corresponding URIs:
-
-| Operation                  |Endpoint                    | Details |
-|:---------------------------|:---------------------------|:--------|
-| Supply PER to registrar - Returns enrollment-response | /requestenroll | {{exchanges_uc2_2_per}}  |
-|------------------------
-| Request (wrapped) CA certificates - Returns wrapped CA Certificates | /wrappedcacerts | {{exchanges_uc2_2_wca}} |
-|===============
-{: #eppfigure2 title='Additional endpoints on the registrar' }
-
-For authentication to the domain registrar, the Registrar-Agent uses its EE (RegAgt) certificate.
-The provisioning of the Registrar-Agent LDevID is out of scope for this document, but may be done in advance using a separate BRSKI run or by other means like configuration.
+The provisioning of the Registrar-Agent LDevID certificate is out of scope for this document, but may be done in advance using a separate BRSKI run or by other means like configuration.
 It is recommended to use short lived Registrar-Agent LDevIDs in the range of days or weeks as outlined in {{sec_cons_reg-agt}}.
 
-The Registrar-Agent will use its EE certificate when establishing a TLS session with the domain registrar for TLS client authentication.
-The EE (RegAgt) certificate MUST include a SubjectKeyIdentifier (SKID), which is used as reference in the context of an agent-signed-data object as defined in {{exchanges_uc2_1}}.
-Note that this is an additional requirement for issuing the certificate, as {{IEEE-802.1AR}} only requires the SKID to be included for intermediate CA certificates.
-{{RFC8995}} makes a similar requirement.
-In BRSKI-PRM, the SKID is used in favor of providing the complete EE (RegAgt) certificate to accommodate also constraint environments and reduce bandwidth needed for communication with the pledge.
+
+# System Components
+
+
+## Domain Registrar
+
+In BRSKI-PRM, the domain registrar provides the endpoints already specified in {{!RFC8995}} (derived from EST {{!RFC7030}}) where suitable.
+In addition, it MUST provide the endpoints defined in {{registrar_ep_table}} within the BRSKI-defined "/.well-known/brski/" URI path.
+These endpoints accommodate for the signature-wrapped objects used by BRSKI-PRM for the Pledge Enroll-Request (PER) and the provisioning of CA certificates.
+
+|Endpoint        | Operation                  | Exchange and Artifacts  |
+|:---------------|:---------------------------|:------------------------|
+| requestenroll  | Supply PER to registrar    | {{per}} |
+|------------------------
+| wrappedcacerts | Request CA certificates | {{req_cacerts}} |
+|===============
+{: #registrar_ep_table title='Additional Well-Known Endpoints on a BRSKI-PRM Registrar' }
+
+According to {{Section 5.3 of !RFC8995}}, the domain registrar performs the pledge authorization for bootstrapping within his domain based on the Pledge Voucher-Request.
+This behavior is retained in BRSKI-PRM.
+
+The domain registrar MUST possess and trust the IDevID (root or issuing) CA certificate 
+of the pledge vendor/manufacturer.
+
+Further, the domain registrar MUST have its own EE credentials.
+
+### Domain Registrar with Combined Functionality
+
+A registrar with combined BRSKI and BRSKI-PRM functionality MAY detect if the bootstrapping is performed by the pledge directly (BRSKI case) or by a Registrar-Agent (BRSKI-PRM case) based on the utilized credential for client authentication during the TLS session establishment and switch switch the operational mode from BRSKI to BRSKI-PRM.
+
+This may be supported by a specific naming in the SAN (subject alternative name) component of the EE certificate of the Registrar-Agent.
+
+Alternatively, this may be supported by using an LDevID certificate signed by the domain owner for the client authentication of the Registrar-Agent.
+Using an LDevID certificate also allows the registrar to verify that a Registrar-Agent is authorized to perform the bootstrapping of a pledge.
+See also agent-proximity assertion in {{agt_prx}}.
+
+Using an LDevID certificate for TLS client authentication of the Registrar-Agent is a deviation from {{!RFC8995}}, in which the IDevID credential of the pledge is used to perform TLS client authentication.
+
+
+## Registrar-Agent
+
+The Registrar-Agent is a new component in BRSKI-PRM that provides a secure message passing service between pledges in responder mode and the domain registrar.
+
+It requires the EE certificate of the domain registrar for TLS server authentication when establishing a TLS session with the domain registrar and to provide the registrar EE certificate to the pledge for creating the Pledge Voucher-Request (PVR).
+
+The Registrar-Agent uses its own EE certificate for TLS client authentication when establishing a TLS session with the domain registrar and for signing agent-signed data.
+This EE certificate MUST include a SubjectKeyIdentifier (SKID), which is used as reference in the context of an agent-signed-data object as defined in {{tpvr}}.
+
+Note that this is an additional requirement for issuing the certificate, as {{!IEEE-802.1AR}} only requires the SKID to be included for intermediate CA certificates.
+{{!RFC8995}} has a similar requirement.
+In BRSKI-PRM, the SKID is used in favor of providing the complete EE certificate of the Registrar-Agent to accommodate also constrained environments and reduce bandwidth needed for communication with the pledge.
 In addition, it follows the recommendation from BRSKI to use SKID in favor of a certificate fingerprint to avoid additional computations.
 
-Using an LDevID for TLS client authentication of the Registrar-Agent is a deviation from {{RFC8995}}, in which the pledge's IDevID credential is used to perform TLS client authentication.
-The use of the EE (RegAgt) certificate allows the domain registrar to distinguish, if bootstrapping is initiated from a pledge or from a Registrar-Agent and to adopt different internal handling accordingly.
-If a registrar detects a request that originates from a Registrar-Agent it is able to switch the operational mode from BRSKI to BRSKI-PRM.
-This may be supported by a specific naming in the SAN (subject alternative name) component of the EE (RegAgt) certificate.
-Alternatively, the domain may feature a CA specifically for issuing Registrar-Agent LDevID certificates.
-This allows the registrar to detect Registrar-Agents based on the issuing CA.
 
-As BRSKI-PRM uses authenticated self-contained data objects between the pledge and the domain registrar, the binding of the pledge identity to the requests is provided by the data object signature employing the pledge's IDevID.
-The objects exchanged between the pledge and the domain registrar used in the context of this specifications are JOSE objects.
 
-In addition to the EE (RegAgt) certificate, the Registrar-Agent is provided with the product-serial-number(s) of the pledge(s) to be bootstrapped.
-This is necessary to allow the discovery of pledge(s) by the Registrar-Agent using DNS-SD with mDNS (see {{discovery_uc2_ppa}})
+In addition to the EE certificates, the Registrar-Agent is provided with the product serial number(s) of the pledge(s) to be bootstrapped.
+This is necessary to allow the discovery of pledge(s) by the Registrar-Agent using DNS-SD with mDNS (see {{discovery_uc2_ppa}}).
 The list may be provided by prior administrative means or the Registrar-Agent may get the information via an interaction with the pledge.
-For instance, {{RFC9238}} describes scanning of a QR code, the product-serial-number would be initialized from the 12N B005 Product Serial Number.
+For instance, {{RFC9238}} describes scanning of a QR code, where the product serial number would be initialized from the 12N B005 Product Serial Number.
 
-According to {{RFC8995}} section 5.3, the domain registrar performs the pledge authorization for bootstrapping within his domain based on the pledge-voucher-request object.
-This behavior is retained also in BRSKI-PRM.
+In summary, the following information MUST be available at the Registrar-Agent before interaction with a pledge:
 
-The following information MUST be available at the Registrar-Agent before interaction with a pledge:
+* Domain registrar EE certificate: certificate of the domain registrar to be provided to the pledge.
+* Registrar-Agent EE certificate and corresponding private key: own operational key pair to sign agent-signed-data.
+* Serial number(s): product serial number(s) of pledge(s) to be bootstrapped for discovery.
 
-* EE (RegAgt) certificate and corresponding private key: own operational key pair (to sign agent-signed-data).
+Further, the Registrar-Agent SHOULD have synchronized time.
 
-* Registrar EE certificate: certificate of the domain registrar (to be provided to the pledge).
+Finally, the Registrar-Agent MAY possess the IDevID (root or issuing) CA certificate of the pledge vendor/manufacturer to validate the IDevID certificate on returned PVR or in case of TLS usage for pledge communication.
+The distribution of IDevID CA certificates to the Registrar-Agent is out of scope of this document and may be done by a manual configuration.
 
-* Serial-number(s): product-serial-number(s) of pledge(s) to be bootstrapped (to query discovery of specific pledges based on the product-serial-number).
-
-
-### Discovery of Registrar by Registrar-Agent {#discovery_uc2_reg}
+### Discovery of the Registrar {#discovery_uc2_reg}
 
 As a Registrar-Agent acts as representative of the domain registrar towards the pledge or may even be collocated with the domain registrar, a separate discovery of the registrar is likely not needed as Registrar-Agent and registrar are domain components and have a trust relation.
 Moreover, other communication (not part of this document) between the Registrar-Agent and the registrar is assumed, e.g., to exchange information about product-serial-number(s) of pledges to be discovered as outlined in {{arch_nomadic}}.
-Moreover, as the standard discovery described in section 4 and the appendix A.2 of {{RFC8995}} does not support  of registrars with an enhanced feature set (like the support of BRSKI-PRM), this standard discovery is not applicable.
+Moreover, as the standard discovery described in {{Section 4 of !RFC8995}} and the {{Appendix A.2 of !RFC8995}} does not support  of registrars with an enhanced feature set (like the support of BRSKI-PRM), this standard discovery is not applicable.
 
 As a more general solution, the BRSKI discovery mechanism can be extended to provide upfront information on the capabilities of registrars, such as the mode of operation (pledge-responder-mode or registrar-responder-mode).
 Defining discovery extensions is out of scope of this document.
 This may be provided in {{I-D.eckert-anima-brski-discovery}}.
 
 
-### Discovery of Pledge by Registrar-Agent {#discovery_uc2_ppa}
+### Discovery of the Pledge {#discovery_uc2_ppa}
 
 The discovery of the pledge by Registrar-Agent in the context of this document describes the minimum discovery approach to be supported.
 A more general discovery mechanism, also supporting GRASP besides DNS-SD with mDNS may be provided in {{I-D.eckert-anima-brski-discovery}}.
 
 Discovery in BRSKI-PRM uses DNS-based Service Discovery {{RFC6763}} over Multicast DNS {{RFC6762}} to discover the pledge.
-Note that {{RFC6762}} section 9 provides support for conflict resolution in situations when an DNS-SD with mDNS responder receives a mDNS response with inconsistent data.
+Note that {{RFC6762}} Section 9 provides support for conflict resolution in situations when an DNS-SD with mDNS responder receives a mDNS response with inconsistent data.
 Note that {{RFC8990}} does not support conflict resolution of mDNS, which may be a limitation for its application.
 
 The pledge constructs a local host name based on device local information (product-serial-number), which results in "product-serial-number._brski-pledge._tcp.local".
@@ -669,7 +640,7 @@ The product-serial-number composition is manufacturer dependent and may contain 
 
 In the absence of a more general discovery as defined in {{I-D.eckert-anima-brski-discovery}} the Registrar-Agent MUST  use
 
-* "product-serial-number._brski-pledge._tcp.local", to discover a specific pledge, e.g., when connected to a local network.
+* "&lt;product-serial-number&gt;._brski-pledge._tcp.local", to discover a specific pledge, e.g., when connected to a local network.
 * "_brski-pledge._tcp.local" to get a list of pledges to be bootstrapped.
 
 A manufacturer may allow the pledge to react on DNS-SD with mDNS discovery without his product-serial-number contained. This allows a commissioning tool to discover pledges to be bootstrapped in the domain. The manufacturer support this functionality as outlined in {{sec_cons_mDNS}}.
@@ -681,54 +652,87 @@ The same approach can be used by 6LoWPAN/mesh using a pre-agreed PAN ID.
 How to gain network connectivity is out of scope of this document.
 
 
-## Behavior of Pledge with Combined Functionality
+## Pledge in Responder Mode {#pledge_ep}
 
-Pledges MAY support both initiator or responder mode.
+The pledge is triggered by the Registrar-Agent to create the PVR and PER.
+It is also triggered for processing of the responses and the generation of status information once the Registrar-Agent has received the responses from the registrar later in the process.
 
-A pledge in initiator mode should listen for announcement messages as described in {{Section 4.1 of RFC8995}}.
+To enable interaction as responder with the Registrar-Agent, pledges in responder mode MUST act as servers and MUST provide the endpoints defined in {{pledge_ep_table}} within the BRSKI-defined "/.well-known/brski/" URI path.
+The endpoints are defined with short names to also accommodate for resource-constrained devices.
+
+| Endpoint | Operation                         | Exchange and Artifacts |
+|:---------|:----------------------------------|:-----------------------|
+| tpvr     | Trigger Pledge Voucher-Request    | {{tpvr}}    |
+|------------------------
+| tper     | Trigger Pledge Enroll-Request     | {{tper}}    |
+|------------------------
+| svr      | Supply Voucher to pledge          | {{voucher}}    |
+|------------------------
+| scac     | Supply CA certificates to pledge  | {{cacerts}}    |
+|------------------------
+| ser      | Supply Enroll-Response to pledge  | {{enroll_response}}    |
+|------------------------
+| qps      | Query Pledge Status               | {{query}}    |
+|===============
+{: #pledge_ep_table title='Well-Known Endpoints on a Pledge in Responder Mode' }
+
+{{Section 7.2 of ?RFC9110}} makes the Host header field mandatory, so it will always be present.
+The pledge MUST respond to all queries regardless of the Host header field provided by the client.
+
+For instance, when the Registrar-Agent reaches out to the "tpvr" endpoint on a pledge in responder mode with the full URI "http://pledge.example.com/.well-known/brski/tpvr", it sets the Host header field to "pledge.example.com" and the absolute path "/.well-known/brski/tpbr".
+In practice, however, the pledge often is only known by its IP address as returned by a discovery protocol, which will be included in the Host header field.
+
+As BRSKI-PRM uses authenticated self-contained data objects between the pledge and the domain registrar, the binding of the pledge identity to the requests is provided by the data object signature employing the IDevID of the pledge.
+Hence, pledges MUST have an Initial Device Identifier (IDevID) installed in them at the factory.
+
+### Pledge with Combined Functionality
+
+Pledges MAY support both initiator and responder mode.
+
+A pledge in initiator mode should listen for announcement messages as described in {{Section 4.1 of !RFC8995}}.
 Upon discovery of a potential registrar, it initiates the bootstrapping to that registrar.
-At the same time (so as to avoid the Slowloris-attack described in {{RFC8995}}), it SHOULD also respond to the triggers for responder mode described in this document.
+At the same time (so as to avoid the Slowloris-attack described in {{!RFC8995}}), it SHOULD also respond to the triggers for responder mode described in this document.
 
 Once a pledge with combined functionality has been bootstrapped, it MAY act as client for enrollment of further certificates needed, e.g., using the enrollment protocol of choice.
-If it still acts as server, the defined BRSKI-PRM endpoints to trigger a pledge-enrollment-request (PER) or to provide an enrollment-response can be used for further certificates.
+If it still acts as server, the defined BRSKI-PRM endpoints to trigger a Pledge Enroll-Request (PER) or to provide an Enroll-Response can be used for further certificates.
 
 
-# Bootstrapping Data Objects and Corresponding Exchanges {#exchanges_uc2}
+# Exchanges and Artifacts {#exchanges_uc2}
 
-The interaction of the pledge with the Registrar-Agent may be accomplished using different transport means (protocols and/or network technologies).
-This specification utilizes HTTP as transport.
-Alternative transport channels may be CoAP, Bluetooth Low Energy (BLE), or Nearfield Communication (NFC).
-These transport means may differ from, and are independent of, the ones used between the Registrar-Agent and the registrar.
-Transport channel independence is realized by data objects, which are not bound to specific transport security and stay the same across the communication from the pledge via the Registrar-Agent to the registrar..
-Therefore, authenticated self-contained objects (here: signature-wrapped objects) are applied for data exchanges between the pledge and the registrar.
+The interaction of the pledge with the Registrar-Agent may be accomplished using different transports (i.e., protocols and/or network technologies).
+This specification utilizes HTTP as default transport.
+Other specifications may define alternative transports such as CoAP, Bluetooth Low Energy (BLE), or Near Field Communication (NFC).
+These transports may differ from and are independent of the ones used between the Registrar-Agent and the registrar.
+Transport independence is realized through data objects that are not bound to specific transport security and stay the same along the communication path from the pledge via the Registrar-Agent to the registrar.
+Therefore, authenticated self-contained objects (e.g., signature-wrapped JWS objects) are applied for data exchanges between the pledge and the registrar.
 
-The Registrar-Agent provides the domain registrar certificate (registrar LDevID certificate) to the pledge to be included in the PVR leaf "agent-provided-proximity-registrar-certificate".
+The Registrar-Agent provides the domain registrar EE certificate to the pledge to be included in the PVR leaf "agent-provided-proximity-registrar-certificate".
 This enables the registrar to verify that it is the desired registrar for handling the request.
+The registrar EE certificate may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar.
 
-The registrar certificate may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar.
-In addition, the Registrar-Agent provides agent-signed-data containing the pledge product-serial-number, signed with the private key corresponding to the EE (RegAgt) certificate, as described in {{exchanges_uc2_1}}.
+In addition, the Registrar-Agent provides "agent-signed-data" containing the pledge product serial number signed with the private key corresponding to the EE certificate of the Registrar-Agent, as described in {{tpvr}}.
 This enables the registrar to verify and log, which Registrar-Agent was in contact with the pledge, when verifying the PVR.
 
-The registrar MUST provide the EE (RegAgt) certificate identified by the SubjectKeyIdentifier (SKID) in the header of the agent-signed-data from the PVR in its RVR (see also {{pvr-proc-reg}}.
+The registrar provides the EE certificate of the Registrar-Agent identified by the SubjectKeyIdentifier (SKID) in the header of the "agent-signed-data" from the PVR in its RVR (see also {{rvr-proc}}).
 
 The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-certificate" leaf and may assert the PVR as "verified" or "logged".
 
-In addition, the MASA MAY issue the assertion "agent-proximity" as follows:
-The MASA verifies the signature of the "agent-signed-data" contained in the "prior-signed-voucher-request", based on the provided EE (RegAgt) certificate in the "agent-sign-cert" leaf of the RVR.
+TODO[LDevID as EE cert for agent-proximity]
+In addition, the MASA may issue the assertion "agent-proximity" as follows:
+The MASA verifies the signature of the "agent-signed-data" contained in the "prior-signed-voucher-request", based on the provided EE certificate of the Registrar-Agent in the "agent-sign-cert" leaf of the RVR.
 If both can be verified successfully, the MASA can assert "agent-proximity" in the voucher.
 The assertion of "agent-proximity" is similar to the proximity assertion by the MASA when using BRSKI.
 Note that the different assertions do not provide a metric of strength as the security properties are not comparable.
 
-Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx error status code as described in section 5.6 of {{RFC8995}}.
-When successful, the voucher will then be supplied via the registrar to the Registrar-Agent.
+Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx response status codes as described in {{Section 5.6 of !RFC8995}}.
+When successful, the Voucher will then be supplied via the registrar to the Registrar-Agent.
 
-{{exchangesfig_uc2_all}} provides an overview of the exchanges detailed in the following sub sections.
+{{exchangesfig_uc2_all}} provides an overview of the exchanges detailed in the following subsections.
 
 ~~~~ aasvg
 +--------+   +-----------+   +-----------+    +--------+  +---------+
-| Pledge |   | Registrar-|   | Domain    |    | Domain |  | Vendor  |
-|        |   | Agent     |   | Registrar |    | CA     |  | Service |
-|        |   | (RegAgt)  |   |  (JRC)    |    |        |  | (MASA)  |
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
 +--------+   +-----------+   +-----------+    +--------+  +---------+
    |                |                 |              |   Internet |
    |   discover     |                 |              |            |
@@ -737,129 +741,130 @@ When successful, the voucher will then be supplied via the registrar to the Regi
    |<---------------|                 |              |            |
    |--------------->|                 |              |            |
    |                |                 |              |            |
-
-   (1) trigger PVR (tPVR) and PER (tPER) generation on pledge
-   |<--opt. TLS --->|                 |              |            |
-   |<----- tPVR ----|                 |              |            |
-   |------ PVR ---->|                 |              |            |
-   |                |                 |              |            |
-   |<----- tPER ----|                 |              |            |
-   |------ PER ---->|                 |              |            |
    ~                ~                 ~              ~            ~
-
-   (2) provide PVR to infrastructure
-   |                |<----- TLS ----->|              |            |
-   |                |         [Reg-Agt authenticated |            |
-   |                |          and authorized?]      |            |
+   (1) Trigger Pledge Voucher-Request
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |<-- opt. TLS -->|                 |              |            |
+   |<---- tPVR -----|                 |              |            |
+   |----- PVR ----->|                 |              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+   (2) Trigger Pledge Enroll-Request
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |<-- opt. TLS -->|                 |              |            |
+   |<---- tPER -----|                 |              |            |
+   |----- PER ----->|                 |              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+   (3) Request Voucher from the Registrar
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |                |<---- mTLS ----->|              |            |
+   |                |         [Registrar-Agent       |            |
+   |                |    authenticated&authorized?]  |            |
    |                |----- PVR ------>|              |            |
-   |                |         [Reg-Agt authorized?]  |            |
    |                |         [accept device?]       |            |
    |                |         [contact vendor]       |            |
+   |                |                 |              |            |
+   |                |                 |<---------- mTLS --------->|
    |                |                 |------------ RVR --------->|
    |                |                 |           [extract DomainID]
    |                |                 |           [update audit log]
    |                |                 |<--------- Voucher --------|
    |                |<--- Voucher ----|              |            |
    |                |                 |              |            |
-
-   (2) provide PER to infrastructure
-   |                |------ PER ----->|              |            |
-   |                |                 |---- CSR ---->|            |
-   |                |                 |<--- Cert ----|            |
-   |                |<--Enroll-Resp---|              |            |
+   ~                ~                 ~              ~            ~
+   (4) Supply PER to Registrar
+   ~                ~                 ~              ~            ~
    |                |                 |              |            |
-   (2) query cACerts from infrastructure
+   |                |<---- mTLS ----->|              |            |
+   |                |----- PER ------>|              |            |
+   |                |                 |<--- mTLS --->|            |
+   |                |                 |---- RER ---->|            |
+   |                |                 |<-Enroll Resp-|            |
+   |                |<--Enroll Resp---|              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+   (5) Request CA Certificates
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
    |                |-- cACert-Req -->|              |            |
    |                |<-- cACert-Resp--|              |            |
+   |                |                 |              |            |
    ~                ~                 ~              ~            ~
-
-   (3) provide voucher and certificate and collect status info
+   (6) Supply Voucher to Pledge
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
    |<--opt. TLS --->|                 |              |            |
    |<--- Voucher ---|                 |              |            |
    |---- vStatus -->|                 |              |            |
-   |<--- cACerts ---|                 |              |            |
-   |<--Enroll-Resp--|                 |              |            |
-   |--- eStatus --->|                 |              |            |
+   |                |                 |              |            |
    ~                ~                 ~              ~            ~
-
-   (4) provide voucher status and enroll status to registrar
-   |                |<------ TLS ---->|              |            |
-   |                |----  vStatus -->|              |            |
+   (7) Supply CA certificates to Pledge
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |<--opt. TLS --->|                 |              |            |
+   |<--- cACerts ---|                 |              |            |
+   |--- cACerts --->|                 |              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+   (8) Supply Enroll-Response to Pledge
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |<--Enroll Resp--|                 |              |            |
+   |--- eStatus --->|                 |              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+   (9) Voucher Status Telemetry
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |                |<---- mTLS ----->|              |            |
+   |                |---- vStatus --->|              |            |
    |                |                 |--- req device audit log-->|
    |                |                 |<---- device audit log ----|
    |                |           [verify audit log]
    |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+   (10) Enroll Status Telemetry
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
    |                |---- eStatus --->|              |            |
    |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+   (11) Query Pledge Status
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   TODO
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
 ~~~~
 {: #exchangesfig_uc2_all title='Overview pledge-responder-mode exchanges' artwork-align="left"}
+TODO[where general status req/res]
 
 The following sub sections split the interactions shown in {{exchangesfig_uc2_all}} between the different components into:
 
-1. {{exchanges_uc2_1}} describes the request object acquisition by the Registrar-Agent from pledge.
+1. {{tpvr}} describes the request object acquisition by the Registrar-Agent from pledge.
 
-2. {{exchanges_uc2_2}} describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA and the domain CA including the response object processing by these entities.
+2. {{tper}} TODO
 
-3. {{exchanges_uc2_3}} describes the supply of response objects between the Registrar-Agent and the pledge including the status information.
+3. {{pvr}} describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA and the domain CA including the response object processing by these entities.
 
-4. {{exchanges_uc2_5}} describes the general status handling and addresses corresponding exchanges between the Registrar-Agent and the registrar.
+4. {{voucher}} describes the supply of the Voucher from the Registrar-Agent to the pledge including the returned status information.
 
+5. {{enroll_response}} describes the supply of the Enroll Reponse from the Registrar-Agent to the pledge including the returned status information.
 
-## Request Objects Acquisition by Registrar-Agent from Pledge {#exchanges_uc2_1}
+6. {{vstatus}} and {{estatus}} describe the general status handling and addresses corresponding exchanges between the Registrar-Agent and the registrar.
 
-The following description assumes that the Registrar-Agent has already discovered the pledge.
+## Trigger Pledge Voucher-Request {#tpvr}
+
+This exchange assumes that the Registrar-Agent has already discovered the pledge.
 This may be done as described in {{discovery_uc2_ppa}} and {{exchangesfig_uc2_all}} based on DNS-SD or similar.
 
-The focus is on the exchange of signature-wrapped objects using endpoints defined for the pledge in {{pledge_ep}}.
+TLS MAY be optionally used to provide privacy for this exchange between the Registrar-Agent and the pledge, see {{pledgehttps}}.
 
-Preconditions:
-
-* Pledge: possesses IDevID
-
-* Registrar-Agent:
-  * possesses own credentials (EE (RegAgt) certificate and corresponding private key) for the registrar domain.
-  * MAY possess the IDevID CA certificate of the pledge vendor/manufacturer to validate IDevID certificate on returned PVR or in case of TLS usage for pledge communication.
-  The distribution of IDevID CA certificates to the Registrar-Agent is out of scope of this document and may be done by a manual configuration.
-  In addition, the Registrar-Agent SHOULD know the product-serial-number(s) of the pledge(s) to be bootstrapped.
-  The Registrar-Agent MAY be provided with the product-serial-number(s) in different ways:
-    * configured, e.g., as a list of pledges to be bootstrapped via QR code scanning
-    * discovered by using standard approaches like DNS-SD with mDNS as described in {{discovery_uc2_ppa}}
-    * discovered by using a manufacturer specific approach, e.g., RF beacons.
-  If the product-serial-number(s) are not known in advance, the Registrar-Agent cannot perform a distinct triggering of pledges but and triggers  all pledges discovered .
-
-  The Registrar-Agent SHOULD have synchronized time.
-
-* Registrar (same as in BRSKI): possesses/trusts IDevID CA certificate and has own registrar EE credentials.
-
-~~~~ aasvg
-+--------+                                    +-----------+
-| Pledge |                                    | Registrar-|
-|        |                                    | Agent     |
-|        |                                    | (RegAgt)  |
-+--------+                                    +-----------+
-    |                                               |-create
-    |                                               | agent-signed-data
-    |<-- optional establish TLS connection ---------|
-    |                                               |
-    |<--- trigger pledge-voucher-request -----------|
-    |     -agent-provided-proximity-registrar-cert  |
-    |     -agent-signed-data                        |
-    |                                               |
-    |----- pledge-voucher-request ----------------->|-store PVR
-    |                                               |
-    |<----- trigger pledge-enrollment-request ------|
-    |       (empty)                                 |
-    |                                               |
-    |------ pledge-enrollment-request ------------->|-store (PER)
-    |                                               |
-~~~~
-{: #exchangesfig_uc2_1 title='Request collection (Registrar-Agent - pledge)' artwork-align="left"}
-
-TLS MAY be optionally used to provide privacy for the interaction between the Registrar-Agent and the pledge, see {{pledgehttps}}.
-
-Note: The Registrar-Agent may trigger the pledge for the PVR or the PER or both. It is expected that this will be aligned with a service technician workflow, visiting and installing each pledge.
-
-### Pledge-Voucher-Request (PVR) - Trigger {#pvrt}
+### Request Artifact: Pledge Voucher-Request Trigger (tPVR)
 
 Triggering the pledge to create the PVR is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tpvr"
 
@@ -880,7 +885,7 @@ The trigger for the pledge to create a PVR is depicted in the following figure:
 ~~~~
 {: #pavrt title='Representation of trigger to create PVR' artwork-align="left"}
 
-Note that at the time of receiving the PVR trigger, the pledge cannot verify the registrar LDevID certificate and has no proof-of-possession of the corresponding private key for the certificate. The pledge therefore accepts the registrar LDevID certificate provisionally until it receives the voucher as described in {{exchanges_uc2_3}}.
+Note that at the time of receiving the PVR trigger, the pledge cannot verify the registrar LDevID certificate and has no proof-of-possession of the corresponding private key for the certificate. The pledge therefore accepts the registrar LDevID certificate provisionally until it receives the voucher as described in {{voucher}}.
 
 The pledge will also be unable to verify the agent-signed-data itself as it does not possess the EE (RegAgt) certificate and the domain trust has not been established at this point of the communication.
 Verification SHOULD be done, after the voucher has been received.
@@ -897,29 +902,27 @@ The body of the agent-signed-data contains an "ietf-voucher-request:agent-signed
 
 * created-on: MUST contain the creation date and time in yang:date-and-time format.
 
-* serial-number: MUST contain the product-serial-number as type string as defined in {{RFC8995}}, section 2.3.1.
+* serial-number: MUST contain the product serial number as type string as defined in {{Section 2.3.1 of !RFC8995}}.
   The serial-number corresponds with the product-serial-number contained in the X520SerialNumber field of the IDevID certificate of the pledge.
 
 ~~~~
 # The agent-signed-data in General JWS Serialization syntax
 {
-  "payload": BASE64URL(ietf-voucher-request:agent-signed-data),
+  "payload": "BASE64URL(ietf-voucher-request-prm:agent-signed-data)",
   "signatures": [
     {
-      "protected": BASE64URL(UTF8(JWS Protected Header)),
+      "protected": "BASE64URL(UTF8(JWS Protected Header))",
       "signature": BASE64URL(JWS Signature)
     }
   ]
 }
 
 # Example: Decoded payload representation in JSON syntax of
-  "ietf-voucher-request:agent-signed-data"
+  "ietf-voucher-request-prm:agent-signed-data"
 
-{
-  "ietf-voucher-request:agent-signed-data": {
-    "created-on": "2021-04-16T00:00:01.000Z",
-    "serial-number": "callee4711"
-  }
+"ietf-voucher-request-prm:agent-signed-data": {
+  "created-on": "2021-04-16T00:00:01.000Z",
+  "serial-number": "callee4711"
 }
 
 # Example: Decoded "JWS Protected Header" representation
@@ -932,9 +935,10 @@ The body of the agent-signed-data contains an "ietf-voucher-request:agent-signed
 {: #asd title='Representation of agent-signed-data in General JWS Serialization syntax' artwork-align="left"}
 
 
-### Pledge-Voucher-Request (PVR) - Response {#pvrr}
 
-Upon receiving the voucher-request trigger, the pledge SHALL construct the body of the PVR as defined in {{RFC8995}}.
+### Response Artifact: Pledge Voucher-Request (PVR)
+
+Upon receiving the voucher-request trigger, the pledge SHALL construct the body of the PVR as defined in {{!RFC8995}}.
 It will contain additional information provided by the Registrar-Agent as specified in the following.
 This PVR becomes a JSON-in-JWS object as defined in {{I-D.ietf-anima-jws-voucher}}.
 If the pledge is unable to construct the PVR it SHOULD respond with a HTTP error code to the Registrar-Agent to indicate that it is not able to create the PVR.
@@ -952,7 +956,7 @@ The header of the PVR SHALL contain the following parameters as defined in {{RFC
 * x5c: contains the base64-encoded pledge IDevID certificate.
   It MAY optionally contain the certificate chain for this certificate. If the certificate chain is not included it MUST be available at the registrar for verification of the IDevID certificate.
 
-The payload of the PVR MUST contain the following parameters as part of the ietf-voucher-request:voucher as defined in {{I-D.ietf-anima-rfc8366bis}}:
+The payload of the PVR MUST contain the following parameters as part of the ietf-voucher-request-prm:voucher as defined in {{!RFC8995}}:
 
 * created-on: SHALL contain the current date and time in yang:date-and-time format.
   If the pledge does not have synchronized time, it SHALL use the created-on time from the agent-signed-data, received in the trigger to create a PVR.
@@ -977,7 +981,7 @@ The PVR is signed using the pledge's IDevID credential contained as x5c paramete
 ~~~~
 # The PVR in General JWS Serialization syntax
 {
-  "payload": BASE64URL(ietf-voucher-request:voucher),
+  "payload": BASE64URL(UTF8(ietf-voucher-request-prm:voucher)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -986,45 +990,45 @@ The PVR is signed using the pledge's IDevID credential contained as x5c paramete
   ]
 }
 
-# Example: Decoded Payload "ietf-voucher-request:voucher"
+# Example: Decoded Payload "ietf-voucher-request-prm:voucher"
   representation in JSON syntax
-{
-  "ietf-voucher-request:voucher": {
-     "created-on": "2021-04-16T00:00:02.000Z",
-     "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
-     "serial-number": "callee4711",
-     "assertion": "agent-proximity",
-     "agent-provided-proximity-registrar-cert": "base64encodedvalue==",
-     "agent-signed-data": "base64encodedvalue=="
-  }
+"ietf-voucher-request-prm:voucher": {
+   "created-on": "2021-04-16T00:00:02.000Z",
+   "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
+   "serial-number": "callee4711",
+   "assertion": "agent-proximity",
+   "agent-provided-proximity-registrar-cert": "base64encodedvalue==",
+   "agent-signed-data": "base64encodedvalue=="
 }
 
 # Example: Decoded "JWS Protected Header" representation
   in JSON syntax
 {
     "alg": "ES256",
+    "typ": "voucher-jws+json",
     "x5c": [
       "base64encodedvalue==",
       "base64encodedvalue=="
-    ],
-    "typ": "voucher-jws+json"
+    ]
 }
 ~~~~
-{: #pvr title='Representation of PVR' artwork-align="left"}
+{: #pvr_example title='Representation of PVR' artwork-align="left"}
 
-The PVR Media-Type is defined in {{I-D.ietf-anima-jws-voucher}} as `application/voucher-jws+json`.
+The PVR Media-Type is defined in {{!I-D.ietf-anima-jws-voucher}} as `application/voucher-jws+json`.
 
 The pledge MUST include this Media-Type header field indicating the included media type for the PVR.
-The PVR is included by the registrar in its RCR as described in {{exchanges_uc2_2}}.
+The PVR is included by the registrar in its RVR as described in {{pvr}}.
 
 
-### Pledge-Enrollment-Request (PER) - Trigger
+## Trigger Pledge Enroll-Request {#tper}
+
+### Request Artifact: Pledge Enroll-Request Trigger (tPER)
 
 Once the Registrar-Agent has received the PVR it can trigger the pledge to generate a PER.
 As in BRSKI the PER contains a PKCS#10, but additionally signed using the pledge's IDevID.
 Note, as the initial enrollment aims to request a generic certificate, no certificate attributes are provided to the pledge.
 
-Triggering the pledge to create the enrollment-request is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tper"
+Triggering the pledge to create the Enroll-Request is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tper"
 
 The Registrar-Agent PER trigger Content-Type header is: `application/json` with an empty body by default.
 Note that using HTTP POST allows for an empty body, but also to provide additional data, like CSR attributes or information about the enroll type "enroll-generic-cert" or "re-enroll-generic-cert".
@@ -1042,19 +1046,21 @@ If specific attributes in the certificate are required, they have to be inserted
 How the HTTP POST can be used to provide CSR attributes is out of scope for this specification.
 
 
-### Pledge-Enrollment-Request (PER) - Response {#PER-response}
+
 
 In the following the enrollment is described as initial enrollment with an empty HTTP POST body.
 
-Upon receiving the PER  trigger, the pledge SHALL construct the PER as authenticated self-contained object.
+### Response Artifact: Pledge Enroll-Request (PER)
+
+Upon receiving the PER trigger, the pledge SHALL construct the PER as authenticated self-contained object.
 The CSR already assures POP of the private key corresponding to the contained public key.
 In addition, based on the PER signature using the IDevID, POI is provided.
-Here, a JOSE object is being created in which the body utilizes the YANG module ietf-ztp-types with the grouping for csr-grouping for the CSR as defined in {{I-D.ietf-netconf-sztp-csr}}.
+Here, a JOSE object is being created in which the body utilizes the YANG module ietf-ztp-types with the grouping for csr-grouping for the CSR as defined in {{!I-D.ietf-netconf-sztp-csr}}.
 
-Depending on the capability of the pledge, it constructs the pledge-enrollment-request (PER) as plain PKCS#10.
+Depending on the capability of the pledge, it constructs the Pledge Enroll-Request (PER) as plain PKCS#10.
 Note, the focus in this use case is placed on PKCS#10 as PKCS#10 can be transmitted in different enrollment protocols in the infrastructure like EST, CMP, CMS, and SCEP.
 If the pledge has already implemented an enrollment protocol, it may leverage that functionality for the creation of the CSR.
-Note, {{I-D.ietf-netconf-sztp-csr}} also allows for inclusion of certification requests in different formats used by CMP or CMC.
+Note, {{!I-D.ietf-netconf-sztp-csr}} also allows for inclusion of certification requests in different formats used by CMP or CMC.
 
 The pledge MUST construct the PER as PKCS#10.
 In BRSKI-PRM it MUST sign it additionally with its IDevID credentials to provide proof-of-identity bound to the PKCS#10 as described below.
@@ -1077,15 +1083,15 @@ The Registrar-Agent SHALL use the endpoints specified in this document.
 {{I-D.ietf-netconf-sztp-csr}} considers PKCS#10 but also CMP and CMC as certification request format.
 Note that the wrapping of the PER signature is only necessary for plain PKCS#10 as other request formats like CMP and CMS support the signature wrapping as part of their own certificate request format.
 
-The Registrar-Agent enrollment-request Content-Type header for a signature-wrapped PKCS#10 is: `application/jose+json`
+The Registrar-Agent Enroll-Request Content-Type header for a signature-wrapped PKCS#10 is: `application/jose+json`
 
-The header of the pledge-enrollment-request SHALL contain the following parameter as defined in {{RFC7515}}:
+The header of the Pledge Enroll-Request SHALL contain the following parameter as defined in {{RFC7515}}:
 
 * alg: algorithm used for creating the object signature.
 
 * x5c: contains the base64-encoded pledge IDevID certificate.
   It MAY optionally contain the certificate chain for this certificate. If the certificate chain is not included it MUST be available at the registrar for verification of the IDevID certificate.
-The body of the pledge-enrollment-request SHOULD contain a P10 parameter (for PKCS#10) as defined for ietf-ztp-types:p10-csr in {{I-D.ietf-netconf-sztp-csr}}
+The body of the Pledge Enroll-Request SHOULD contain a P10 parameter (for PKCS#10) as defined for ietf-ztp-types:p10-csr in {{I-D.ietf-netconf-sztp-csr}}
 
 * P10: contains the base64-encoded PKCS#10 of the pledge.
 
@@ -1097,10 +1103,10 @@ Note that in this case the current LDevID credential is used instead of the IDev
 ~~~~
 # The PER in General JWS Serialization syntax
 {
-  "payload": BASE64URL(ietf-ztp-types),
+  "payload": "BASE64URL(ietf-ztp-types)",
   "signatures": [
     {
-      "protected": BASE64URL(UTF8(JWS Protected Header)),
+      "protected": "BASE64URL(UTF8(JWS Protected Header))",
       "signature": BASE64URL(JWS Signature)
     }
   ]
@@ -1108,10 +1114,8 @@ Note that in this case the current LDevID credential is used instead of the IDev
 
 # Example: Decoded Payload "ietf-ztp-types" Representation
   in JSON Syntax
-{
-  "ietf-ztp-types": {
-    "p10-csr": "base64encodedvalue=="
-  }
+"ietf-ztp-types": {
+  "p10-csr": "base64encodedvalue=="
 }
 
 # Example: Decoded "JWS Protected Header" Representation
@@ -1126,12 +1130,12 @@ Note that in this case the current LDevID credential is used instead of the IDev
   "created-on": "2022-09-13T00:00:02.000Z"
 }
 ~~~~
-{: #per title='Representation of PER' artwork-align="left"}
+{: #per_example title='Representation of PER' artwork-align="left"}
 
 With the collected PVR and PER, the Registrar-Agent starts the interaction with the domain registrar.
 
 The new protected header field "created-on" is introduced to reflect freshness of the PER.
-The field is marked critical "crit" to ensure that it must be understood and validated by the receiver (here the domain registrar) according to section 4.1.11 of {{RFC7515}}.
+The field is marked critical "crit" to ensure that it must be understood and validated by the receiver (here the domain registrar) according to {{Section 4.1.11 of RFC7515}}.
 It allows the registrar to verify the timely correlation between the PER and previously exchanged messages, i.e., created-on of PER >= created-on of PVR >= created-on of PVR trigger.
 The registrar MAY consider to ignore any but the newest PER from the same pledge in the case the registrar has at any point in time more than one pending PER from the pledge.
 
@@ -1139,70 +1143,20 @@ As the Registrar-Agent is intended to facilitate communication between the pledg
 This allows bulk bootstrapping of several pledges using the same connection between the Registrar-Agent and the domain registrar.
 
 
-## Request Object Handling initiated by the Registrar-Agent on Registrar, MASA and Domain CA {#exchanges_uc2_2}
 
-The BRSKI-PRM bootstrapping exchanges between Registrar-Agent and domain registrar resemble the BRSKI exchanges between pledge and domain registrar (pledge-initiator-mode) with some deviations.
 
-Preconditions:
 
-* Registrar-Agent: possesses its own credentials (EE (RegAgt) certificate and corresponding private key) of the domain.
-  In addition, it MAY possess the IDevID CA certificate of the pledge vendor/manufacturer to verify the pledge certificate in the received request messages.
-  It has the address of the domain registrar through configuration or by discovery, e.g., DNS-SD with mDNS.
-  The Registrar-Agent has acquired one or more PVR and PER objects.
+## Request Voucher from the Registrar {#pvr}
 
-* Registrar (same as in BRSKI): possesses the IDevID CA certificate of the pledge vendor/manufacturer and its own registrar EE credentials of the domain.
+Similar to BRSKI "requestvoucher" endpoint in {{Section 5.2 of !RFC8995}}.
 
-* MASA (same as in BRSKI): possesses its own vendor/manufacturer credentials (voucher signing key and certificate, TLS server certificate and private key) related to pledges IDevID and MAY possess the site-specific domain CA certificate.
-
-~~~~ aasvg
-+-----------+     +-----------+       +--------+   +---------+
-| Registrar-|     | Domain    |       | Domain |   | Vendor  |
-| Agent     |     | Registrar |       | CA     |   | Service |
-| (RegAgt)  |     |  (JRC)    |       |        |   | (MASA)  |
-+-----------+     +-----------+       +--------+   +---------+
-    |                   |                  |   Internet |
-[voucher + enrollment]  |                  |            |
-[PVR, PER available ]   |                  |            |
-    |                   |                  |            |
-    |<----- mTLS ------>|                  |            |
-    |           [Reg-Agt authenticated     |            |
-    |            and authorized?]          |            |
-    |                   |                  |            |
-    |--- Voucher-Req -->|                  |            |
-    |       (PVR)       |                  |            |
-    |           [Reg-Agt authorized?]      |            |
-    |           [accept device?]           |            |
-    |           [contact vendor]                        |
-    |                   |------------- mTLS ----------->|
-    |                   |--------- Voucher-Req -------->|
-    |                   |             (RVR)             |
-    |                   |                   [extract DomainID]
-    |                   |                   [update audit log]
-    |                   |<---------- Voucher -----------|
-    |<---- Voucher -----|                  |            |
-    |                   |                  |            |
-    |--- Enroll-Req --->|                  |            |
-    |      (PER)        |                  |            |
-    |                   |<----- mTLS ----->|            |
-    |                   |--- Enroll-Req -->|            |
-    |                   |     (RER)        |            |
-    |                   |<-- Enroll-Resp---|            |
-    |<-- Enroll-Resp ---|                  |            |
-    |                   |                  |            |
-    |--- caCerts-Req -->|                  |            |
-    |<-- caCerts-Res ---|                  |            |
-    |                   |                  |            |
-~~~~
-{: #exchangesfig_uc2_2 title='Request processing between Registrar-Agent and bootstrapping services' artwork-align="left"}
+The Registrar-Agent has acquired one or more PVR and PER object pairs
 
 The Registrar-Agent establishes a TLS connection to the registrar.
-As already stated in {{RFC8995}}, the use of TLS 1.3 (or newer) is encouraged.
+As already stated in {{!RFC8995}}, the use of TLS 1.3 (or newer) is encouraged.
 TLS 1.2 or newer is REQUIRED on the Registrar-Agent side.
 TLS 1.3 (or newer) SHOULD be available on the registrar, but TLS 1.2 MAY be used.
 TLS 1.3 (or newer) SHOULD be available on the MASA, but TLS 1.2 MAY be used.
-
-
-### Connection Establishment (Registrar-Agent to Registrar)
 
 In contrast to BRSKI {{RFC8995}} TLS client authentication to the registrar is achieved by using Registrar-Agent EE credentials instead of pledge IDevID credentials.
 Consequently BRSKI (pledge-initiator-mode) is distinguishable from BRSKI-PRM (pledge-responder-mode) by the registrar.
@@ -1211,51 +1165,26 @@ If the connection from Registrar-Agent to registrar is established, the authoriz
 This ensures that the pledge has been triggered by an authorized Registrar-Agent.
 
 With BRSKI-PRM, the pledge generates PVR and PER as JSON-in-JWS objects and the Registrar-Agent forwards them to the registrar.
-In {{RFC8995}}, the pledge generates PVR as CMS-signed JSON and PER as PKCS#10 or PKCS#7 according to {{RFC7030}} and inherited by {{RFC8995}}.
+In {{!RFC8995}}, the pledge generates PVR as CMS-signed JSON and PER as PKCS#10 or PKCS#7 according to {{!RFC7030}} and inherited by {{!RFC8995}}.
+
+### Request Artifact: PVR
 
 For BRSKI-PRM, the Registrar-Agent sends the PVR by HTTP POST to the same registrar endpoint as introduced by BRSKI: "/.well-
 known/brski/requestvoucher", but with a Content-Type header field for JSON-in-JWS"
 
-The Content-Type header field for JSON-in-JWS PVR is: `application/voucher-jws+json` (see {{pvr}} for the content definition), as defined in {{I-D.ietf-anima-jws-voucher}}.
+The Content-Type header field for JSON-in-JWS PVR is: `application/voucher-jws+json` (see {{tpvr}} for the content definition), as defined in {{I-D.ietf-anima-jws-voucher}}.
 
 The Registrar-Agent sets the Accept field in the request-header indicating the acceptable Content-Type for the voucher-response.
 The voucher-response Content-Type header field is set to `application/voucher-jws+json` as defined in {{I-D.ietf-anima-jws-voucher}}.
 
 
-### Pledge-Voucher-Request (PVR) Processing by Registrar {#pvr-proc-reg}
 
-After receiving the PVR from Registrar-Agent, the registrar SHALL perform the verification as defined in section 5.3 of {{RFC8995}}.
-In addition, the registrar SHALL verify the following parameters from the PVR:
+### Registrar Voucher-Request (RVR) Processing (Registrar to MASA) {#rvr-proc}
 
-* agent-provided-proximity-registrar-cert: MUST contain registrar's own registrar LDevID certificate to ensure the registrar in proximity of the Registrar-Agent is the desired registrar for this PVR.
+If the MASA address/URI is learned from the IDevID MASA URI extension ({{Section 2.3 of !RFC8995}}), then the MASA on that URI MUST support the procedures defined in this document if the PVR used JSON-JWS encoding.
+If the MASA is only configured on the registrar, then a registrar supporting BRKSI-PRM and other voucher encoding formats (such as those in {{!RFC8995}}) SHOULD support per-message-format MASA address/URI configuration for the same IDevID trust anchor."
 
-* agent-signed-data: The registrar MUST verify that the Registrar-Agent provided data has been signed with the private key corresponding to the EE (RegAgt) certificate indicated in the "kid" JOSE header parameter.
-  The registrar MUST verify that the LDevID(ReAgt) certificate, corresponding to the signature, is still valid.
-  If the certificate is already expired, the registrar SHALL reject the request.
-  Validity of used signing certificates at the time of signing the agent-signed-data is necessary to avoid that a rogue Registrar-Agent generates agent-signed-data objects to onboard arbitrary pledges at a later point in time, see also {{sec_cons_reg-agt}}.
-  The registrar MUST fetch the EE (RegAgt) certificate, based on the provided SubjectKeyIdentifier (SKID) contained in the "kid" header parameter of the agent-signed-data, and perform this verification.
-  This requires, that the registrar has access to the EE (RegAgt) certificate data (including intermediate CA certificates if existent) based on the SKID.
-  Note, the registrar may have stored the EE (RegAgt) certificate if used during TLS establishment between Registrar-Agent and registrar or it may be provided via a repository.
-
-If the registrar is unable to validate the PVR it SHOULD respond with a HTTP 4xx/5xx error code to the Registrar-Agent.
-
-The following 4xx client error codes SHOULD be used:
-
-* 403 Forbidden: if the registrar detected that one or more security related parameters are not valid.
-
-* 404 Not Found status code if the pledge provided information could not be used with automated allowance, as described in section 5.3 of {{RFC8995}}.
-
-* 406 Not Acceptable: if the Content-Type indicated by the Accept header is unknown or unsupported.
-
-If the validation succeeds, the registrar performs pledge authorization according to {{RFC8995}}, section 5.3 followed by obtaining a voucher from the pledge's MASA according to {{RFC8995}}, section 5.4 with the modifications described below in {{rvr-proc}}.
-
-
-### Registrar-Voucher-Request (RVR) Processing (Registrar to MASA) {#rvr-proc}
-
-If the MASA address/URI is learned from the {{RFC8995}} section 2.3 IDevID MASA URI extension, then the MASA on that URI MUST support the procedures defined in this document if the PVR used JSON-JWS encoding.
-If the MASA is only configured on the registrar, then a registrar supporting BRKSI-PRM and other voucher encoding formats (such as those in {{RFC8995}}) SHOULD support per-message-format MASA address/URI configuration for the same IDevID trust anchor."
-
-The registrar SHALL construct the payload of the RVR as defined in {{RFC8995}}, section 5.5.
+The registrar SHALL construct the payload of the RVR as defined in {{!RFC8995}}, Section 5.5.
 The RVR encoding SHALL be JSON-in-JWS as defined in {{I-D.ietf-anima-jws-voucher}}.
 
 The header of the RVR SHALL contain the following parameter as defined for JWS {{RFC7515}}:
@@ -1265,7 +1194,7 @@ The header of the RVR SHALL contain the following parameter as defined for JWS {
 * x5c: base64-encoded registrar LDevID certificate(s)
   (It optionally contains the certificate chain for this certificate)
 
-The payload of the RVR MUST contain the following parameter as part of the voucher-request as defined in {{RFC8995}}:
+The payload of the RVR MUST contain the following parameter as part of the voucher-request as defined in {{!RFC8995}}:
 
 * created-on: current date and time in yang:date-and-time format of RVR creation
 
@@ -1278,7 +1207,7 @@ The payload of the RVR MUST contain the following parameter as part of the vouch
 * assertion: voucher assertion requested by the pledge (agent-proximity).
   The registrar provides this information to assure successful verification of Registrar-Agent proximity based on the agent-signed-data.
 
-* prior-signed-voucher-request: PVR as received from Registrar-Agent, see {{pvrr}}
+* prior-signed-voucher-request: PVR as received from Registrar-Agent, see {{tpvr}}
 
 The RVR MUST be extended with the following parameter, when the assertion "agent-proximity" is requested, as defined in {{I-D.ietf-anima-rfc8366bis}}:
 
@@ -1294,7 +1223,7 @@ The object is signed using the registrar LDevID credentials, which corresponds t
 ~~~~
 # The RVR in General JWS Serialization syntax
 {
-  "payload": BASE64URL(ietf-voucher-request:voucher),
+  "payload": BASE64URL(UTF8(ietf-voucher-request-prm:voucher)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -1303,21 +1232,19 @@ The object is signed using the registrar LDevID credentials, which corresponds t
   ]
 }
 
-# Example: Decoded payload "ietf-voucher-request:voucher"
+# Example: Decoded payload "ietf-voucher-request-prm:voucher"
   representation in JSON syntax
-{
-  "ietf-voucher-request:voucher": {
-     "created-on": "2022-01-04T02:37:39.235Z",
-     "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
-     "serial-number": "callee4711",
-     "assertion": "agent-proximity",
-     "prior-signed-voucher-request": "base64encodedvalue==",
-     "agent-sign-cert": [
-       "base64encodedvalue==",
-       "base64encodedvalue==",
-       "..."
-     ]
-  }
+"ietf-voucher-request-prm:voucher": {
+   "created-on": "2022-01-04T02:37:39.235Z",
+   "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
+   "serial-number": "callee4711",
+   "assertion": "agent-proximity",
+   "prior-signed-voucher-request": "base64encodedvalue==",
+   "agent-sign-cert": [
+     "base64encodedvalue==",
+     "base64encodedvalue==",
+     "..."
+   ]
 }
 
 # Example: Decoded "JWS Protected Header" representation
@@ -1335,17 +1262,17 @@ The object is signed using the registrar LDevID credentials, which corresponds t
 
 The registrar SHALL send the RVR to the MASA endpoint by HTTP POST: "/.well-known/brski/requestvoucher"
 
-The RVR Content-Type header field is defined in {{I-D.ietf-anima-jws-voucher}} as: `application/voucher-jws+json`
+The RVR Content-Type header field is defined in {{!I-D.ietf-anima-jws-voucher}} as: `application/voucher-jws+json`
 
 The registrar SHOULD set the Accept header of the RVR indicating the desired media type for the voucher-response.
 The media type is `application/voucher-jws+json` as defined in {{I-D.ietf-anima-jws-voucher}}.
 
 This document uses the JSON-in-JWS format throughout the definition of exchanges and in the examples.
-Nevertheless, alternative encodings of the voucher as used in BRSKI {{RFC8995}} with JSON-in-CMS or CBOR-in-COSE_Sign {{RFC8152}} for constraint environments are possible as well.
+Nevertheless, alternative encodings of the voucher as used in BRSKI {{!RFC8995}} with JSON-in-CMS or CBOR-in-COSE_Sign {{?RFC9052}} for constraint environments are possible as well.
 The assumption is that a pledge typically supports a single encoding variant and creates the PVR in the supported format.
 To ensure that the pledge is able to process the voucher, the registrar MUST use the media type for Accept header in the RVR based on the media type used for the PVR.
 
-Once the MASA receives the RVR it SHALL perform the verification as described in section 5.5 in {{RFC8995}}.
+Once the MASA receives the RVR it SHALL perform the verification as described in {{Section 5.5 of !RFC8995}}.
 
 In addition, the following processing SHALL be performed for PVR contained in RVR "prior-signed-voucher-request" field:
 
@@ -1363,7 +1290,7 @@ In addition, the following processing SHALL be performed for PVR contained in RV
   As the "agent-sign-cert" field is defined as array (x5c), it can handle multiple certificates.
 
 If validation fails, the MASA SHOULD respond with an HTTP 4xx client error status code to the registrar.
-The HTTP error status codes are kept the same as defined in section 5.6 of {{RFC8995}} and comprise the codes: 403, 404, 406, and 415.
+The HTTP error status codes are kept the same as defined in {{Section 5.6 of !RFC8995}} and comprise the codes: 403, 404, 406, and 415.
 
 
 ### Voucher Issuance by MASA {#exchanges_uc2_2_vc}
@@ -1388,14 +1315,12 @@ The voucher is according to {{I-D.ietf-anima-rfc8366bis}} but uses the new asser
 
 # Example: Decoded payload "ietf-voucher:voucher" representation
   in JSON syntax
-{
-  "ietf-voucher:voucher": {
-    "assertion": "agent-proximity",
-    "serial-number": "callee4711",
-    "nonce": "base64encodedvalue==",
-    "created-on": "2022-01-04T00:00:02.000Z",
-    "pinned-domain-cert": "base64encodedvalue=="
-  }
+"ietf-voucher:voucher": {
+  "assertion": "agent-proximity",
+  "serial-number": "callee4711",
+  "nonce": "base64encodedvalue==",
+  "created-on": "2022-01-04T00:00:02.000Z",
+  "pinned-domain-cert": "base64encodedvalue=="
 }
 
 # Example: Decoded "JWS Protected Header" representation
@@ -1411,31 +1336,31 @@ The voucher is according to {{I-D.ietf-anima-rfc8366bis}} but uses the new asser
 ~~~~
 {: #MASA-vr title='Representation of MASA issued voucher' artwork-align="left"}
 
-The pinned-domain certificate to be put into the voucher is determined by the MASA as described in section 5.5 of {{RFC8995}}.
+The pinned-domain certificate to be put into the voucher is determined by the MASA as described in {{Section 5.5 of !RFC8995}}.
 The MASA returns the voucher-response (voucher) to the registrar.
 
 
 ### MASA issued Voucher Processing by Registrar {#exchanges_uc2_2_vs}
 
-After receiving the voucher the registrar SHOULD evaluate it for transparency and logging purposes as outlined in section 5.6 of {{RFC8995}}.
+After receiving the voucher the registrar SHOULD evaluate it for transparency and logging purposes as outlined in {{Section 5.6 of !RFC8995}}.
 The registrar MUST add an additional signature to the MASA provided voucher using its registrar EE credentials.
 
 
 
-The signature is created by signing the original "JWS Payload" produced by MASA and the registrar added "JWS Protected Header" using the registrar EE credentials (see {{RFC7515}}, section 5.2 point 8.
+The signature is created by signing the original "JWS Payload" produced by MASA and the registrar added "JWS Protected Header" using the registrar EE credentials (see {{RFC7515}}, Section 5.2 point 8.
 The x5c component of the "JWS Protected Header" MUST contain the registrar EE certificate as well as potential subordinate CA certificates up to (but not including) the pinned domain certificate.
 The pinned domain certificate is already contained in the voucher payload ("pinned-domain-cert").
 
 (For many installations, with a single registrar credential, the registrar credential is what is pinned)
 
-In {{RFC8995}}, the Registrar proved possession of the it's credential when the TLS session was setup.
+In {{!RFC8995}}, the Registrar proved possession of the it's credential when the TLS session was setup.
 While the pledge could not, at the time, validate the certificate truly belonged the registrar, it did validate that the certificate it was provided was able to authenticate the TLS connection.
 
 In the BRSKI-PRM mode, with the Registrar-Agent mediating all communication, the Pledge has not as yet been able to witness that the intended Registrar really does possess the relevant private key.
 This second signature provides for the same level of assurance to the pledge, and that it matches the public key that the pledge received in the trigger for the PVR (see {{pavrt}}).
 
 The registrar MUST use the same registrar EE credentials used for authentication in the TLS handshake to authenticate towards the Registrar-Agent.
-This has some operational implications when the registrar may be part of a scalable framework as described in {{?I-D.richardson-anima-registrar-considerations, section 1.3.1}}.
+This has some operational implications when the registrar may be part of a scalable framework as described in {{?I-D.richardson-anima-registrar-considerations, Section 1.3.1}}.
 
 The second signature MUST either be done with the private key associated with the registrar EE certificate provided to the Registrar-Agent, or the use of a certificate chain is necessary.
 This ensures that the same registrar EE certificate can be used to verify the signature as transmitted in the voucher-request as also transferred in the PVR in the "agent-provided-proximity-registrar-cert".
@@ -1461,25 +1386,23 @@ This ensures that the same registrar EE certificate can be used to verify the si
 
 # Example: Decoded payload "ietf-voucher:voucher" representation in
   JSON syntax
-{
-  "ietf-voucher:voucher": {
-     "assertion": "agent-proximity",
-     "serial-number": "callee4711",
-     "nonce": "base64encodedvalue==",
-     "created-on": "2022-01-04T00:00:02.000Z",
-     "pinned-domain-cert": "base64encodedvalue=="
-  }
+"ietf-voucher:voucher": {
+   "assertion": "agent-proximity",
+   "serial-number": "callee4711",
+   "nonce": "base64encodedvalue==",
+   "created-on": "2022-01-04T00:00:02.000Z",
+   "pinned-domain-cert": "base64encodedvalue=="
 }
 
 # Example: Decoded "JWS Protected Header (MASA)" representation
   in JSON syntax
 {
   "alg": "ES256",
+  "typ": "voucher-jws+json",
   "x5c": [
     "base64encodedvalue==",
     "base64encodedvalue=="
-  ],
-  "typ": "voucher-jws+json"
+  ]
 }
 
 # Example: Decoded "JWS Protected Header (Reg)" representation
@@ -1498,18 +1421,55 @@ Depending on the security policy of the operator, this signature can also be int
 The registrar sends the voucher to the Registrar-Agent.
 
 
-### Pledge-Enrollment-Request (PER) Processing (Registrar-Agent to Registrar) {#exchanges_uc2_2_per}
 
-After receiving the voucher, the Registrar-Agent sends the PER to the registrar in the same HTTP-over-TLS connection. Which is similar to the PER processing described in section 5.2 of {{RFC8995}}.
+### Response Artifact: Voucher
+
+After receiving the PVR from Registrar-Agent, the registrar SHALL perform the verification as defined in {{Section 5.3 of RFC8995}}.
+In addition, the registrar SHALL verify the following parameters from the PVR:
+
+* agent-provided-proximity-registrar-cert: MUST contain registrar's own registrar LDevID certificate to ensure the registrar in proximity of the Registrar-Agent is the desired registrar for this PVR.
+
+* agent-signed-data: The registrar MUST verify that the Registrar-Agent provided data has been signed with the private key corresponding to the EE (RegAgt) certificate indicated in the "kid" JOSE header parameter.
+  The registrar MUST verify that the LDevID(ReAgt) certificate, corresponding to the signature, is still valid.
+  If the certificate is already expired, the registrar SHALL reject the request.
+  Validity of used signing certificates at the time of signing the agent-signed-data is necessary to avoid that a rogue Registrar-Agent generates agent-signed-data objects to onboard arbitrary pledges at a later point in time, see also {{sec_cons_reg-agt}}.
+  The registrar MUST fetch the EE (RegAgt) certificate, based on the provided SubjectKeyIdentifier (SKID) contained in the "kid" header parameter of the agent-signed-data, and perform this verification.
+  This requires, that the registrar has access to the EE (RegAgt) certificate data (including intermediate CA certificates if existent) based on the SKID.
+  Note, the registrar may have stored the EE (RegAgt) certificate if used during TLS establishment between Registrar-Agent and registrar or it may be provided via a repository.
+
+If the registrar is unable to validate the PVR it SHOULD respond with a HTTP 4xx/5xx error code to the Registrar-Agent.
+
+The following 4xx client error codes SHOULD be used:
+
+* 403 Forbidden: if the registrar detected that one or more security related parameters are not valid.
+
+* 404 Not Found status code if the pledge provided information could not be used with automated allowance, as described in {{Section 5.3 of RFC8995}}.
+
+* 406 Not Acceptable: if the Content-Type indicated by the Accept header is unknown or unsupported.
+
+If the validation succeeds, the registrar performs pledge authorization according to {{Section 5.3 of !RFC8995}} followed by obtaining a voucher from the pledge's MASA according to {{Section 5.4 of !RFC8995}} with the modifications described below in {{rvr-proc}}.
+
+
+
+
+
+## Supply PER to Registrar {#per}
+
+After receiving the voucher, the Registrar-Agent sends the PER to the registrar in the same HTTP-over-TLS connection. Which is similar to the PER processing described in {{Section 5.2 of !RFC8995}}.
 In case the PER cannot be send in the same HTTP-over-TLS connection the Registrar-Agent may send the PER in a new HTTP-over-TLS connection. The registrar is able to correlate the PVR and the PER based on the signatures and the contained product-serial-number information.
 Note, this also addresses situations in which a nonceless voucher is used and may be pre-provisioned to the pledge.
-As specified in {{PER-response}} deviating from BRSKI the PER is not a raw PKCS#10.
-As the Registrar-Agent is involved in the exchange, the PKCS#10 is wrapped in a JWS object by the pledge and signed with pledge's IDevID to ensure proof-of-identity as outlined in {{per}}.
+
+### Request Artifact: Pledge Enroll-Request (PER)
+
+As specified in {{tper}} deviating from BRSKI the PER is not a raw PKCS#10.
+As the Registrar-Agent is involved in the exchange, the PKCS#10 is wrapped in a JWS object by the pledge and signed with pledge's IDevID to ensure proof-of-identity as outlined in {{per_example}}.
 
 EST {{RFC7030}} standard endpoints (/simpleenroll, /simplereenroll, /serverkeygen, /cacerts) on the registrar cannot be used for BRSKI-PRM.
 This is caused by the utilization of signature wrapped-objects in BRSKI-PRM.
 As EST requires to sent a raw PKCS#10 request to e.g., "/.well-known/est/simpleenroll" endpoint, this document makes an enhancement by utilizing EST but with the exception to transport a signature wrapped PKCS#10 request.
 Therefore a new endpoint for BRSKI-PRM on the registrar is defined as "/.well-known/brski/requestenroll"
+
+The Registrar-Agent SHALL send the PER to the registrar by HTTP POST to the endpoint: "/.well-known/brski/requestenroll"
 
 The Content-Type header of PER is: `application/jose+json`.
 
@@ -1520,21 +1480,26 @@ Note, the registrar is already aware that the bootstrapping is performed in a pl
 
 * The registrar verifies that the pledge's certificate (here IDevID), carried in "x5c" header field, is accepted to join the domain after successful validation of the PVR.
 
-* If both succeed, the registrar utilizes the PKCS#10 request contained in the JWS object body as "P10" parameter of "ietf-sztp-csr:csr" for further processing of the enrollment-request with the corresponding domain CA.
-  It creates a registrar-enrollment-request (RER) by utilizing the protocol expected by the domain CA.
-  The domain registrar may either directly forward the provided PKCS#10 request to the CA or provide additional information about attributes to be included by the CA into the requested LDevID certificate.
-  The approach of sending this information to the CA depends on the utilized certificate management protocol between the RA and the CA and is out of scope for this document.
+### Enrollment by Domain CA
 
-Note while BRSKI-PRM targets the initial enrollment, re-enrollment may be supported in a similar way with the exception that the current LDevID certificate is used instead of the IDevID certificate to verify the wrapping signature of the PKCS#10 request (see also {{PER-response}}).
+If both succeed, the registrar utilizes the PKCS#10 request contained in the JWS object body as "P10" parameter of "ietf-sztp-csr:csr" for further processing of the Enroll-Request with the corresponding domain CA.
+It creates a registrar-Enroll-Request (RER) by utilizing the protocol expected by the domain CA.
 
-The Registrar-Agent SHALL send the PER to the registrar by HTTP POST to the endpoint: "/.well-known/brski/requestenroll"
+The domain registrar may either directly forward the provided PKCS#10 request to the CA or provide additional information about attributes to be included by the CA into the requested LDevID certificate.
+
+The approach of sending this information to the CA depends on the utilized certificate management protocol between the RA and the CA and is out of scope for this document.
+
+### Response Artifact: Enroll-Response
 
 The registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
 
 A successful interaction with the domain CA will result in a pledge LDevID certificate, which is then forwarded by the registrar to the Registrar-Agent using the Content-Type header: `application/pkcs7-mime`.
 
 
-### Request Wrapped-CA-certificate(s) (Registrar-Agent to Registrar) {#exchanges_uc2_2_wca}
+Note while BRSKI-PRM targets the initial enrollment, re-enrollment may be supported in a similar way with the exception that the current LDevID certificate is used instead of the IDevID certificate to verify the wrapping signature of the PKCS#10 request (see also {{tper}}).
+
+
+## Request CA Certificates {#req_cacerts}
 
 As the pledge will verify it own certificate LDevID certificate when received, it also needs the corresponding CA certificates.
 This is done in EST {{RFC7030}} using the "/.well-known/est/cacerts" endpoint, which provides the CA certificates over a TLS protected connection.
@@ -1542,15 +1507,19 @@ BRSKI-PRM requires a signature wrapped CA certificate object, to avoid that the 
 The registrar signed CA certificate object will allow the pledge to verify the authorization to install the received CA certificate(s).
 As the CA certificate(s) are provided to the pledge after the voucher, the pledge has the required information (the domain certificate) to verify the wrapped CA certificate object.
 
+### Request Artifact: cACert-Req
+
 To support Registrar-Agents requesting a signature wrapped CA certificate(s) object, a new endpoint for BRSKI-PRM is defined on the registrar: "/.well-known/brski/wrappedcacerts"
 
 The Registrar-Agent SHALL requests the EST CA trust anchor database information (in form of CA certificates) by HTTP GET.
+
+### Response Artifact: cACert-Resp
 
 The Content-Type header of the response SHALL be: `application/jose+json`.
 
 This is a deviation from the Content-Type header values used in EST {{RFC7030}} and results in additional processing at the domain registrar (as EST server).
 The additional processing is to sign the CA certificate(s) information using the registrar LDevID credentials.
-This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certificates are provided as base64 encoded "x5bag" (see definition in {{RFC9360}}) in the JWS payload.
+This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certificates are provided as base64-encoded "x5bag" (see definition in {{RFC9360}}) in the JWS payload.
 
 ~~~~
 # The CA certificates data with registrar signature in General JWS Serialization syntax
@@ -1586,68 +1555,45 @@ This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certific
 {: #PCAC title='Representation of CA certificate(s) data with registrar signature' artwork-align="left"}
 
 
-## Response Objects supplied by the Registrar-Agent to the Pledge {#exchanges_uc2_3}
+
+
+
+## Supply Voucher to Pledge {#voucher}
+
 
 It is assumed that the Registrar-Agent already obtained the bootstrapping response objects from the domain registrar and can supply them to the pledge:
 
 * voucher-response - Voucher (from MASA via Registrar)
-
 * wrapped-CA-certificate(s)-response - CA certificates
-
 * enrollment-response - LDevID (Pledge) certificate (from CA via registrar)
 
 To deliver these response objects, the Registrar-Agent will re-connect to the pledge.
 To contact the pledge, it may either discover the pledge as described in {{discovery_uc2_ppa}} or use stored information from the first contact with the pledge.
 
-Preconditions in addition to {{exchanges_uc2_2}}:
+Preconditions in addition to {{pvr}}:
 
 * Registrar-Agent: obtained voucher and LDevID certificate and optionally IDevID CA certificates.
-  The IDevID CA certificate is necessary, when the connection between the Registrar-Agent and the pledge is established using TLS to enable the Registrar-Agent to validate the pledges' IDevID certificate during the TLS handshake as described in {{exchanges_uc2_1}}.
+  The IDevID CA certificate is necessary, when the connection between the Registrar-Agent and the pledge is established using TLS to enable the Registrar-Agent to validate the pledges' IDevID certificate during the TLS handshake as described in {{tpvr}}.
 
-
-~~~~ aasvg
-+--------+                        +-----------+
-| Pledge |                        | Registrar-|
-|        |                        | Agent     |
-|        |                        | (RegAgt)  |
-+--------+                        +-----------+
-    |                          [voucher and enrollment]
-    |                          [responses available]
-    |                                   |
-    |<----- optional TLS connection ----|
-    |                                   |
-    |<------- supply voucher -----------|
-    |                                   |
-    |--------- voucher status --------->| - store
-    |                                   |   pledge voucher status
-    |<--- supply CAcerts (optional) ----|
-    |                                   |
-    |<--- supply enrollment-response ---|
-    |                                   |
-    |--------- enroll status ---------->| - store
-    |                                   |   pledge enroll status
-
-~~~~
-{: #exchangesfig_uc2_3 title='Responses and status handling between pledge and Registrar-Agent' artwork-align="left"}
-
-The Registrar-Agent MAY optionally use TLS to protect the communication as outlined in {{exchanges_uc2_1}}.
+The Registrar-Agent MAY optionally use TLS to protect the communication as outlined in {{tpvr}}.
 
 The Registrar-Agent provides the information via distinct pledge endpoints as following.
 
-### Pledge: Voucher-Response Processing {#exchanges_uc2_3a}
+
+### Request Artifact: Voucher
 
 The Registrar-Agent SHALL send the voucher-response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/svr".
 
 The Registrar-Agent voucher-response Content-Type header is `application/voucher-jws+json` and contains the voucher as provided by the MASA. An example is given in {{MASA-vr}} for a MASA  signed voucher and in {{MASA-REG-vr}} for the voucher with the additional signature of the registrar.
 
-A nonceless voucher may be accepted as in {{RFC8995}} and may be allowed by a manufacture's pledge implementation.
+A nonceless voucher may be accepted as in {{!RFC8995}} and may be allowed by a manufacture's pledge implementation.
 
 To perform the validation of several signatures on the voucher object, the pledge SHALL perform the signature verification in the following order:
 
-  1. Verify MASA signature as described in section 5.6.1 in {{RFC8995}}, against pre-installed manufacturer trust anchor (IDevID).
+  1. Verify MASA signature as described in {{Section 5.6.1 of !RFC8995}}, against pre-installed manufacturer trust anchor (IDevID).
   2. Install trust anchor contained in the voucher ("pinned-domain-cert")  provisionally
-  3. Validate the LDevID(Reg) certificate received in the agent-provided-proximity-registrar-cert in the pledge-voucher-request trigger request (in the field "agent-provided-proximity-registrar-cert")
-  4. Verify registrar signature of the voucher similar as described in section 5.6.1 in {{RFC8995}}, but take the registrar certificate instead of the MASA certificate for the verification
+  3. Validate the LDevID(Reg) certificate received in the agent-provided-proximity-registrar-cert in the Pledge-Voucher-Request trigger request (in the field "agent-provided-proximity-registrar-cert")
+  4. Verify registrar signature of the voucher similar as described in {{Section 5.6.1 of !RFC8995}}, but take the registrar certificate instead of the MASA certificate for the verification
 
 Step3 and step 4 have been introduced in BRSKI-PRM to enable verification of LDevID(Reg) certificate and also the proof-of-possession of the corresponding private key by the registrar, which is done in BRSKI based on the established TLS channel.
 If all steps stated above have been performed successfully, the pledge SHALL terminate the "PROVISIONAL accept" state for the domain trust anchor and the registrar LDevID certificate.
@@ -1655,32 +1601,13 @@ If all steps stated above have been performed successfully, the pledge SHALL ter
 If an error occurs during the verification and validation of the voucher, this SHALL be reported in the reason field of the pledge voucher status.
 
 
-### Pledge: Voucher-Status Telemetry {#exchanges_uc2_3b}
+### Response Artifact: vStatus
 
-After voucher processing the pledge MUST reply with a voucher status telemetry message as defined in section 5.7 of {{RFC8995}}.
-The voucher-status is also a signed object in BRSKI-PRM and results in form of JSON-in-JWS here. 
-It SHALL be signed with pledge's IDevID credentials.
-BRSKI {{RFC8995}} section 5.7 specifies the voucher status telemetry message with two optional fields for "reason" and "reason-context". 
-In BRSKI-PRM the optional fields are mandated to have a clear distinction between other status messages and MUST be provided therefore.
-This distinction is intended for better error handling on registrar side, as a status object could be send to a wrong status endpoint.
-The following CDDL {{RFC8610}} defines the pledge voucher-status response structure. 
-It is similar as defined in {{?RFC8995, section 5.7}} with the optional fields set as mandatory as described above.
-
-~~~~
-<CODE BEGINS>
-voucherstatus-post = {
-    "version": uint,
-    "status": bool,
-    "reason": text,
-    "reason-context" : { $$arbitrary-map }
-  }
-<CODE ENDS>
-~~~~
-{: #v_stat_res_def title='CDDL for pledge-voucher-status response' artwork-align="left"}
-
-  
+After voucher verification and validation the pledge MUST reply with a status telemetry message as defined in {{Section 5.7 of !RFC8995}}.
 The pledge generates the voucher-status and provides it as signed JSON-in-JWS object in response to the Registrar-Agent.
+
 The response has the Content-Type `application/jose+json` and is signed using the IDevID of the pledge as shown in {{vstat}}.
+As the reason field is optional (see {{!RFC8995}}), it MAY be omitted in case of success.
 
 ~~~~
 # The "pledge-voucher-status" telemetry in general JWS
@@ -1730,10 +1657,12 @@ The response has the Content-Type `application/jose+json` and is signed using th
 ~~~~
 {: #vstat title='Representation of pledge voucher status telemetry' artwork-align="left"}
 
-If the pledge did not did not provide voucher status telemetry information after processing the voucher, the Registrar-Agent MAY query the pledge status explicitly as described in {{exchanges_uc2_5}} and MAY resent the voucher depending on the Pledge status following the procedure described in {{exchanges_uc2_3a}}.
+If the pledge did not did not provide voucher status telemetry information after processing the voucher, the Registrar-Agent MAY query the pledge status explicitly as described in {{query}} and MAY resent the voucher depending on the Pledge status following the procedure described in {{voucher}}.
 
 
-### Pledge: Wrapped-CA-Certificate(s) Processing {#exchanges_uc2_3c}
+## Supply CA certificates to Pledge {#cacerts}
+
+### Request Artifact:
 
 The Registrar-Agent SHALL provide the set of CA certificates requested from the registrar to the pledge by HTTP POST to the endpoint: "/.well-known/brski/scac".
 
@@ -1741,7 +1670,7 @@ As the CA certificate provisioning is crucial from a security perspective, this 
 
 The CA certificates message has the Content-Type `application/jose+json` and is signed using the credential of the registrar as shown in {{PCAC}}.
 
-The CA certificates are provided as base64 encoded "x5bag".
+The CA certificates are provided as base64-encoded "x5bag".
 The pledge SHALL install the received CA certificates as trust anchor after successful verification of the registrar's signature.
 
 The verification comprises the following steps the pledge MUST perform. Maintaining the order of versification steps as indicated allows to determine, which verification has already been passed:
@@ -1752,31 +1681,35 @@ The verification comprises the following steps the pledge MUST perform. Maintain
   4. Verify signature of the the received wrapped CA certificate object. If the validation of the signature fails, the pledge SHOULD reply with a 406 Not Acceptable. It signals that the object has not been accepted.
   5. If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of [RFC7030].
 
+### Response
 
-### Pledge: Enrollment-Response Processing
+TODO[empty?]
 
-The Registrar-Agent SHALL send the enroll-response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/ser".
+## Supply Enroll-Response to Pledge {#enroll_response}
 
-The Registrar-Agent enroll-response Content-Type header, when using EST {{RFC7030}} as enrollment protocol between the Registrar-Agent and the infrastructure is: `application/pkcs7-mime`.
+### Request Artifact: Enroll-Response
+
+The Registrar-Agent SHALL send the Enroll-Response to the pledge by HTTP POST to the endpoint: "/.well-known/brski/ser".
+
+The Content-Type header when using EST {{RFC7030}} as enrollment protocol between the Registrar-Agent and the infrastructure is `application/pkcs7-mime`.
 Note: It only contains the LDevID certificate for the pledge, not the certificate chain.
 
 Upon reception, the pledge SHALL verify the received LDevID certificate.
 The pledge SHALL generate the enroll status and provide it in the response to the Registrar-Agent.
 If the verification of the LDevID certificate succeeds, the status property SHALL be set to "status": true, otherwise to "status": false
 
+### Response Artifact: eStatus
 
-### Pledge: Enrollment-Status Telemetry  {#exchanges_uc2_3e}
-
-After enrollment processing the pledge MUST reply with a enrollment status telemetry message as defined in section 5.9.4 of {{RFC8995}}.
+After enrollment processing the pledge MUST reply with a enrollment status telemetry message as defined in {{Section 5.9.4 of !RFC8995}}.
 The enroll-status is also a signed object in BRSKI-PRM and results in form of JSON-in-JWS here.
 If the pledge verified the received LDevID certificate successfully it SHALL sign the enroll-status using its new LDevID credentials as shown in {{estat}}.
 In failure case, the pledge SHALL use its IDevID credentials.
-BRSKI {{RFC8995}} section 5.9.4 specifies the enrollment status telemetry message with two optional fields for "reason" and "reason-context". 
+{{Section 5.9.4 of !RFC8995}} specifies the enrollment status telemetry message with two optional fields for "reason" and "reason-context". 
 In BRSKI-PRM the optional fields are mandated to have a clear distinction between other status messages and MUST be provided therefore.
 This distinction is intended for better error handling on registrar side, as a status object could be send to a wrong status endpoint.
 
-The following CDDL {{RFC8610}} explains enroll-status response structure. 
-It is similar as defined in {{?RFC8995, section 5.9.4}} with the optional fields set to mandatory as described above.
+The following CDDL {{!RFC8610}} explains enroll-status response structure. 
+It is similar as defined in {{Section 5.9.4 of !RFC8995}} with the optional fields set to mandatory as described above.
 
 ~~~~
 <CODE BEGINS>
@@ -1810,7 +1743,7 @@ The response has the Content-Type `application/jose+json`.
 {
   "version": 1,
   "status": true,
-  "reason": "Enrollment response successfully processed",
+  "reason": "Enroll-Response successfully processed",
   "reason-context": {
     "pes-details": "JSON"
   }
@@ -1821,7 +1754,7 @@ The response has the Content-Type `application/jose+json`.
 {
   "version": 1,
   "status": false,
-  "reason": "Enrollment response could not be verified.",
+  "reason": "Enroll-Response could not be verified.",
   "reason-context": {
     "pes-details": "no matching trust anchor"
   }
@@ -1842,20 +1775,19 @@ The response has the Content-Type `application/jose+json`.
 Once the Registrar-Agent has collected the information, it can connect to the registrar to provide it with the status responses.
 
 
-### Telemetry Voucher Status and Enroll Status Handling (Registrar-Agent to Domain Registrar) {#exchanges_uc2_4}
+## Voucher Status Telemetry {#vstatus}
 
 The following description requires that the Registrar-Agent has collected the status information from the pledge.
 It SHALL provide the status information to the registrar for further processing.
 
-Preconditions in addition to {{exchanges_uc2_2}}:
+Preconditions in addition to {{pvr}}:
 
 * Registrar-Agent: obtained voucher status and enroll status from pledge.
 
 ~~~~ aasvg
 +-----------+        +-----------+   +--------+   +---------+
-| Registrar-|        | Domain    |   | Domain |   | Vendor  |
-| Agent     |        | Registrar |   | CA     |   | Service |
-| (RegAgt)  |        |  (JRC)    |   |        |   | (MASA)  |
+| Registrar-|        | Domain    |   | Domain |   | MASA    |
+| Agent     |        | Registrar |   | CA     |   |         |
 +-----------+        +-----------+   +--------+   +---------+
     |                      |              |   Internet |
 [voucher + enroll ]        |              |            |
@@ -1876,9 +1808,11 @@ Preconditions in addition to {{exchanges_uc2_2}}:
 The Registrar-Agent MUST provide the collected pledge voucher status to the registrar.
 This status indicates if the pledge could process the voucher successfully or not.
 
-In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in {{exchanges_uc2_2}}.
+In case the TLS connection to the registrar is already closed, the Registrar-Agent opens a new TLS connection with the registrar as stated in {{pvr}}.
 
-The Registrar-Agent sends the pledge voucher status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/voucher_status". The Content-Type header is kept as `application/jose+json` as described in {{exchangesfig_uc2_3}} and depicted in the example in {{vstat}}.
+### Request Artifact: vStatus
+
+The Registrar-Agent sends the pledge voucher status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/voucher_status". The Content-Type header is kept as `application/jose+json` as depicted in the example in {{vstat}}.
 
 The registrar SHOULD log the transaction provided for a pledge via Registrar-Agent and include the identity of the Registrar-Agent in these logs. For log analysis the following may be considered:
 
@@ -1888,25 +1822,33 @@ The registrar SHOULD log the transaction provided for a pledge via Registrar-Age
 
 The registrar SHALL verify the signature of the pledge voucher status and validate that it belongs to an accepted device of the domain based on the contained "serial-number" in the IDevID certificate referenced in the header of the voucher status.
 
-According to {{RFC8995}} section 5.7, the registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
+### Response
+
+According to {{Section 5.7 of !RFC8995}}, the registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
 The Registrar-Agent may use the response to signal success / failure to the service technician operating the Registrar-Agent.
 Within the server logs the server SHOULD capture this telemetry information.
 
-The registrar SHOULD proceed with collecting and logging status information by requesting the MASA audit-log from the MASA service as described in section 5.8 of {{RFC8995}}.
+The registrar SHOULD proceed with collecting and logging status information by requesting the MASA audit-log from the MASA service as described in {{Section 5.8 of !RFC8995}}.
+
+## Enroll Status Telemetry {#estatus}
 
 The Registrar-Agent MUST provide the pledge's enroll status to the registrar.
-The status indicates the pledge could process the enroll-response (certificate) and holds the corresponding private key.
+The status indicates the pledge could process the Enroll-Response (certificate) and holds the corresponding private key.
+
+### Request Artifact: vStatus
 
 The Registrar-Agent sends the pledge enroll status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/enrollstatus".
-The Content-Type header is kept as `application/jose+json` as described in {{exchangesfig_uc2_3}} and depicted in the example in {{estat}}.
+The Content-Type header is kept as `application/jose+json` as depicted in the example in {{estat}}.
 
 The registrar MUST verify the signature of the pledge enroll status.
 Also, the registrar SHALL validate that the pledge is an accepted device of the domain based on the contained product-serial-number in the LDevID certificate referenced in the header of the enroll status.
 The registrar SHOULD log this event.
 In case the pledge enroll status indicates a failure, the pledge was unable to verify the received LDevID certificate and therefore signed the enroll status with its IDevID credential.
-Note that the signature verification of the status information is an addition to the described handling in section 5.9.4 of {{RFC8995}}, and is replacing the pledges TLS client authentication by DevID credentials in [RFC8995].
+Note that the signature verification of the status information is an addition to the described handling in {{Section 5.9.4 of !RFC8995}}, and is replacing the pledges TLS client authentication by DevID credentials in {{!RFC8995}}.
 
-According to {{RFC8995}} section 5.9.4, the registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
+### Response
+
+According to {{Section 5.9.4 of !RFC8995}}, the registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes as defined by the HTTP standard.
 Based on the failure case the registrar MAY decide that for security reasons the pledge is not allowed to reside in the domain. In this case the registrar MUST revoke the certificate.
 An example case for the registrar revoking the issued LDevID for the pledge is when the pledge was not able to verify the received LDevID certificate and therefore did send a 406 (Not Acceptable) response.
 In this case the registrar may revoke the LDevID certificate as the pledge did no accepted it for installation.
@@ -1915,7 +1857,7 @@ The Registrar-Agent may use the response to signal success / failure to the serv
 Within the server log the registrar SHOULD capture this telemetry information.
 
 
-## Request Pledge-Status by Registrar-Agent from Pledge {#exchanges_uc2_5}
+## Query Pledge Status {#query}
 
 The following assumes that a Registrar-Agent may need to query the status of a pledge.
 This information may be useful to solve errors, when the pledge was not able to connect to the target domain during the bootstrapping.
@@ -1930,7 +1872,6 @@ Preconditions:
 +--------+                     +-----------+
 | Pledge |                     | Registrar-|
 |        |                     | Agent     |
-|        |                     | (RegAgt)  |
 +--------+                     +-----------+
     |                                |
     |<--- pledge-status request -----|
@@ -1940,7 +1881,7 @@ Preconditions:
 ~~~~
 {: #exchangesfig_uc2_5 title='Pledge-status handling between Registrar-Agent and pledge' artwork-align="left"}
 
-### Pledge-Status - Request (Registrar-Agent to Pledge) {#exchanges_uc2_5a}
+### Request Artifact: status-request
 
 The Registrar-Agent requests the pledge-status via HTTP POST on the defined pledge endpoint: "/.well-known/brski/qps"
 
@@ -1948,7 +1889,7 @@ The Registrar-Agent Content-Type header for the pledge-status request is: `appli
 It contains information on the requested status-type, the time and date the request is created, and the product serial-number of the pledge contacted as shown in {{stat_req_def}}.
 The pledge-status request is signed by Registrar-Agent using the private key corresponding to the EE (RegAgt) certificate.
 
-The following Concise Data Definition Language (CDDL) {{RFC8610}} explains the structure of the format for the pledge-status request. It is defined following the status telemetry definitions in BRSKI {{RFC8995}}.
+The following Concise Data Definition Language (CDDL) {{RFC8610}} explains the structure of the format for the pledge-status request. It is defined following the status telemetry definitions in BRSKI {{!RFC8995}}.
 Consequently, format and semantics of pledge-status requests below are for version 1.
 The version field is included to permit significant changes to the pledge-status request and response in the future.
 A pledge or a Registrar-Agent that receives a pledge-status request with a version larger than it knows about SHOULD log the contents and alert a human.
@@ -1976,7 +1917,7 @@ This is out of scope for this specification.
 # The Registrar-Agent request of "pledge-status" in general JWS
   serialization syntax
 {
-  "payload": BASE64URL(status-request),
+  "payload": BASE64URL(UTF8(status-request)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -2007,9 +1948,9 @@ This is out of scope for this specification.
 {: #stat_req title='Example of Registrar-Agent request of pledge-status using status-type bootstrap' artwork-align="left"}
 
 
-### Pledge-Status - Response (Pledge - Registrar-Agent) {#exchanges_uc2_5b}
+### Response Artifact: status-response
 
-If the pledge receives the pledge-status request with status-type "bootstrap" it SHALL react with a status response message based on the telemetry information described in {{exchanges_uc2_3}}.
+If the pledge receives the pledge-status request with status-type "bootstrap" it SHALL react with a status response message based on the telemetry information described in TODO.
 
 The pledge-status response Content-Type header is `application/jose+json`.
 
@@ -2056,7 +1997,7 @@ The pledge-status response message is signed with IDevID or LDevID, depending on
   Additional information may be provided in the reason or reason-context.
   The pledge signs the response message using its IDevID(Pledge).
 
-The reason and the reason-context SHOULD contain the telemetry information as described in {{exchanges_uc2_3}}.
+The reason and the reason-context SHOULD contain the telemetry information as described in TODO[exchanges_uc2_3].
 
 As the pledge is assumed to utilize its bootstrapped credentials (LDevID) in communication with other peers, additional status information is provided for the connectivity to other peers, which may be helpful in analyzing potential error cases.
 
@@ -2074,7 +2015,7 @@ The pledge-status responses are cumulative in the sense that connect-success imp
 ~~~~
 # The pledge "status-response" in General JWS Serialization syntax
 {
-  "payload": BASE64URL(status-response),
+  "payload": BASE64URL(UTF8(status-response)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -2119,18 +2060,18 @@ If validation of the JWS signature fails, the pledge SHOULD respond with the HTT
 The pledge SHOULD by default only respond to requests from nodes it can authenticate (such as registrar
 agent), once the pledge is enrolled with CA certificates and a matching domain certificate.
 
-# Artifacts
+# TODO Artifacts
 
 ## Voucher-Request Artifact {#voucher-request-prm-yang}
 
-{{I-D.ietf-anima-rfc8366bis}} extends the voucher-request as defined in {{RFC8995}} to include additional fields necessary for handling bootstrapping in the pledge-responder-mode.
-These additional fields are defined in {{exchanges_uc2_1}} as:
+{{I-D.ietf-anima-rfc8366bis}} extends the voucher-request as defined in {{!RFC8995}} to include additional fields necessary for handling bootstrapping in the pledge-responder-mode.
+These additional fields are defined in {{tpvr}} as:
 
 * agent-signed-data to provide a JSON encoded artifact from the involved Registrar-Agent, which allows the registrar to verify the Registrar-Agent's involvement
-* agent-provided-proximity-registrar-cert to provide the registrar certificate visible to the Registrar-Agent, comparable to the registrar-proximity-certificate used in {{RFC8995}}
-* agent-signing certificate to optionally provide the Registrar-Agent signing certificate.
+* agent-provided-proximity-registrar-cert to provide the registrar certificate visible to the Registrar-Agent, comparable to the registrar-proximity-certificate used in {{!RFC8995}}
+* TODO[where used? LDevID?] agent-signing certificate to optionally provide the Registrar-Agent signing certificate.
 
-Examples for the application of these fields in the context of a PVR are provided in {{exchanges_uc2_2}}.
+Examples for the application of these fields in the context of a PVR are provided in {{pvr}}.
 
 
 # IANA Considerations {#iana-con}
@@ -2141,19 +2082,18 @@ This document requires the following IANA actions.
 
 IANA is requested to enhance the Registry entitled: "BRSKI Well-Known URIs" with the following endpoints:
 
-~~~~
- URI                Description                       Reference
- tpvr               create pledge-voucher-request     [THISRFC]
- tper               create pledge-enrollment-request  [THISRFC]
- svr                supply voucher-response           [THISRFC]
- ser                supply enrollment-response        [THISRFC]
- scac               supply CA certificates to pledge  [THISRFC]
- qps                query pledge status               [THISRFC]
- requestenroll      supply PER to registrar           [THISRFC]
- wrappedcacerts     request wrapped CA certificates   [THISRFC]
-
-~~~~
-{: artwork-align="left"}
+| Path Segment   | Description                       | Reference |
+|----------------|-----------------------------------|-----------|
+| requestenroll  | Supply PER to registrar           | [THISRFC] |
+| wrappedcacerts | Request wrapped CA certificates   | [THISRFC] |
+| tpvr           | Trigger Pledge Voucher-Request    | [THISRFC] |
+| tper           | Trigger Pledge Enroll-Request     | [THISRFC] |
+| svr            | Supply Voucher to pledge          | [THISRFC] |
+| scac           | Supply CA certificates to pledge  | [THISRFC] |
+| ser            | Supply Enroll-Response to pledge  | [THISRFC] |
+| qps            | Query Pledge Status               | [THISRFC] |
+|=========
+{: #iana_table title='BRSKI Well-Known URIs Additions' }
 
 ##  DNS Service Names
 
@@ -2168,13 +2108,13 @@ IANA has registered the following service names:
 
 # Privacy Considerations
 
-In general, the privacy considerations of {{RFC8995}} apply for BRSKI-PRM also.
+In general, the privacy considerations of {{!RFC8995}} apply for BRSKI-PRM also.
 Further privacy aspects need to be considered for:
 
 * the introduction of the additional component Registrar-Agent
 * potentially no transport layer security between Registrar-Agent and pledge
 
-{{exchanges_uc2_1}} describes to optional apply TLS to protect the communication between the Registrar-Agent and the pledge.
+{{tpvr}} describes to optional apply TLS to protect the communication between the Registrar-Agent and the pledge.
 The following is therefore applicable to the communication without the TLS protection.
 
 The credential used by the Registrar-Agent to sign the data for the pledge SHOULD NOT contain any personal information.
@@ -2195,7 +2135,7 @@ Depending on the requests and responses, the following information is disclosed.
 
 # Security Considerations {#sec_cons}
 
-In general, the security considerations of {{RFC8995}} apply for BRSKI-PRM also.
+In general, the security considerations of {{!RFC8995}} apply for BRSKI-PRM also.
 Further security aspects are considered here related to:
 
 * the introduction of the additional component Registrar-Agent
@@ -2206,7 +2146,7 @@ Further security aspects are considered here related to:
 ## Denial of Service (DoS) Attack on Pledge {#sec_cons-dos}
 
 Disrupting the pledge behavior by a DoS attack may prevent the bootstrapping of the pledge to a new domain.
-Because in BRSKI-PRM, the pledge responds to requests from real or illicit Registrar-Agents, pledges are more subject to DoS attacks from Registrar-Agents in BRSKI-PRM than they are from illicit registrars in {{RFC8995}}, where pledges do initiate the connections.
+Because in BRSKI-PRM, the pledge responds to requests from real or illicit Registrar-Agents, pledges are more subject to DoS attacks from Registrar-Agents in BRSKI-PRM than they are from illicit registrars in {{!RFC8995}}, where pledges do initiate the connections.
 
 A DoS attack with a faked Registrar-Agent may block the bootstrapping of the pledge due changing state on the pledge (the pledge may produce a voucher-request, and refuse to produce another one).
 One mitigation may be that the pledge does not limited the number of voucher-requests it creates until at least one has finished.
@@ -2225,7 +2165,7 @@ The domain registrar needs to verify that the "proximity-registrar-cert" field i
 In addition, the domain registrar needs to verify the association of the pledge to its domain based on the product-serial-number contained in the PVR and in the IDevID certificate of the pledge. (This is just part of the supply chain integration).
 Moreover, the domain registrar verifies if the Registrar-Agent is authorized to interact with the pledge for voucher-requests and enroll-requests, based on the EE (RegAgt) certificate data contained in the PVR.
 
-Misbinding of a pledge by a faked domain registrar is countered as described in BRSKI security considerations {{RFC8995}} (Section 11.4).
+Misbinding of a pledge by a faked domain registrar is countered as described in BRSKI security considerations {{Section 11.4 of !RFC8995}}.
 
 
 ## Misuse of Registrar-Agent Credentials {#sec_cons_reg-agt}
@@ -2254,15 +2194,15 @@ A manufacturer may decide to support this feature only for devices not possessin
 
 ## YANG Module Security Considerations
 
-The enhanced voucher-request described in {{I-D.ietf-anima-rfc8366bis}} is based on {{RFC8995}}, but uses a different encoding based on {{I-D.ietf-anima-jws-voucher}}.
-The security considerations as described in {{RFC8995}} section 11.7 (Security Considerations) apply.
+The enhanced voucher-request described in {{!I-D.ietf-anima-rfc8366bis}} is based on {{!RFC8995}}, but uses a different encoding based on {{!I-D.ietf-anima-jws-voucher}}.
+The security considerations as described in {{Section 11.7 of !RFC8995}} (Security Considerations) apply.
 
 The YANG module specified in {{I-D.ietf-anima-rfc8366bis}} defines the schema for data that is subsequently encapsulated by a JOSE signed-data Content-type as described in {{I-D.ietf-anima-jws-voucher}}.
 As such, all of the YANG-modeled data is protected against modification.
 
 The use of YANG to define data structures via the {{?RFC8971}} "structure" statement, is relatively
-new and distinct from the traditional use of YANG to define an API accessed by network management protocols such as NETCONF {{RFC6241}} and RESTCONF {{RFC8040}}.
-For this reason, these guidelines do not follow the template described by {{RFC8407}} section 3.7 (Security Considerations section).
+new and distinct from the traditional use of YANG to define an API accessed by network management protocols such as NETCONF {{?RFC6241}} and RESTCONF {{?RFC8040}}.
+For this reason, these guidelines do not follow the template described by {{Section 3.7 of ?RFC8407}} (Security Considerations).
 
 
 # Acknowledgments
@@ -2280,7 +2220,7 @@ Support in PoC implementations and comments resulting from the implementation wa
 These examples are folded according to {{RFC8792}} Single Backslash rule.
 
 
-## Example Pledge-Voucher-Request - PVR (from Pledge to Registrar-Agent)
+## Example Pledge Voucher-Request (PVR) - from Pledge to Registrar-Agent
 
 The following is an example request sent from a Pledge to the Registrar-Agent, in "General JWS JSON Serialization".
 The message size of this PVR is: 4649 bytes
@@ -2367,9 +2307,9 @@ yuXZ2aw93zZId45R7XxAK-12YKIx6qLjiPjMw"
 {: #ExamplePledgeVoucherRequestfigure title='Example Pledge-Voucher-Request - PVR' artwork-align="left"}
 
 
-## Example Parboiled Registrar-Voucher-Request - RVR (from Registrar to MASA)
+## Example Parboiled Registrar Voucher-Request (RVR) - from Registrar to MASA
 
-The term parboiled refers to food which is partially cooked.  In {{RFC8995}}, the term refers to a pledge-voucher-request (PVR) which has
+The term parboiled refers to food which is partially cooked.  In {{!RFC8995}}, the term refers to a pledge-voucher-request (PVR) which has
 been received by the Registrar, and then has been processed by the Registrar ("cooked"), and is now being forwarded to the MASA.
 
 The following is an example registrar-voucher-request (RVR) sent from the Registrar to the MASA, in "General JWS JSON Serialization".
@@ -2584,7 +2524,7 @@ yyFd3kP6YCn35YYJ7yK35d3styo_yoiPfKA"
 {: #ExampleRegistrarVoucherRequestfigure title='Example Registrar-Voucher-Request - RVR' artwork-align="left"}
 
 
-## Example Voucher-Response (from MASA to Pledge, via Registrar and Registrar-Agent)
+## Example Voucher - from MASA to Pledge, via Registrar and Registrar-Agent
 
 The following is an example voucher-response from MASA to Pledge via Registrar and Registrar-Agent, in "General JWS JSON Serialization". The message size of this Voucher is: 1916 bytes
 
@@ -2628,7 +2568,7 @@ TvHMUw0wx9wdyuNVjNoAgLysNIgEvlcltBw"
 {: #ExampleVoucherResponsefigure title='Example Voucher-Response from MASA' artwork-align="left"}
 
 
-## Example Voucher-Response, MASA issued Voucher with additional Registrar signature (from MASA to Pledge, via Registrar and Registrar-Agent)
+## Example Voucher, MASA issued Voucher with additional Registrar signature (from MASA to Pledge, via Registrar and Registrar-Agent)
 
 The following is an example voucher-response from MASA to Pledge via Registrar and Registrar-Agent, in "General JWS JSON Serialization".
 The message size of this Voucher is: 3006 bytes
@@ -2701,20 +2641,20 @@ The use of HTTP-over-TLS is not mandated by this document for a number of reason
 
 1. A certificate is generally required in order to do TLS.  While there are other modes of authentication including PSK, various EAP methods and raw public key, they do no help as there is no previous relationship between the Registrar-Agent.
 
-2. The pledge can use it's IDevID certificate to authenticate itself, but {{?RFC6125}} DNS-ID methods do not apply as the pledge does not have a FQDN.  Instead a new mechanism is required, which authenticates the X520SerialNumber DN attribute which must be present in every IDevID.
+2. The pledge can use it's IDevID certificate to authenticate itself, but {{?RFC9525}} DNS-ID methods do not apply as the pledge does not have a FQDN.  Instead a new mechanism is required, which authenticates the X520SerialNumber DN attribute which must be present in every IDevID.
 
 If the Registrar-Agent has a preconfigured list of which product-serial-number(s), from which manufacturers it expects to see, then it can attempt to match this pledge against a list of potential devices.
 
 In many cases only the list of manufacturers is known ahead of time, so at most the Registrar-Agent can show the X520SerialNumber to the (human) operator who may then attempt to confirm that they are standing in front of a device with that product-serial-number.
 The use of scannable QRcodes may help automate this in some cases.
 
-3. The CA used to sign the IDevID will be a manufacturer private PKI as described in {{?I-D.irtf-t2trg-taxonomy-manufacturer-anchors, section 4.1}}.
+3. The CA used to sign the IDevID will be a manufacturer private PKI as described in {{?I-D.irtf-t2trg-taxonomy-manufacturer-anchors, Section 4.1}}.
 The anchors for this PKI will never be part of the public WebPKI anchors which are distributed with most smartphone operating systems.
 A Registrar-Agent application will need to use different APIs in order to initiate an HTTPS connection without performing WebPKI verification.
 The application will then have to do it's own certificate chain verification against a store of manufacturer trust anchors.
 In the Android ecosystem this involved use of a customer TrustManager: many application developers do not create these correctly, and there is significant push to remove this option as it has repeatedly resulted in security failures. See {{androidtrustfail}}
 
-4. The use of the Host: (or :authority in HTTP/2) is explained in {{?RFC9110, section 7.2}}. This header is mandatory, and so a compliant HTTPS client is going to insert it.
+4. The use of the Host: (or :authority in HTTP/2) is explained in {{?RFC9110, Section 7.2}}. This header is mandatory, and so a compliant HTTPS client is going to insert it.
 But, the contents of this header will at best be an IP address that came from the discovery process.
 The pledge MUST therefore ignore the Host: header when it processes requests, and the pledge MUST NOT do any kind of name-base virtual hosting using the IP address/port combination.
 Note that there is no requirement for the pledge to operate it's BRSKI-PRM service on port 80 or port 443, so if there is no reason for name-based virtual hosting.
@@ -2730,18 +2670,14 @@ Proof of Concept Code available
 From IETF draft 11 -> IETF draft 12:
 
 * Updated acknowledgements to reflect early reviews
-* Reworked examples to fit JSON syntax
-* Update references to for voucher context to I-D.ietf-anima-rfc8366bis
-* Renamed ietf-voucher-request-prm to ietf-voucher to refelct move of YANG module to RFC8366bis
-* Updated status response member usage in {{exchanges_uc2_3b}} and {{exchanges_uc2_3e}} to always use all field in the BRSKI defined status messages 
 
 
 From IETF draft 10 -> IETF draft 11:
 
 * issue #79, clarified that BRSKI discovery in the context of BRSKI-PRM is not needed in {{discovery_uc2_reg}}.
-* issue #103, removed step 6 in verification handling for the wrapped CA certificate provisioning as only applicable after enrollment {{exchanges_uc2_3c}}
+* issue #103, removed step 6 in verification handling for the wrapped CA certificate provisioning as only applicable after enrollment {{cacerts}}
 * issue #128: included notation of nomadic operation of the Registrar-Agent in {{architecture}}, including proposed text from PR #131
-* issue #130, introduced DNS service discovery name for brski_pledge to enable discovery by the Registrar-Agent in {{iana-con}
+* issue #130, introduced DNS service discovery name for brski_pledge to enable discovery by the Registrar-Agent in {{iana-con}}
 * removed unused reference RFC 5280
 * removed site terminology
 * deleted duplicated text in {{pledge_ep}}
@@ -2753,11 +2689,11 @@ From IETF draft 09 -> IETF draft 10:
 
 * issue #79, clarified discovery in the context of BRSKI-PRM and included information about future discovery enhancements in a separate draft in {{discovery_uc2_reg}}.
 * issue #93, included information about conflict resolution in mDNS and GRASP in {{discovery_uc2_ppa}}
-* issue #103, included verification handling for the wrapped CA certificate provisioning in {{exchanges_uc2_3c}}
-* issue #106, included additional text to elaborate more the registrar status handling in {{exchanges_uc2_4}}
+* issue #103, included verification handling for the wrapped CA certificate provisioning in {{cacerts}}
+* issue #106, included additional text to elaborate more the registrar status handling in {{vstatus}} and {{estatus}}
 * issue #116, enhanced DoS description in {{sec_cons-dos}}
 * issue #120, included statement regarding pledge host header processing in {{pledge_ep}}
-* issue #122, availability of product-serial-number information on registrar agent clarified in {{exchanges_uc2_1}}
+* issue #122, availability of product-serial-number information on registrar agent clarified in {{tpvr}}
 * issue #123, Clarified usage of alternative voucher formats in  {{rvr-proc}}
 * issue #124, determination of pinned domain certificate done as in RFC 8995 included in {{exchanges_uc2_2_vc}}
 * issue #125, remove strength comparison of voucher assertions in {{agt_prx}} and {{exchanges_uc2}}
@@ -2770,28 +2706,28 @@ From IETF draft 08 -> IETF draft 09:
 
 * issue #80, enhanced {{discovery_uc2_ppa}} with clarification on the product-serial-number and the inclusion of GRASP
 * issue #81, enhanced introduction with motivation for agent_signed_data
-* issue #82, included optional TLS protection of the communication link between Registrar-Agent and pledge in the introduction {{req-sol}}, and {{exchanges_uc2_1}}
-* issue #83, enhanced {{PER-response}} and {{exchanges_uc2_2_per}} with note to re-enrollment
-* issue #87, clarified available information at the Registrar-Agent in {{exchanges_uc2_1}
-* issue #88, clarified, that the PVR in {{pvrr}} and PER in {{PER-response}} may contain the certificate chain. If not contained it MUST be available at the registrar.
-* issue #91, clarified that a separate HTTP connection may also be used to provide the PER in {{exchanges_uc2_2_per}}
+* issue #82, included optional TLS protection of the communication link between Registrar-Agent and pledge in the introduction {{req-sol}}, and {{tpvr}}
+* issue #83, enhanced {{tper}} and {{pvr}} with note to re-enrollment
+* issue #87, clarified available information at the Registrar-Agent in {{tpvr}}
+* issue #88, clarified, that the PVR in {{tpvr}} and PER in {{tper}} may contain the certificate chain. If not contained it MUST be available at the registrar.
+* issue #91, clarified that a separate HTTP connection may also be used to provide the PER in {{per}}
 * resolved remaining editorial issues discovered after WGLC (responded to on the mailing list in Reply 1 and Reply 2) resulting in more consistent descriptions
-* issue #92: kept separate endpoint for wrapped CSR on registrar {{exchanges_uc2_2_wca}}
+* issue #92: kept separate endpoint for wrapped CSR on registrar {{req_cacerts}}
 * issue #94: clarified terminology (possess vs. obtained)
-* issue #95: clarified optional IDevID CA certificates on Registrar-Agent {{exchanges_uc2_3}}
-* issue #96: updated {{exchangesfig_uc2_3}} to correct to just one CA certificate provisioning
-* issue #97: deleted format explanation in {{exchanges_uc2_3}} as it may be misleading
-* issue #99: motivated verification of second signature on voucher in {{exchanges_uc2_3}}
+* issue #95: clarified optional IDevID CA certificates on Registrar-Agent
+* issue #96: updated exchangesfig_uc2_3 to correct to just one CA certificate provisioning
+* issue #97: deleted format explanation in exchanges_uc2_3 as it may be misleading
+* issue #99: motivated verification of second signature on voucher in {{voucher}}
 * issue #100: included negative example in {{vstat}}
 
-* issue #101: included handling if {{exchanges_uc2_3b}} voucher telemetry information has not been received by the Registrar-Agent
-* issue #102: relaxed requirements for CA certs provisioning in {{exchanges_uc2_3c}}
+* issue #101: included handling if {{voucher}} voucher telemetry information has not been received by the Registrar-Agent
+* issue #102: relaxed requirements for CA certs provisioning in {{cacerts}}
 * issue #105: included negative example in {{estat}}
-* issue #107: included example for certificate revocation in {{exchanges_uc2_4}}
-* issue	#108: renamed heading to Pledge-Status Request of {{exchanges_uc2_5a}}
-* issue #111: included pledge-status response processing for authenticated requests in {{exchanges_uc2_5b}}
+* issue #107: included example for certificate revocation in exchanges_uc2_4 TODO[N/A]
+* issue	#108: renamed heading to Pledge-Status Request of {{query}}
+* issue #111: included pledge-status response processing for authenticated requests in {{query}}
 * issue #112: added "Example key word in pledge-status response in {{stat_res}}
-* issue #113: enhanced description of status reply for "factory-default" in  {{exchanges_uc2_5b}}
+* issue #113: enhanced description of status reply for "factory-default" in  {{query}}
 * issue #114: Consideration of optional TLS usage in Privacy Considerations
 * issue #115: Consideration of optional TLS usage in Privacy Considerations to protect potentially privacy related information in the bootstrapping like status information, etc.
 * issue #116: Enhanced DoS description and mitigation options in security consideration section
@@ -2832,7 +2768,7 @@ From IETF draft 04 -> IETF draft 05:
 * Reworked terminology of "enrollment object", "certification object", "enrollment request object", etc., issue #27
 * Reworked all message representations to align with encoding
 * Added explanation of MASA requiring domain CA cert in section 5.5.1 and section 5.5.2, issue #36
-* Defined new endpoint for pledge bootstrapping status inquiry, issue #35 in section {{exchanges_uc2_5}}, IANA considerations and section {{pledge_ep}}
+* Defined new endpoint for pledge bootstrapping status inquiry, issue #35 in section {{query}}, IANA considerations and section {{pledge_ep}}
 * Included examples for several objects in section {{examples}} including message example sizes, issue #33
 * PoP for private key to registrar certificate included as mandatory, issues #32 and #49
 * Issue #31, clarified that combined pledge may act as client/server for further (re)enrollment
@@ -2849,7 +2785,7 @@ From IETF draft 03 -> IETF draft 04:
 * Added a statement that nonceless voucher may be accepted, issue #18
 * Simplified structure in section {{sup-env}}, issue #19
 * Removed join proxy in {{uc2figure}} and added explanatory text, issue #20
-* Added description of pledge-CAcerts endpoint plus further handling of providing a wrapped CA certs response to the pledge in section {{exchanges_uc2_3}}; also added new required registrar endpoint (section {{exchanges_uc2_2}} and IANA considerations) for the registrar to provide a wrapped CA certs response, issue #21
+* Added description of pledge-CAcerts endpoint plus further handling of providing a wrapped CA certs response to the pledge in section {{cacerts}}; also added new required registrar endpoint (section {{pvr}} and IANA considerations) for the registrar to provide a wrapped CA certs response, issue #21
 * utilized defined abbreviations in the document consistently, issue #22
 * Reworked text on discovery according to issue #23 to clarify scope and handling
 * Added several clarifications based on review comments
@@ -2864,27 +2800,27 @@ From IETF draft 02 -> IETF draft 03:
 
 From IETF draft 01 -> IETF draft 02:
 
-* Issue #15 included additional signature on voucher from registrar in section {{exchanges_uc2_2}} and section {{agt_prx}}
-  The verification of multiple signatures is described in section {{exchanges_uc2_3}}
+* Issue #15 included additional signature on voucher from registrar in section {{pvr}} and section {{agt_prx}}
+  The verification of multiple signatures is described in section {{voucher}}
 
 * Included representation for General JWS JSON Serialization for examples
 
-* Included error responses from pledge if it is not able to create a pledge-voucher-request or an enrollment request in section {{exchanges_uc2_1}}
+* Included error responses from pledge if it is not able to create a Pledge-Voucher-Request or an enrollment request in section {{tpvr}}
 
-* Removed open issue regarding handling of multiple CSRs and enrollment responses during the bootstrapping as the initial target it the provisioning of a generic LDevID certificate. The defined endpoint on the pledge may also be used for management of further certificates.
+* Removed open issue regarding handling of multiple CSRs and Enroll-Responses during the bootstrapping as the initial target it the provisioning of a generic LDevID certificate. The defined endpoint on the pledge may also be used for management of further certificates.
 
 From IETF draft 00 -> IETF draft 01:
 
-* Issue #15 lead to the inclusion of an option for an additional signature of the registrar on the voucher received from the MASA before forwarding to the Registrar-Agent to support verification of POP of the registrars private key in section {{exchanges_uc2_2}} and {{exchanges_uc2_3}}.
+* Issue #15 lead to the inclusion of an option for an additional signature of the registrar on the voucher received from the MASA before forwarding to the Registrar-Agent to support verification of POP of the registrars private key in section {{pvr}} and exchanges_uc2_3.
 
 * Based on issue #11, a new endpoint was defined for the registrar to enable delivery of the wrapped enrollment request from the pledge (in contrast to plain PKCS#10 in simple enroll).
 
-* Decision on issue #8 to not provide an additional signature on the enrollment-response object by the registrar. As the enrollment response will only contain the generic LDevID certificate. This credential builds the base for further configuration outside the initial enrollment.
+* Decision on issue #8 to not provide an additional signature on the enrollment-response object by the registrar. As the Enroll-Response will only contain the generic LDevID certificate. This credential builds the base for further configuration outside the initial enrollment.
 
 * Decision on issue #7 to not support multiple CSRs during the bootstrapping, as based on the generic LDevID certificate the pledge may enroll for further certificates.
 
 * Closed open issue #5 regarding verification of ietf-ztp-types usage as verified
-  via a proof-of-concept in section {#exchanges_uc2_1}.
+  via a proof-of-concept in section {{tpvr}}.
 
 * Housekeeping: Removed already addressed open issues stated in the draft directly.
 
@@ -2893,9 +2829,9 @@ From IETF draft 00 -> IETF draft 01:
 * Fixed "serial-number" encoding in PVR/RVR
 
 * Added prior-signed-voucher-request in the parameter description of the
-  registrar-voucher-request in {{exchanges_uc2_2}}.
+  registrar-voucher-request in {{pvr}}.
 
-* Note added in {{exchanges_uc2_2}} if sub-CAs are used, that the
+* Note added in {{pvr}} if sub-CAs are used, that the
   corresponding information is to be provided to the MASA.
 
 * Inclusion of limitation section (pledge sleeps and needs to be waked
@@ -2907,28 +2843,28 @@ From IETF draft 00 -> IETF draft 01:
 * Included table for endpoints in {{pledge_ep}} for better readability.
 
 * Included registrar authorization check for Registrar-Agent during
-  TLS handshake  in section {{exchanges_uc2_2}}. Also enhanced figure
-  {{exchangesfig_uc2_2}} with the authorization step on TLS level.
+  TLS handshake  in section {{pvr}}. Also enhanced figure
+  {{exchangesfig_uc2_all}} with the authorization step on TLS level.
 
 * Enhanced description of registrar authorization check for Registrar-Agent
-  based on the agent-signed-data in section {{exchanges_uc2_2}}. Also
-  enhanced figure {{exchangesfig_uc2_2}} with the authorization step
-  on pledge-voucher-request level.
+  based on the agent-signed-data in section {{pvr}}. Also
+  enhanced figure {{exchangesfig_uc2_all}} with the authorization step
+  on Pledge-Voucher-Request level.
 
 * Changed agent-signed-cert to an array to allow for providing further
   certificate information like the issuing CA cert for the LDevID(RegAgt)
   certificate in case the registrar and the Registrar-Agent have different
-  issuing CAs in {{exchangesfig_uc2_2}} (issue #12).
+  issuing CAs in {{exchangesfig_uc2_all}} (issue #12).
   This also required changes in the YANG module in {{I-D.ietf-anima-rfc8366bis}}
 
 * Addressed YANG warning (issue #1)
 
-* Inclusion of examples for a trigger to create a pledge-voucher-request
-  and an pledge-enrollment-request.
+* Inclusion of examples for a trigger to create a Pledge-Voucher-Request
+  and an Pledge Enroll-Request.
 
 From IETF draft-ietf-anima-brski-async-enroll-03 -> IETF anima-brski-prm-00:
 
-* Moved UC2 related parts defining the pledge in responder mode from
+* Moved UC2 related parts defining the Pledge in Responder Mode from
   draft-ietf-anima-brski-async-enroll-03 to this document
   This required changes and adaptations in several sections to remove
   the description and references to UC1.
@@ -2950,7 +2886,7 @@ From IETF draft-ietf-anima-brski-async-enroll-03 -> IETF anima-brski-prm-00:
 From IETF draft 02 -> IETF draft 03:
 
 * Housekeeping, deleted open issue regarding YANG voucher-request
-  in {{exchanges_uc2_1}} as voucher-request was
+  in {{tpvr}} as voucher-request was
   enhanced with additional leaf.
 
 * Included open issues in YANG model in {{architecture}} regarding assertion
@@ -2972,7 +2908,7 @@ From IETF draft 01 -> IETF draft 02:
   changed by removing TLS-PSK (former section TLS establishment)
   and associated references to other drafts in favor of relying on
   higher layer exchange of signed data objects. These data objects
-  are included also in the pledge-voucher-request and lead to an
+  are included also in the Pledge-Voucher-Request and lead to an
   extension of the YANG module for the voucher-request (issue #12).
 
 * Details on trust relationship between Registrar-Agent and
@@ -3037,7 +2973,7 @@ From individual version 03 -> IETF draft 00:
   of identity binding and mapping to existing protocols.
 
 * Removal of copied call flows for voucher exchange and registrar
-  discovery flow from {{RFC8995}} in UC1 to avoid doubling or text or
+  discovery flow from {{!RFC8995}} in UC1 to avoid doubling or text or
   inconsistencies.
 
 * Reworked abstract and introduction to be more crisp regarding

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -711,20 +711,6 @@ The registrar EE certificate may be configured at the Registrar-Agent or may be 
 In addition, the Registrar-Agent provides "agent-signed-data" containing the pledge product serial number signed with the private key corresponding to the EE certificate of the Registrar-Agent, as described in {{tpvr}}.
 This enables the registrar to verify and log, which Registrar-Agent was in contact with the pledge, when verifying the PVR.
 
-The registrar provides the EE certificate of the Registrar-Agent identified by the SubjectKeyIdentifier (SKID) in the header of the "agent-signed-data" from the PVR in its RVR (see also {{rvr-proc}}).
-
-The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-certificate" leaf and may assert the PVR as "verified" or "logged".
-
-TODO[LDevID as EE cert for agent-proximity]
-In addition, the MASA may issue the assertion "agent-proximity" as follows:
-The MASA verifies the signature of the "agent-signed-data" contained in the "prior-signed-voucher-request", based on the provided EE certificate of the Registrar-Agent in the "agent-sign-cert" leaf of the RVR.
-If both can be verified successfully, the MASA can assert "agent-proximity" in the voucher.
-The assertion of "agent-proximity" is similar to the proximity assertion by the MASA when using BRSKI.
-Note that the different assertions do not provide a metric of strength as the security properties are not comparable.
-
-Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx response status codes as described in {{Section 5.6 of !RFC8995}}.
-When successful, the Voucher will then be supplied via the registrar to the Registrar-Agent.
-
 {{exchangesfig_uc2_all}} provides an overview of the exchanges detailed in the following subsections.
 
 ~~~~ aasvg
@@ -1290,6 +1276,19 @@ In addition, the following processing SHALL be performed for PVR contained in RV
 If validation fails, the MASA SHOULD respond with an HTTP 4xx client error status code to the registrar.
 The HTTP error status codes are kept the same as defined in {{Section 5.6 of !RFC8995}} and comprise the codes: 403, 404, 406, and 415.
 
+
+The registrar provides the EE certificate of the Registrar-Agent identified by the SubjectKeyIdentifier (SKID) in the header of the "agent-signed-data" from the PVR in its RVR (see also {{rvr-proc}}).
+
+The MASA in turn verifies the registrar LDevID certificate is included in the PVR (contained in the "prior-signed-voucher-request" field of RVR) in the "agent-provided-proximity-registrar-certificate" leaf and may assert the PVR as "verified" or "logged".
+
+In addition, the MASA may issue the assertion "agent-proximity" as follows:
+The MASA verifies the signature of the "agent-signed-data" contained in the "prior-signed-voucher-request", based on the provided EE certificate of the Registrar-Agent in the "agent-sign-cert" leaf of the RVR.
+If both can be verified successfully, the MASA can assert "agent-proximity" in the voucher.
+The assertion of "agent-proximity" is similar to the proximity assertion by the MASA when using BRSKI.
+Note that the different assertions do not provide a metric of strength as the security properties are not comparable.
+
+Depending on the MASA verification policy, it may also respond with a suitable 4xx or 5xx response status codes as described in {{Section 5.6 of !RFC8995}}.
+When successful, the Voucher will then be supplied via the registrar to the Registrar-Agent.
 
 ### Voucher Issuance by MASA {#exchanges_uc2_2_vc}
 

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -835,7 +835,7 @@ The following sub sections split the interactions shown in {{exchangesfig_uc2_al
 
 3. {{pvr}} describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA using the RVR {{rvr-proc}} including the response object processing by these entities.
 
-4. {per}} describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the CA using the PER including the response object processing by these entities.
+4. {{per}} describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the CA using the PER including the response object processing by these entities.
 
 5. {{req_cacerts}} describes the object acquisition for the optional CA certificate provisioning to the Pledge initiated by the Registrar-Agent to the CA. 
 

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -903,13 +903,13 @@ The following CDDL {{!RFC8610}} explains the Pledge Voucher-Request Trigger stru
 
 ~~~~
 <CODE BEGINS>
-pledgevoucherrequesttrigger = {
+  pledgevoucherrequesttrigger = {
     "agent-provided-proximity-registrar-cert": bytes,
     "agent-signed-data": bytes
   }
 <CODE ENDS>
 ~~~~
-{: #tpvr_CDDL-def title='CDDL for Pledge Voucher-Request Trigger' artwork-align="left"}
+{: #tpvr_CDDL_def title='CDDL for Pledge Voucher-Request Trigger' artwork-align="left"}
 
 The fields contained in the `pledgevoucherrequesttrigger` are:
 
@@ -919,7 +919,7 @@ The fields contained in the `pledgevoucherrequesttrigger` are:
 
 ~~~~
 {
-  "payload": BASE64URL(UTF8(asData)),
+  "payload": BASE64URL(UTF8(prmasd)),
   "signatures": [
     {
       "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -928,22 +928,22 @@ The fields contained in the `pledgevoucherrequesttrigger` are:
   ]
 }
 ~~~~
-{: #asd title="JWS structure for the agent-sigend-data member in General JWS Serialization syntax" artwork-align="left"}
+{: #asd title="JWS structure for the agent-signed-data member in General JWS Serialization syntax" artwork-align="left"}
 
-The asdfields MUST be UTF-8 encoded to become the octet-based JWS Payload defined in {{!RFC7515}}.
+The BRSKI-PRM Agent Signed Data structure MUST be encoded in JSON as defined in {{!RFC8259}} following the CDDL definition {{prmasd_CDDL_def}}.
 The JWS Payload is further base64url-encoded to become the string value of the `payload` member as described in {{Section 3.2 of RFC7515}}.
 
 The following CDDL {{!RFC8610}} explains the BRSKI-PRM Agent Signed Data structure. 
 
 ~~~~
 <CODE BEGINS>
-prmasd = {
+  prmasd = {
     "created": tdate,
     "serial-number": text
   }
 <CODE ENDS>
 ~~~~
-{: #prmasd_CDDL-def title='CDDL for BRSKI-PRM Agent Signed Data' artwork-align="left"}
+{: #prmasd_CDDL_def title='CDDL for BRSKI-PRM Agent Signed Data' artwork-align="left"}
 
 The fields contained in the `prmasd` are:
 
@@ -952,6 +952,7 @@ The fields contained in the `prmasd` are:
 * `serial-number`: product-serial-number in the X520SerialNumber field of the IDevID certificate of the pledge as string as defined in {{Section 2.3.1 of !RFC8995}}
 
 {{prmasd_payload}} below shows an example for unsigned BRSKI-PRM Agent Signed Data in JSON syntax. 
+
 ~~~~
 {
   "created-on": "2021-04-16T00:00:01.000Z",
@@ -1114,7 +1115,7 @@ pledgeenrollrequesttrigger = {
   }
 <CODE ENDS>
 ~~~~
-{: #tpvr_CDDL_def title='CDDL for Pledge Enroll-Request Trigger' artwork-align="left"}
+{: #tper_CDDL_def title='CDDL for Pledge Enroll-Request Trigger' artwork-align="left"}
 
 The enroll-type field is an enum, identifying what is being enrolled. 
 Currently only "enroll-generic-cert" for the LDevID certificate is defined. 
@@ -1129,7 +1130,7 @@ Currently only "enroll-generic-cert" for the LDevID certificate is defined.
 {: #tPER_payload title="Data example for pledgeenrollrequesttrigger" artwork-align="left"}
 
 
-The Pledge Enroll-Request Trigger (tPER) artifact MUST be encoded in JSON as defined in {{!RFC8259}} following the CDDL definition {{tpvr_CDDL_def}}.
+The Pledge Enroll-Request Trigger (tPER) artifact MUST be encoded in JSON as defined in {{!RFC8259}} following the CDDL definition {{tper_CDDL_def}}.
 
 The Pledge Enroll-Request Trigger (tPER) artifact MAY be used to provide additional data, like CSR attributes.
 How to provide and use such additional data is out of scope for this specification.
@@ -1685,7 +1686,8 @@ The additional processing is to sign the CA certificate(s) information using the
 This results in a signed CA certificate(s) object (JSON-in-JWS), the CA certificates are provided as base64-encoded "x5bag" (see definition in {{RFC9360}}) in the JWS payload.
 
 ~~~~
-# The CA certificates data with registrar signature in General JWS Serialization syntax
+# The CA certificates data with registrar signature in 
+# General JWS Serialization syntax
 {
   "payload": BASE64URL(certs),
   "signatures": [
@@ -2937,6 +2939,7 @@ Proof of Concept Code available
 From IETF draft 11 -> IETF draft 12:
 
 * Updated acknowledgements to reflect early reviews
+* Addressed Shepherd review part 2 (Pull Request #132)
 
 
 From IETF draft 10 -> IETF draft 11:

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -820,8 +820,8 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
    (11) Query Pledge Status
    ~                ~                 ~              ~            ~
    |                |                 |              |            |
-   |<--pStatus Req--|                 |              |            |
-   |--pStatus Resp->|                 |              |            |
+   |<--pStatus-Req--|                 |              |            |
+   |--pStatus-Resp->|                 |              |            |
    |                |                 |              |            |
    ~                ~                 ~              ~            ~
 ~~~~
@@ -1790,7 +1790,7 @@ It SHALL provide the status information to the registrar for further processing.
 
 Preconditions in addition to {{pvr}}:
 
-* Registrar-Agent: obtained voucher status and enroll status from pledge.
+* Registrar-Agent: obtained voucher status (vStatus) and enroll status (eStatus) from pledge.
 
 ~~~~ aasvg
 +-----------+        +-----------+   +--------+   +---------+
@@ -1803,12 +1803,12 @@ Preconditions in addition to {{pvr}}:
     |                      |              |            |
     |<------- mTLS ------->|              |            |
     |                      |              |            |
-    |--- Voucher Status -->|              |            |
+    |------ vStatus ------>|              |            |
     |                      |--- req-device audit log-->|
     |                      |<---- device audit log ----|
     |              [verify audit log ]
     |                      |              |            |
-    |--- Enroll Status --->|              |            |
+    |------ eStatus ------>|              |            |
     |                      |              |            |
 ~~~~
 {: #exchangesfig_uc2_4 title='Bootstrapping status handling' artwork-align="left"}
@@ -1871,25 +1871,20 @@ The following assumes that a Registrar-Agent may need to query the status of a p
 This information may be useful to solve errors, when the pledge was not able to connect to the target domain during the bootstrapping.
 The pledge MAY provide a dedicated endpoint to accept status-requests.
 
-Preconditions:
-
-* Registrar-Agent: possesses LDevID (RegAgt), may have a list of product-serial-number(s) of pledges to be queried and a list of corresponding manufacturer trust anchors to be able to verify signatures performed with the IDevID credential.
-* Pledge: may already possess domain credentials and LDevID(Pledge), or may not possess one or both of these.
-
 ~~~~ aasvg
 +--------+                     +-----------+
 | Pledge |                     | Registrar-|
 |        |                     | Agent     |
 +--------+                     +-----------+
     |                                |
-    |<--- pledge-status request -----|
+    |<-------- pStatus-Req ----------|
     |                                |
-    |---- pledge-status response --->|
+    | -------- pStatus-Resp -------->|
     |                                |
 ~~~~
 {: #exchangesfig_uc2_5 title='Pledge-status handling between Registrar-Agent and pledge' artwork-align="left"}
 
-### Request Artifact: status-request
+### Request Artifact: pStatus-Req
 
 The Registrar-Agent requests the pledge-status via HTTP POST on the defined pledge endpoint: "/.well-known/brski/qps"
 
@@ -1956,7 +1951,7 @@ This is out of scope for this specification.
 {: #stat_req title='Example of Registrar-Agent request of pledge-status using status-type bootstrap' artwork-align="left"}
 
 
-### Response Artifact: status-response
+### Response Artifact: pStatus-Resp
 
 If the pledge receives the pledge-status request with status-type "bootstrap" it SHALL react with a status response message based on previously collected telemetry information (see {{vstatus}} and {{estatus}}) in a single status-response artifact.
 

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -789,7 +789,6 @@ Therefore, authenticated self-contained artifacts (e.g., JWS-signed JSON structu
  |                  |                 |                 |            |
  |<----opt. TLS---->|                 |                 |            |
  |<-----cACerts-----|                 |                 |            |
- |------cACerts---->|                 |                 |            |
  |                  |                 |                 |            |
  ~                  ~                 ~                 ~            ~
 (8) Supply Enroll-Response to Pledge
@@ -1557,11 +1556,7 @@ If the registrar is unable to validate the PVR, it SHOULD respond with a HTTP 4x
 
 The following 4xx client error codes SHOULD be used:
 
-* 403 Forbidden: if the registrar detected that one or more security related parameters are not valid.
-
-* 404 Not Found: if the pledge provided information could not be used with automated allowance, as described in {{Section 5.3 of RFC8995}}.
-
-TODO: From EST or BRSKI? Otherwise should be 422 Unprocessable Content, as the resource endpoint must exist and cannot be 404.
+* 403 Forbidden: if the registrar detected that one or more security related parameters are not valid or if the pledge-provided information could not be used with automated allowance.
 
 * 406 Not Acceptable: if the Content-Type indicated by the Accept header is unknown or unsupported.
 
@@ -1862,8 +1857,6 @@ The following subsections describe the corresponding artifacts.
  |                  |                 |                 |            |
  |<----opt. TLS---->|                 |                 |            |
  |<-----cACerts-----|                 |                 |            |
-TODO: certs sent back in response?
- |------cACerts---->|                 |                 |            |
  |                  |                 |                 |            |
  ~                  ~                 ~                 ~            ~
 ~~~~
@@ -1889,7 +1882,7 @@ The verification comprises the following steps the pledge MUST perform. Maintain
 1. Check content-type of the CA certificates message. If no Content-Type is contained in the HTTP header, the default Content-Type utilized in this document (JSON-in-JWS) is used. If the Content-Type of the response is in an unknown or unsupported format, the pledge SHOULD reply with a 415 Unsupported media type error code.
 2. Check the encoding of the payload. If the pledge detects errors in the encoding of the payload, it SHOULD reply with 400 Bad Request error code.
 3. Verify that the wrapped CA certificate object is signed using the registrar certificate against the pinned-domain certificate. This MAY be done by comparing the hash that is indicating the certificate used to sign the message is that of the pinned-domain certificate. If the validation against the pinned domain-certificate fails, the client SHOULD reply with a 401 Unauthorized error code. It signals that the authentication has failed and therefore the object was not accepted.
-4. Verify signature of the received wrapped CA certificate object using the domain certificate contained in the voucher. If the validation of the signature fails, the pledge SHOULD reply with a 406 Not Acceptable. It signals that the object could not be verified and has not been accepted.
+4. Verify signature of the received wrapped CA certificate object using the domain certificate contained in the voucher. If the validation of the signature fails, the pledge SHOULD reply with a 403 Forbidden. It signals that the object could not be verified and has not been accepted.
 5. If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of {{RFC7030}}.
 
 In case of success, the pledge SHOULD reply with 200 OK.

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -825,7 +825,8 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
    ~                ~                 ~              ~            ~
 ~~~~
 {: #exchangesfig_uc2_all title='Overview pledge-responder-mode exchanges' artwork-align="left"}
-TODO[where general status req/res]
+
+TODO[align, shorten, move into figure, or remove?]
 
 The following sub sections split the interactions shown in {{exchangesfig_uc2_all}} between the different components into:
 
@@ -840,6 +841,8 @@ The following sub sections split the interactions shown in {{exchangesfig_uc2_al
 5. {{enroll_response}} describes the supply of the Enroll Reponse from the Registrar-Agent to the pledge including the returned status information.
 
 6. {{vstatus}} and {{estatus}} describe the general status handling and addresses corresponding exchanges between the Registrar-Agent and the registrar.
+
+TODO[...]
 
 ## Trigger Pledge Voucher-Request {#tpvr}
 
@@ -1670,6 +1673,8 @@ The CA certificates message has the Content-Type `application/jose+json` and is 
 The CA certificates are provided as base64-encoded "x5bag".
 The pledge SHALL install the received CA certificates as trust anchor after successful verification of the registrar's signature.
 
+### Response
+
 The verification comprises the following steps the pledge MUST perform. Maintaining the order of versification steps as indicated allows to determine, which verification has already been passed:
 
   1. Check content-type of the CA certificates message. If no Content-Type is contained in the HTTP header, the default Content-Type utilized in this document (JSON-in-JWS) is used. If the Content-Type of the response is in an unknown or unsupported format, the pledge SHOULD reply with a 415 Unsupported media type error code.
@@ -1678,9 +1683,6 @@ The verification comprises the following steps the pledge MUST perform. Maintain
   4. Verify signature of the the received wrapped CA certificate object. If the validation of the signature fails, the pledge SHOULD reply with a 406 Not Acceptable. It signals that the object has not been accepted.
   5. If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of [RFC7030].
 
-### Response
-
-TODO[empty?]
 
 ## Supply Enroll-Response to Pledge {#enroll_response}
 
@@ -1947,7 +1949,7 @@ This is out of scope for this specification.
 
 ### Response Artifact: status-response
 
-If the pledge receives the pledge-status request with status-type "bootstrap" it SHALL react with a status response message based on the telemetry information described in TODO.
+If the pledge receives the pledge-status request with status-type "bootstrap" it SHALL react with a status response message based on previously collected telemetry information (see {{vstatus}} and {{estatus}}) in a single status-response artifact.
 
 The pledge-status response Content-Type header is `application/jose+json`.
 
@@ -1993,8 +1995,6 @@ The pledge-status response message is signed with IDevID or LDevID, depending on
 * "enroll-error": Pledge enrollment-response processing terminated with error.
   Additional information may be provided in the reason or reason-context.
   The pledge signs the response message using its IDevID(Pledge).
-
-The reason and the reason-context SHOULD contain the telemetry information as described in TODO[exchanges_uc2_3].
 
 As the pledge is assumed to utilize its bootstrapped credentials (LDevID) in communication with other peers, additional status information is provided for the connectivity to other peers, which may be helpful in analyzing potential error cases.
 
@@ -2057,18 +2057,6 @@ If validation of the JWS signature fails, the pledge SHOULD respond with the HTT
 The pledge SHOULD by default only respond to requests from nodes it can authenticate (such as registrar
 agent), once the pledge is enrolled with CA certificates and a matching domain certificate.
 
-# TODO Artifacts
-
-## Voucher-Request Artifact {#voucher-request-prm-yang}
-
-{{I-D.ietf-anima-rfc8366bis}} extends the voucher-request as defined in {{!RFC8995}} to include additional fields necessary for handling bootstrapping in the pledge-responder-mode.
-These additional fields are defined in {{tpvr}} as:
-
-* agent-signed-data to provide a JSON encoded artifact from the involved Registrar-Agent, which allows the registrar to verify the Registrar-Agent's involvement
-* agent-provided-proximity-registrar-cert to provide the registrar certificate visible to the Registrar-Agent, comparable to the registrar-proximity-certificate used in {{!RFC8995}}
-* TODO[where used? LDevID?] agent-signing certificate to optionally provide the Registrar-Agent signing certificate.
-
-Examples for the application of these fields in the context of a PVR are provided in {{pvr}}.
 
 
 # IANA Considerations {#iana-con}
@@ -2720,7 +2708,7 @@ From IETF draft 08 -> IETF draft 09:
 * issue #101: included handling if {{voucher}} voucher telemetry information has not been received by the Registrar-Agent
 * issue #102: relaxed requirements for CA certs provisioning in {{cacerts}}
 * issue #105: included negative example in {{estat}}
-* issue #107: included example for certificate revocation in exchanges_uc2_4 TODO[N/A]
+* issue #107: included example for certificate revocation in {{estatus}}
 * issue	#108: renamed heading to Pledge-Status Request of {{query}}
 * issue #111: included pledge-status response processing for authenticated requests in {{query}}
 * issue #112: added "Example key word in pledge-status response in {{stat_res}}

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -904,7 +904,7 @@ The following CDDL {{!RFC8610}} explains the Pledge Voucher-Request Trigger stru
 
 ~~~~
 <CODE BEGINS>
-pledge-voucher-request-trigger = {
+pledgevoucherrequesttrigger = {
     "agent-provided-proximity-registrar-cert": bytes,
     "agent-signed-data": bytes
   }
@@ -912,12 +912,13 @@ pledge-voucher-request-trigger = {
 ~~~~
 {: #tpvr_CDDL-def title='CDDL for Pledge Voucher-Request Trigger' artwork-align="left"}
 
+The fields contained in the `pledgevoucherrequesttrigger` are:
+
 * `agent-provided-proximity-registrar-cert`: X.509 v3 certificate structure of the domain registrar EE certificate (base64-encoded value); may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar
 
 * `agent-signed-data`: base64-encoded JWS structure containing the SubjectKeyIdentifier of the EE (RegAgt) certificate and signing Data including the serial number of the pledge
 
 ~~~~
-# The agent-signed-data in General JWS Serialization syntax
 {
   "payload": BASE64URL(UTF8(asData)),
   "signatures": [
@@ -930,36 +931,35 @@ pledge-voucher-request-trigger = {
 ~~~~
 {: #asd title="JWS structure for the agent-sigend-data member in General JWS Serialization syntax" artwork-align="left"}
 
-TODO: ietf-voucher-request:agent-signed-data is only defined as binary in YANG! No definition of the fields! /* "ietf-voucher-request:agent-signed-data" element (defined in {{I-D.ietf-anima-rfc8366bis}}): */
-
-The asData MUST be UTF-8 encoded to become the octet-based JWS Payload defined in {{!RFC7515}}.
+The asdfields MUST be UTF-8 encoded to become the octet-based JWS Payload defined in {{!RFC7515}}.
 The JWS Payload is further base64url-encoded to become the string value of the `payload` member as described in {{Section 3.2 of RFC7515}}.
 
-The following CDDL {{!RFC8610}} explains the asData structure. 
+The following CDDL {{!RFC8610}} explains the BRSKI-PRM Agent Signed Data structure. 
 
 ~~~~
 <CODE BEGINS>
-asData = {
+prmasd = {
     "created": tdate,
-    "serial-number": string
+    "serial-number": text
   }
 <CODE ENDS>
 ~~~~
-{: #asData_CDDL-def title='CDDL for asData' artwork-align="left"}
+{: #prmasd_CDDL-def title='CDDL for BRSKI-PRM Agent Signed Data' artwork-align="left"}
 
-The asData MUST be a JSON object with two members (see {{asd_payload}} for an example):
+The fields contained in the `prmasd` are:
 
-* `created-on`: creation date and time in yang:date-and-time format
+* `created-on`: creation date and time as standard date/time string as defined in {{!RFC3339}} 
 
 * `serial-number`: product-serial-number in the X520SerialNumber field of the IDevID certificate of the pledge as string as defined in {{Section 2.3.1 of !RFC8995}}
 
+{{prmasd_payload}} below shows an example for unsigned BRSKI-PRM Agent Signed Data in JSON syntax. 
 ~~~~
 {
   "created-on": "2021-04-16T00:00:01.000Z",
   "serial-number": "callee4711"
 }
 ~~~~
-{: #asd_payload title="Data example for asData" artwork-align="left"}
+{: #prmasd_payload title="Data example for prmasd" artwork-align="left"}
 
 The JWS Protected Header of the `agent-signed-data` JWS structure MUST contain the following parameters (see {{asd_header}} for an example):
 
@@ -1106,29 +1106,33 @@ This document specifies the trigger for a generic certificate with no CSR attrib
 If specific attributes in the certificate are required, they have to be inserted by the issuing RA/CA.
 
 The Pledge Enroll-Request Trigger (tPVR) artifact is an unsigned JSON structure providing the trigger parameters (tPER-data).
-The following CDDL {{!RFC8610}} explains the tPER-data parameter. 
+The following CDDL {{!RFC8610}} explains the Pledge Enroll-Request Trigger structure. 
 
 ~~~~
 <CODE BEGINS>
-tPER-data = {
-    "enroll-type": text
+pledgeenrollrequesttrigger = {
+    "enroll-type": "enroll-generic-cert"
   }
 <CODE ENDS>
 ~~~~
-{: #tpvr_CDDL-def title='CDDL for tPER-data' artwork-align="left"}
+{: #tpvr_CDDL_def title='CDDL for Pledge Enroll-Request Trigger' artwork-align="left"}
 
-The enroll-type field provided  information about the enroll type "enroll-generic-cert" or "re-enroll-generic-cert". The "enroll-generic-cert" case is shown 
-The tPER-data MUST be a JSON object with one member (see {{tPER_payload}} for an example):
+The enroll-type field is an enum, identifying what is being enrolled. 
+Currently only "enroll-generic-cert" for the LDevID certificate is defined. 
+
+{{tPER_payload}} below shows an example for unsigned Pledge Enroll-Request Trigger in JSON syntax. 
 
 ~~~~
 {
   "enroll-type" : "enroll-generic-cert"
 }
 ~~~~
-{: #tPER_payload title="Data example for asData" artwork-align="left"}
-TODO: Unclear if JSON with { "enroll-type" : "enroll-generic-cert" } could be used alternatively to an empty body (i.e., is the assumed default enroll-type). Must update/remove response codes if there is no alternative to empty body.
+{: #tPER_payload title="Data example for pledgeenrollrequesttrigger" artwork-align="left"}
 
-The Pledge Enroll-Request Trigger (tPER) artifact MAY be used to provide additional data, like CSR attributes or information about the enroll type.
+
+The Pledge Enroll-Request Trigger (tPER) artifact MUST be encoded in JSON as defined in {{!RFC8259}} following the CDDL definition {{tpvr_CDDL_def}}.
+
+The Pledge Enroll-Request Trigger (tPER) artifact MAY be used to provide additional data, like CSR attributes.
 How to provide and use such additional data is out of scope for this specification.
 
 ### Response Artifact: Pledge Enroll-Request (PER)
@@ -2168,7 +2172,7 @@ The following Concise Data Definition Language (CDDL) {{RFC8610}} defines the st
   }
 <CODE ENDS>
 ~~~~
-{: #stat_req_def title="CDDL for unsigned Status Query data (status-query)" artwork-align="left"}
+{: #stat_req_def title="CDDL for unsigned Status Trigger data (statustrigger)" artwork-align="left"}
 
 The `version` field is included to permit significant changes to the pledge status artifacts in the future.
 The format and semantics in this document follow the status telemetry definitions of {{!RFC8995}}.

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -860,6 +860,26 @@ This may be done as described in {{discovery_uc2_ppa}} and {{exchangesfig_uc2_al
 
 TLS MAY be optionally used to provide privacy for this exchange between the Registrar-Agent and the pledge, see {{pledgehttps}}.
 
+{{exchangesfig_uc2_1}} shows the Pledge Voucher-Request aquisition and the following subsections describe the corresponding artifacts. 
+
+~~~~ aasvg
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+   ~                ~                 ~              ~            ~
+   (1) Trigger Pledge Voucher-Request
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |<-- opt. TLS -->|                 |              |            |
+   |<---- tPVR -----|                 |              |            |
+   |----- PVR ----->|                 |              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+~~~~
+{: #exchangesfig_uc2_1 title='PVR aquisition exchanges' artwork-align="left"}
+
 ### Request Artifact: Pledge Voucher-Request Trigger (tPVR)
 
 Triggering the pledge to create the PVR is done using HTTP POST on the defined pledge endpoint: "/.well-known/brski/tpvr"
@@ -1017,6 +1037,25 @@ The PVR is included by the registrar in its RVR as described in {{pvr}}.
 
 
 ## Trigger Pledge Enroll-Request {#tper}
+{{exchangesfig_uc2_2}} shows the the aquisition of the Pledge Enroll-Request aquisition and the following subsections describe the corresponding artifacts. 
+
+~~~~ aasvg
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+  ~                ~                 ~              ~            ~
+   (2) Trigger Pledge Enroll-Request
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |<-- opt. TLS -->|                 |              |            |
+   |<---- tPER -----|                 |              |            |
+   |----- PER ----->|                 |              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+~~~~
+{: #exchangesfig_uc2_2 title='PER aquisition exchanges' artwork-align="left"}
 
 ### Request Artifact: Pledge Enroll-Request Trigger (tPER)
 
@@ -1162,6 +1201,36 @@ This ensures that the pledge has been triggered by an authorized Registrar-Agent
 
 With BRSKI-PRM, the pledge generates PVR and PER as JSON-in-JWS objects and the Registrar-Agent forwards them to the registrar.
 In {{!RFC8995}}, the pledge generates PVR as CMS-signed JSON and PER as PKCS#10 or PKCS#7 according to {{!RFC7030}} and inherited by {{!RFC8995}}.
+
+{{exchangesfig_uc2_3}} shows the exchanges for the Voucher Request processing and the following subsections describe the corresponding artifacts. 
+
+~~~~ aasvg
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+   ~                ~                 ~              ~            ~
+   (3) Supply PVR to Registrar (including backend interaction)
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |                |<---- mTLS ----->|              |            |
+   |                |         [Registrar-Agent       |            |
+   |                |    authenticated&authorized?]  |            |
+   |                |----- PVR ------>|              |            |
+   |                |         [accept device?]       |            |
+   |                |         [contact vendor]       |            |
+   |                |                 |              |            |
+   |                |                 |<---------- mTLS --------->|
+   |                |                 |------------ RVR --------->|
+   |                |                 |           [extract DomainID]
+   |                |                 |           [update audit log]
+   |                |                 |<--------- Voucher --------|
+   |                |<--- Voucher ----|              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+~~~~
+{: #exchangesfig_uc2_3 title='Voucher Request processing' artwork-align="left"}
 
 ### Request Artifact: PVR
 
@@ -1468,6 +1537,29 @@ After receiving the voucher, the Registrar-Agent sends the PER to the registrar 
 In case the PER cannot be send in the same HTTP-over-TLS connection the Registrar-Agent may send the PER in a new HTTP-over-TLS connection. The registrar is able to correlate the PVR and the PER based on the signatures and the contained product-serial-number information.
 Note, this also addresses situations in which a nonceless voucher is used and may be pre-provisioned to the pledge.
 
+{{exchangesfig_uc2_4}} depicts exchanges for the PER request handling and the following subsections describe the corresponding artifacts. 
+
+~~~~ aasvg
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+   ~                ~                 ~              ~            ~
+   (4) Supply PER to Registrar (including backend interaction)
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |                |<---- mTLS ----->|              |            |
+   |                |----- PER ------>|              |            |
+   |                |                 |<--- mTLS --->|            |
+   |                |                 |---- RER ---->|            |
+   |                |                 |<-Enroll Resp-|            |
+   |                |<--Enroll Resp---|              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+~~~~
+{: #exchangesfig_uc2_4 title='Pledge Enroll-Request processing' artwork-align="left"}
+
 ### Request Artifact: Pledge Enroll-Request (PER)
 
 As specified in {{tper}} deviating from BRSKI the PER is not a raw PKCS#10.
@@ -1515,6 +1607,26 @@ This is done in EST {{RFC7030}} using the "/.well-known/est/cacerts" endpoint, w
 BRSKI-PRM requires a signature wrapped CA certificate object, to avoid that the pledge can be provided with arbitrary CA certificates in an authorized way.
 The registrar signed CA certificate object will allow the pledge to verify the authorization to install the received CA certificate(s).
 As the CA certificate(s) are provided to the pledge after the voucher, the pledge has the required information (the domain certificate) to verify the wrapped CA certificate object.
+
+{{exchangesfig_uc2_5}} shows the request and provisioning of CA certificates in the infrastructure. 
+The following subsections describe the corresponding artifacts. 
+
+~~~~ aasvg
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+   ~                ~                 ~              ~            ~
+   (5) Request CA Certificates
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |                |-- cACert-Req -->|              |            |
+   |                |<-- cACert-Resp--|              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+~~~~
+{: #exchangesfig_uc2_5 title='CA certificate retrival' artwork-align="left"}
 
 ### Request Artifact: cACert-Req
 
@@ -1587,7 +1699,26 @@ Preconditions in addition to {{pvr}}:
 The Registrar-Agent MAY optionally use TLS to protect the communication as outlined in {{tpvr}}.
 
 The Registrar-Agent provides the information via distinct pledge endpoints as following.
+{{exchangesfig_uc2_6}} shows the provisioning of the voucher to the pledge. 
+The following subsections describe the corresponding artifacts. 
 
+~~~~ aasvg
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+   ~                ~                 ~              ~            ~
+   (6) Supply Voucher to Pledge
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |<--opt. TLS --->|                 |              |            |
+   |<--- Voucher ---|                 |              |            |
+   |---- vStatus -->|                 |              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+~~~~
+{: #exchangesfig_uc2_6 title='Supply voucher to pledge' artwork-align="left"}
 
 ### Request Artifact: Voucher
 
@@ -1670,6 +1801,26 @@ If the pledge did not did not provide voucher status telemetry information after
 
 
 ## Supply CA certificates to Pledge {#cacerts}
+{{exchangesfig_uc2_7}} shows the provisioning of the CA certificates aquired by the pledge-agent to the pledge. 
+The following subsections describe the corresponding artifacts. 
+
+~~~~ aasvg
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+   ~                ~                 ~              ~            ~
+   (7) Supply CA certificates to Pledge
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |<--opt. TLS --->|                 |              |            |
+   |<--- cACerts ---|                 |              |            |
+   |--- cACerts --->|                 |              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+~~~~
+{: #exchangesfig_uc2_7 title='Supply CA certificates to pledge' artwork-align="left"}
 
 ### Request Artifact:
 
@@ -1694,6 +1845,25 @@ The verification comprises the following steps the pledge MUST perform. Maintain
 
 
 ## Supply Enroll-Response to Pledge {#enroll_response}
+{{exchangesfig_uc2_8}} shows the supply of the Enroll-Response to the pledge.
+The following subsections describe the corresponding artifacts. 
+
+~~~~ aasvg
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+   ~                ~                 ~              ~            ~
+   (8) Supply Enroll-Response to Pledge
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |<--Enroll Resp--|                 |              |            |
+   |--- eStatus --->|                 |              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+~~~~
+{: #exchangesfig_uc2_8 title='Supply Enroll-Response to pledge' artwork-align="left"}
 
 ### Request Artifact: Enroll-Response
 
@@ -1793,25 +1963,24 @@ Preconditions in addition to {{pvr}}:
 * Registrar-Agent: obtained voucher status (vStatus) and enroll status (eStatus) from pledge.
 
 ~~~~ aasvg
-+-----------+        +-----------+   +--------+   +---------+
-| Registrar-|        | Domain    |   | Domain |   | MASA    |
-| Agent     |        | Registrar |   | CA     |   |         |
-+-----------+        +-----------+   +--------+   +---------+
-    |                      |              |   Internet |
-[voucher + enroll ]        |              |            |
-[status info available]    |              |            |
-    |                      |              |            |
-    |<------- mTLS ------->|              |            |
-    |                      |              |            |
-    |------ vStatus ------>|              |            |
-    |                      |--- req-device audit log-->|
-    |                      |<---- device audit log ----|
-    |              [verify audit log ]
-    |                      |              |            |
-    |------ eStatus ------>|              |            |
-    |                      |              |            |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+   ~                ~                 ~              ~            ~
+   (9) Voucher Status Telemetry
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |                |<---- mTLS ----->|              |            |
+   |                |---- vStatus --->|              |            |
+   |                |                 |--- req device audit log-->|
+   |                |                 |<---- device audit log ----|
+   |                |           [verify audit log]
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
 ~~~~
-{: #exchangesfig_uc2_4 title='Bootstrapping status handling' artwork-align="left"}
+{: #exchangesfig_uc2_9 title='Voucher Status tekemetry handling' artwork-align="left"}~~~~ aasvg
 
 The Registrar-Agent MUST provide the collected pledge voucher status to the registrar.
 This status indicates if the pledge could process the voucher successfully or not.
@@ -1843,6 +2012,22 @@ The registrar SHOULD proceed with collecting and logging status information by r
 The Registrar-Agent MUST provide the pledge's enroll status to the registrar.
 The status indicates the pledge could process the Enroll-Response (certificate) and holds the corresponding private key.
 
+~~~~ aasvg
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+   ~                ~                 ~              ~            ~
+   (10) Enroll Status Telemetry
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |                |---- eStatus --->|              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
+~~~~
+{: #exchangesfig_uc2_10 title='Enroll-Status provisioning to domain registrar' artwork-align="left"}
+
 ### Request Artifact: Enroll Status (eStatus)
 
 The Registrar-Agent sends the pledge enroll status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/enrollstatus".
@@ -1872,17 +2057,21 @@ This information may be useful to solve errors, when the pledge was not able to 
 The pledge MAY provide a dedicated endpoint to accept status-requests.
 
 ~~~~ aasvg
-+--------+                     +-----------+
-| Pledge |                     | Registrar-|
-|        |                     | Agent     |
-+--------+                     +-----------+
-    |                                |
-    |<-------- pStatus-Req ----------|
-    |                                |
-    | -------- pStatus-Resp -------->|
-    |                                |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+| Pledge |   | Registrar-|   | Domain    |    | Domain |  | MASA    |
+|        |   | Agent     |   | Registrar |    | CA     |  |         |
++--------+   +-----------+   +-----------+    +--------+  +---------+
+   |                |                 |              |   Internet |
+   ~                ~                 ~              ~            ~
+   (11) Query Pledge Status
+   ~                ~                 ~              ~            ~
+   |                |                 |              |            |
+   |<--pStatus-Req--|                 |              |            |
+   |--pStatus-Resp->|                 |              |            |
+   |                |                 |              |            |
+   ~                ~                 ~              ~            ~
 ~~~~
-{: #exchangesfig_uc2_5 title='Pledge-status handling between Registrar-Agent and pledge' artwork-align="left"}
+{: #exchangesfig_uc2_11 title='Pledge-status handling between Registrar-Agent and pledge' artwork-align="left"}
 
 ### Request Artifact: Pledge Status Request (pStatus-Req)
 

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -331,9 +331,9 @@ At least the following properties are required for the voucher and enrollment pr
 
 Solution examples based on existing technology are provided with the focus on existing IETF RFCs:
 
-* Voucher-requests and -responses as used in {{!RFC8995}} already provide both, POP and POI, through a digital signature to protect the integrity of the voucher, while the corresponding signing certificate contains the identity of the signer.
+* Voucher-Requests and Vouchers as used in {{!RFC8995}} already provide both, POP and POI, through a digital signature to protect the integrity of the voucher, while the corresponding signing certificate contains the identity of the signer.
 
-* Certification requests are data structures containing the information from a requester for a CA to create a certificate.
+* Enroll-Requests are data structures containing the information from a requester for a CA to create a certificate.
   The certification request format in BRSKI is PKCS#10 {{!RFC2986}}.
   In PKCS#10, the structure is signed to ensure integrity protection and POP of the private key of the requester that corresponds to the contained public key.
   In the application examples, this POP alone is not sufficient.

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -742,7 +742,7 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
    |----- PER ----->|                 |              |            |
    |                |                 |              |            |
    ~                ~                 ~              ~            ~
-   (3) Request Voucher from the Registrar
+   (3) Request PVR to Registrar incl. backend interaction
    ~                ~                 ~              ~            ~
    |                |                 |              |            |
    |                |<---- mTLS ----->|              |            |
@@ -760,7 +760,7 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
    |                |<--- Voucher ----|              |            |
    |                |                 |              |            |
    ~                ~                 ~              ~            ~
-   (4) Supply PER to Registrar
+   (4) Supply PER to Registrar incl. backend interaction
    ~                ~                 ~              ~            ~
    |                |                 |              |            |
    |                |<---- mTLS ----->|              |            |
@@ -820,29 +820,38 @@ This enables the registrar to verify and log, which Registrar-Agent was in conta
    (11) Query Pledge Status
    ~                ~                 ~              ~            ~
    |                |                 |              |            |
-   TODO
+   |<--pStatus Req--|                 |              |            |
+   |--pStatus Resp->|                 |              |            |
    |                |                 |              |            |
    ~                ~                 ~              ~            ~
 ~~~~
 {: #exchangesfig_uc2_all title='Overview pledge-responder-mode exchanges' artwork-align="left"}
 
-TODO[align, shorten, move into figure, or remove?]
-
 The following sub sections split the interactions shown in {{exchangesfig_uc2_all}} between the different components into:
 
-1. {{tpvr}} describes the request object acquisition by the Registrar-Agent from pledge.
+1. {{tpvr}} describes the request object acquisition for the Pledge Voucher-Request by the Registrar-Agent.
 
-2. {{tper}} TODO
+2. {{tper}} describes the request object acquisition for the Pledge Enroll-Request by the Registrar-Agent.
 
-3. {{pvr}} describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA and the domain CA including the response object processing by these entities.
+3. {{pvr}} describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the MASA using the RVR {{rvr-proc}} including the response object processing by these entities.
 
-4. {{voucher}} describes the supply of the Voucher from the Registrar-Agent to the pledge including the returned status information.
+4. {per}} describes the request object processing initiated by the Registrar-Agent to the registrar and also the interaction of the registrar with the CA using the PER including the response object processing by these entities.
 
-5. {{enroll_response}} describes the supply of the Enroll Reponse from the Registrar-Agent to the pledge including the returned status information.
+5. {{req_cacerts}} describes the object acquisition for the optional CA certificate provisioning to the Pledge initiated by the Registrar-Agent to the CA. 
 
-6. {{vstatus}} and {{estatus}} describe the general status handling and addresses corresponding exchanges between the Registrar-Agent and the registrar.
+6. {{voucher}} describes the supply of the Voucher from the Registrar-Agent to the pledge including the returned status information.
 
-TODO[...]
+7. {{cacerts}} describes the supply of CA certificates to the Pledge by the Registrar-Agent. 
+
+8. {{enroll_response}} describes the supply of the Enroll Reponse (containing the LDevID (Pledge) certificate) from the Registrar-Agent to the pledge including the returned status information.
+
+9. {{vstatus}} describes the status handling for the pledge processing of the voucher and addresses corresponding exchanges between the Registrar-Agent and the registrar as well as between the registrar and the MASA.
+
+10. {{estatus}} describes the status handling for the pledge processing of the enrollment response  and addresses the corresponding exchange between the Registrar-Agent and the registrar.
+
+11. {{query}} describes the general status handling to query information about the bootstrapping state from the pledge initiated by the Registrar-Agent.
+   
+
 
 ## Trigger Pledge Voucher-Request {#tpvr}
 
@@ -1834,7 +1843,7 @@ The registrar SHOULD proceed with collecting and logging status information by r
 The Registrar-Agent MUST provide the pledge's enroll status to the registrar.
 The status indicates the pledge could process the Enroll-Response (certificate) and holds the corresponding private key.
 
-### Request Artifact: vStatus
+### Request Artifact: eStatus
 
 The Registrar-Agent sends the pledge enroll status without modification to the registrar with an HTTP-over-TLS POST using the registrar endpoint "/.well-known/brski/enrollstatus".
 The Content-Type header is kept as `application/jose+json` as depicted in the example in {{estat}}.

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -916,7 +916,7 @@ The fields contained in the `pledgevoucherrequesttrigger` are:
 
 * `agent-provided-proximity-registrar-cert`: X.509 v3 certificate structure of the domain registrar EE certificate (base64-encoded value); may be configured at the Registrar-Agent or may be fetched by the Registrar-Agent based on a prior TLS connection with this domain registrar
 
-* `agent-signed-data`: base64-encoded JWS structure containing the SubjectKeyIdentifier of the EE (RegAgt) certificate and signing Data including the serial number of the pledge
+* `agent-signed-data`: base64-encoded JWS structure containing the SubjectKeyIdentifier of the EE (RegAgt) certificate and signing Data including the creation date and serial number of the pledge. Note that {{I-D.ietf-anima-rfc8366bis}} defines an opaque binary element for agent-signed data, for which the structure is defined in BRSKI-PRM.
 
 ~~~~
 {

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -947,7 +947,7 @@ asData = {
 ~~~~
 {: #asData_CDDL-def title='CDDL for asData' artwork-align="left"}
 
-The Data MUST be a JSON object with two members (see {{asd_payload}} for an example):
+The asData MUST be a JSON object with two members (see {{asd_payload}} for an example):
 
 * `created-on`: creation date and time in yang:date-and-time format
 
@@ -998,7 +998,7 @@ The Pledge Voucher-Request (PVR) artifact is a JWS Voucher Request as defined in
 Its unsigned data SHALL be constructed similar to the Voucher-Request artifact defined in {{!RFC8995}}.
 It will contain additional data provided by the Registrar-Agent as specified in the following.
 
-The payload of the PVR MUST contain the following parameters as part of the ietf-voucher-request:voucher as defined in {{!RFC8995}}:
+The payload of the PVR MUST contain the following parameters as part of the ietf-voucher-request:voucher as defined in {{I-D.ietf-anima-rfc8366bis}} and thus makes optional leaves in the YANG definition mandatory:
 
 * `created-on`: SHALL contain the current date and time in yang:date-and-time format.
   If the pledge does not have synchronized time, it SHALL use the created-on time from the agent-signed-data, received in the trigger to create a PVR.
@@ -1087,7 +1087,7 @@ Optionally, TLS MAY be used to provide privacy for this exchange between the Reg
 
 The Registrar-Agent triggers the pledge to create the PER via HTTP POST on the well-known pledge endpoint `/.well-known/brski/tper`.
 As the initial enrollment aims to request a generic certificate, no certificate attributes are provided to the pledge.
-Hence, by default, the request body is empty, no artifact is provided.
+To avoid an empty request body an artifact is provided containing the description of the requested operation.
 
 Upon receiving a valid tPER, the pledge MUST reply with the PER artifact in the body of a 200 OK response.
 The response header MUST have the Content-Type field set to `application/jose+json`.
@@ -1095,10 +1095,6 @@ The response header MUST have the Content-Type field set to `application/jose+js
 If the pledge is unable to create the PER, it SHOULD respond with an HTTP error code. The following 4xx client error codes MAY be used:
 
 * 400 Bad Request: if the pledge detected an error in the format of the request.
-
-* 403 Forbidden: if the pledge detected that one or more security parameters (if provided) from the trigger message to create the PER are not valid.
-
-TODO: Can this make sense? (empty body, note that it cannot validate)
 
 * 406 Not Acceptable: if the Accept request header field indicates a type that is unknown or unsupported. For example, a type other than `application/jose+json`.
 
@@ -1109,6 +1105,27 @@ TODO: Can this make sense? (empty body, note that it cannot validate)
 This document specifies the trigger for a generic certificate with no CSR attributes provided to the pledge.
 If specific attributes in the certificate are required, they have to be inserted by the issuing RA/CA.
 
+The Pledge Enroll-Request Trigger (tPVR) artifact is an unsigned JSON structure providing the trigger parameters (tPER-data).
+The following CDDL {{!RFC8610}} explains the tPER-data parameter. 
+
+~~~~
+<CODE BEGINS>
+tPER-data = {
+    "enroll-type": text
+  }
+<CODE ENDS>
+~~~~
+{: #tpvr_CDDL-def title='CDDL for tPER-data' artwork-align="left"}
+
+The enroll-type field provided  information about the enroll type "enroll-generic-cert" or "re-enroll-generic-cert". The "enroll-generic-cert" case is shown 
+The tPER-data MUST be a JSON object with one member (see {{tPER_payload}} for an example):
+
+~~~~
+{
+  "enroll-type" : "enroll-generic-cert"
+}
+~~~~
+{: #tPER_payload title="Data example for asData" artwork-align="left"}
 TODO: Unclear if JSON with { "enroll-type" : "enroll-generic-cert" } could be used alternatively to an empty body (i.e., is the assumed default enroll-type). Must update/remove response codes if there is no alternative to empty body.
 
 The Pledge Enroll-Request Trigger (tPER) artifact MAY be used to provide additional data, like CSR attributes or information about the enroll type.
@@ -2143,10 +2160,9 @@ The following Concise Data Definition Language (CDDL) {{RFC8610}} defines the st
 
 ~~~~
 <CODE BEGINS>
-  status-query = {
+  statustrigger = {
       "version": uint,
-      "created-on": tdate ttime,
-TODO: Not sure if "ttime" exists. tdate is already a string with CBOR tag 0, i.e., a full datatime string
+      "created-on": tdate,
       "serial-number": text,
       "status-type": text
   }

--- a/draft-ietf-anima-brski-prm.md
+++ b/draft-ietf-anima-brski-prm.md
@@ -1262,19 +1262,19 @@ In {{!RFC8995}}, the pledge generates PVR as CMS-signed JSON and PER as PKCS#10 
 ~~~~
 {: #exchangesfig_uc2_3 title="Voucher issuing exchange" artwork-align="center"}
 
+The HTTP request Content-Type header field for JSON-in-JWS PVR is: `application/voucher-jws+json` (see {{tpvr}} for the content definition), as defined in {{I-D.ietf-anima-jws-voucher}}.
+
+The Registrar-Agent sets the Accept field in the request-header indicating the acceptable Content-Type for the Voucher.
+
+The HTTP response Content-Type header field is set to `application/voucher-jws+json` as defined in {{I-D.ietf-anima-jws-voucher}} if no content negotiation is used.
+
 
 ### Request Artifact: Pledge Voucher-Request (PVR)
 
 For BRSKI-PRM, the Registrar-Agent sends the PVR by HTTP POST to the same registrar endpoint as introduced by BRSKI: "/.well-
 known/brski/requestvoucher", but with a Content-Type header field for JSON-in-JWS"
 
-The Content-Type header field for JSON-in-JWS PVR is: `application/voucher-jws+json` (see {{tpvr}} for the content definition), as defined in {{I-D.ietf-anima-jws-voucher}}.
 
-The Registrar-Agent sets the Accept field in the request-header indicating the acceptable Content-Type for the Voucher.
-
-The voucher-response Content-Type header field is set to `application/voucher-jws+json` as defined in {{I-D.ietf-anima-jws-voucher}}.
-
-TODO: conflict with content negotiation (Accept). So you mean "by default"?
 
 ### Supply RVR to MASA (backend interaction) {#rvr-proc}
 
@@ -1885,7 +1885,7 @@ The verification comprises the following steps the pledge MUST perform. Maintain
 4. Verify signature of the received wrapped CA certificate object using the domain certificate contained in the voucher. If the validation of the signature fails, the pledge SHOULD reply with a 403 Forbidden. It signals that the object could not be verified and has not been accepted.
 5. If the received CA certificates are not self-signed, i.e., an intermediate CA certificate, verify them against an already installed trust anchor, as described in section 4.1.3 of {{RFC7030}}.
 
-In case of success, the pledge SHOULD reply with 200 OK.
+In case of success, the pledge SHOULD reply with HTTP 200 OK without a response body.
 
 
 
@@ -2051,10 +2051,8 @@ The registrar SHALL verify the signature of the pledge voucher status and valida
 
 ### Response (no artifact)
 
-TODO: Clarify if diagnostic payload (and what representation format) may be included "to signal success/failure to the service technician. 200 OK should have payload, otherwise 204 No Content...
-
-According to {{Section 5.7 of !RFC8995}}, the registrar SHOULD respond with an HTTP 200 OK in the success case or fail with HTTP 4xx/5xx status codes.
-The Registrar-Agent may use the response to signal success/failure to the service technician operating the Registrar-Agent.
+According to {{Section 5.7 of !RFC8995}}, the registrar SHOULD respond with an HTTP 200 OK without a response body in the success case or fail with HTTP 4xx/5xx status codes.
+The Registrar-Agent may use the response status code to signal success/failure to the service technician operating the Registrar-Agent.
 Within the server logs the server SHOULD capture this telemetry information.
 
 The registrar SHOULD proceed with collecting and logging status information by requesting the MASA audit-log from the MASA service as described in {{Section 5.8 of !RFC8995}}.


### PR DESCRIPTION
As announced in my first review, #85, I now worked on improving the structure and consistency of the second half of the document:

* Give architecture overview
* Declare system components and their static requirements such as endpoints and configured information
* Declare exchanges on the endpoints and artifacts sent around

Besides a clearer structure with less redundancy, the terms used must be come consistent, so the reader can follow. In particular the names of the exchanged artifacts was varying between figures, headings, and (normative) statements.

The section on Exchanges now has subsection headings clearly referring to the exchanges used on the defined endpoints and further subsubsection headings stating the artifact names -- further alignment of this terminology is needed, but hard as RFC8995 is not that consistent, either.